### PR TITLE
add a minimum disk size to cloud deploy and manager start

### DIFF
--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -519,7 +519,7 @@ func (p *openstackp) spawn(resources *Resources, osPrefix string, flavorID strin
 	// doesn't always work, so we roll our own
 	waitForActive := make(chan error)
 	go func() {
-		timeout := time.After(120 * time.Second)
+		timeout := time.After(240 * time.Second)
 		ticker := time.NewTicker(1 * time.Second)
 		for {
 			select {

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -319,6 +319,7 @@ func init() {
 	managerStartCmd.Flags().StringVarP(&osPrefix, "cloud_os", "o", "Ubuntu 16", "for cloud schedulers, prefix name of the OS image your servers should use")
 	managerStartCmd.Flags().StringVarP(&osUsername, "cloud_username", "u", "ubuntu", "for cloud schedulers, username needed to log in to the OS image specified by --cloud_os")
 	managerStartCmd.Flags().IntVarP(&osRAM, "cloud_ram", "r", 2048, "for cloud schedulers, ram (MB) needed by the OS image specified by --cloud_os")
+	managerStartCmd.Flags().IntVarP(&osDisk, "cloud_disk", "d", 1, "for cloud schedulers, minimum disk (GB) for servers")
 	managerStartCmd.Flags().StringVarP(&flavorRegex, "cloud_flavor", "l", "", "for cloud schedulers, a regular expression to limit server flavors that can be automatically picked")
 	managerStartCmd.Flags().StringVarP(&postCreationScript, "cloud_script", "p", "", "for cloud schedulers, path to a start-up script that will be run on each server created")
 	managerStartCmd.Flags().IntVarP(&serverKeepAlive, "cloud_keepalive", "k", 120, "for cloud schedulers, how long in seconds to keep idle spawned servers alive for")
@@ -360,6 +361,7 @@ func startJQ(sayStarted bool, postCreation []byte) {
 			OSPrefix:           osPrefix,
 			OSUser:             osUsername,
 			OSRAM:              osRAM,
+			OSDisk:             osDisk,
 			FlavorRegex:        flavorRegex,
 			PostCreationScript: postCreation,
 			ServerKeepTime:     time.Duration(serverKeepAlive) * time.Second,

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -86,6 +86,11 @@ type ConfigOpenStack struct {
 	// Schedule() by a Requirements.Other["cloud_os_ram"] value.)
 	OSRAM int
 
+	// OSDisk is the minimum disk in GB with which to bring up a server instance
+	// that runs your Operating System image. It defaults to 1. (Overridden during
+	// Schedule() by a Requirements.Other["cloud_os_disk"] value.)
+	OSDisk int
+
 	// FlavorRegex is a regular expression that you can use to limit what
 	// flavors of server will be created to run commands on. The default of an
 	// empty string means there is no limit, and any available flavor can be


### PR DESCRIPTION
to use when spawning a server. Also double timeout for instance creation
from 2min to 4min to allow for boot from volume

Attempts to resolve #1