### PR TITLE
Allow for build with go defaults if GOPATH not explicitly set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GO_FILES := $(shell find . -name '*.go' | grep -v /vendor/)
 VERSION := $(shell git describe --tags --always --long --dirty)
 TAG := $(shell git describe --abbrev=0 --tags)
 LDFLAGS = -ldflags "-X ${PKG}/cmd.wrVersion=${VERSION}"
+export GOPATH := $(shell go env GOPATH)
+PATH := $(PATH):${GOPATH}/bin
+SHELL := env PATH=${PATH} $(SHELL)
 GLIDE := $(shell command -v glide 2> /dev/null)
 
 default: install
@@ -13,7 +16,7 @@ ifndef GLIDE
 	@mkdir -p ${GOPATH}/bin
 	@curl -s https://glide.sh/get | sh
 endif
-	@${GOPATH}/bin/glide -q install
+	@glide -q install
 	@echo installed latest dependencies
 
 build: vendor


### PR DESCRIPTION
I'd installed both go and glide with homebrew on osx. (Such a setup puts `go get` results into go default of `$HOME/go` ). This tweak allows working with such defaults rather than the README suggested go install location and `GOPATH` setup.

Not convinced the `PATH` and `SHELL` setting form a particularly elegant solution - but it was the only thing I could come up with.