### PR TITLE
Resolve #120: Buried jobs stay buried after a manager restart.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       script:
         - "go test -tags netgo -coverprofile=queue.coverprofile -covermode count -failfast ./queue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=sched.coverprofile -covermode count -failfast ./jobqueue/scheduler || travis_terminate 1"
-        - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"
+        - "go test -tags netgo -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=cloud.coverprofile -covermode count -failfast ./cloud || travis_terminate 1"
         - "go test -tags netgo -coverprofile=rp.coverprofile -covermode count -failfast ./rp || travis_terminate 1"
         - "$HOME/gopath/bin/gover || travis_terminate 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
   include:
     -
       script:
-        - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue -run TestJobqueueRunners || travis_terminate 1"
         - "go test -tags netgo -coverprofile=queue.coverprofile -covermode count -failfast ./queue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=sched.coverprofile -covermode count -failfast ./jobqueue/scheduler || travis_terminate 1"
         - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       script:
         - "go test -tags netgo -coverprofile=queue.coverprofile -covermode count -failfast ./queue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=sched.coverprofile -covermode count -failfast ./jobqueue/scheduler || travis_terminate 1"
-        - "go test -tags netgo -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"
+        - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=cloud.coverprofile -covermode count -failfast ./cloud || travis_terminate 1"
         - "go test -tags netgo -coverprofile=rp.coverprofile -covermode count -failfast ./rp || travis_terminate 1"
         - "$HOME/gopath/bin/gover || travis_terminate 1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
   include:
     -
       script:
+        - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue -run TestJobqueueRunners || travis_terminate 1"
         - "go test -tags netgo -coverprofile=queue.coverprofile -covermode count -failfast ./queue || travis_terminate 1"
         - "go test -tags netgo -coverprofile=sched.coverprofile -covermode count -failfast ./jobqueue/scheduler || travis_terminate 1"
         - "go test -tags netgo -v -coverprofile=jq.coverprofile -covermode count -failfast ./jobqueue || travis_terminate 1"

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1134,7 +1134,7 @@ func (c *Client) Execute(job *Job, shell string) error {
 		}
 	}
 
-	if closeErr != nil {
+	if closeErr != nil && !strings.Contains(closeErr.Error(), "file already closed") {
 		if myerr != nil {
 			myerr = fmt.Errorf("%s; closing stderr/out of the cmd also failed: %s", myerr.Error(), closeErr.Error())
 		} else {

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1062,18 +1062,15 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		var prev []int
 		for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
 			max, _ = strconv.Atoi(string(v))
-			fmt.Printf("max now %d\n", max)
 
 			count++
 			if count > 100 {
 				window = (float32(count) / 100) * jobStatWindowPercent
-				fmt.Printf("window now %f (%d /100 * %f)\n", window, count, jobStatWindowPercent)
 			}
 
 			prev = append(prev, max)
 			if float32(len(prev)) > window {
 				recommendation, prev = prev[0], prev[1:]
-				fmt.Printf("len(prev) %d > window %f, recommendation now %d\n", len(prev), window, recommendation)
 			}
 		}
 
@@ -1082,8 +1079,6 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 	if err != nil {
 		return 0, err
 	}
-
-	fmt.Printf("final max is %d; recommendation %d\n", max, recommendation)
 
 	if recommendation == 0 {
 		if max == 0 {
@@ -1096,14 +1091,11 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		recommendation = max
 	}
 
-	fmt.Printf("pre-round recommendation is %d vs rountAmount %d\n", recommendation, roundAmount)
 	if recommendation < roundAmount {
 		recommendation = roundAmount
-		fmt.Printf("set recommendation to roundamount\n")
 	}
 
 	if recommendation%roundAmount > 0 {
-		fmt.Printf("recommendation = ceil(%d / %d) * %d\n", recommendation, roundAmount, roundAmount)
 		recommendation = int(math.Ceil(float64(recommendation)/float64(roundAmount))) * roundAmount
 	}
 

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1062,15 +1062,18 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		var prev []int
 		for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
 			max, _ = strconv.Atoi(string(v))
+			fmt.Printf("max now %d\n", max)
 
 			count++
 			if count > 100 {
 				window = (float32(count) / 100) * jobStatWindowPercent
+				fmt.Printf("window now %f (%d /100 * %f)\n", window, count, jobStatWindowPercent)
 			}
 
 			prev = append(prev, max)
 			if float32(len(prev)) > window {
 				recommendation, prev = prev[0], prev[1:]
+				fmt.Printf("len(prev) %d > window %f, recommendation now %d\n", len(prev), window, recommendation)
 			}
 		}
 
@@ -1096,6 +1099,7 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 	}
 
 	if recommendation%roundAmount > 0 {
+		fmt.Printf("recommendation = ceil(%d / %d) * %d\n", recommendation, roundAmount, roundAmount)
 		recommendation = int(math.Ceil(float64(recommendation)/float64(roundAmount))) * roundAmount
 	}
 

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1062,15 +1062,18 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		var prev []int
 		for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
 			max, _ = strconv.Atoi(string(v))
+			fmt.Printf("max now %d\n", max)
 
 			count++
 			if count > 100 {
 				window = (float32(count) / 100) * jobStatWindowPercent
+				fmt.Printf("window now %f (%d /100 * %f)\n", window, count, jobStatWindowPercent)
 			}
 
 			prev = append(prev, max)
 			if float32(len(prev)) > window {
 				recommendation, prev = prev[0], prev[1:]
+				fmt.Printf("len(prev) %d > window %f, recommendation now %d\n", len(prev), window, recommendation)
 			}
 		}
 
@@ -1092,6 +1095,7 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 	}
 
 	if recommendation%roundAmount > 0 {
+		fmt.Printf("recommendation = ceil(%d / %d) * %d\n", recommendation, roundAmount, roundAmount)
 		recommendation = int(math.Ceil(float64(recommendation)/float64(roundAmount))) * roundAmount
 	}
 

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1083,6 +1083,8 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		return 0, err
 	}
 
+	fmt.Printf("final max is %d; recommendation %d\n", max, recommendation)
+
 	if recommendation == 0 {
 		if max == 0 {
 			return recommendation, err
@@ -1094,8 +1096,10 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		recommendation = max
 	}
 
+	fmt.Printf("pre-round recommendation is %d vs rountAmount %d\n", recommendation, roundAmount)
 	if recommendation < roundAmount {
 		recommendation = roundAmount
+		fmt.Printf("set recommendation to roundamount\n")
 	}
 
 	if recommendation%roundAmount > 0 {

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -620,14 +620,16 @@ func (db *db) deleteLiveJob(key string) {
 
 // recoverIncompleteJobs returns all jobs in the live bucket, for use when
 // restarting the server, allowing you start working on any jobs that were
-// stored with storeNewJobs() but not yet archived with archiveJob(). Note that
-// any state changes to the Jobs that may have occurred will be lost: you get
-// back the Jobs exactly as they were when you put them in with storeNewJobs().
+// stored with storeNewJobs() but not yet archived with archiveJob().
+//
+// Note that you will get back the job as it was in its last recorded state.
+// The state is recorded when a job starts to run, when it exits, and when it
+// is kicked.
 func (db *db) recoverIncompleteJobs() ([]*Job, error) {
 	var jobs []*Job
 	err := db.bolt.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketJobsLive)
-		return b.ForEach(func(_, encoded []byte) error {
+		return b.ForEach(func(key, encoded []byte) error {
 			if encoded != nil {
 				dec := codec.NewDecoderBytes(encoded, db.ch)
 				job := &Job{}
@@ -836,20 +838,26 @@ func (db *db) retrieveEnv(envkey string) []byte {
 }
 
 // updateJobAfterExit stores the Job's peak RAM usage and wall time against the
-// Job's ReqGroup, allowing recommendedReqGroup*(ReqGroup) to work. It also
-// updates the stdout/err associated with a job.
+// Job's ReqGroup, but only if the job failed for using too much RAM or time,
+// allowing recommendedReqGroup*(ReqGroup) to work.
 //
-// We don't want to store these in the job, since that would waste a lot of the
-// queue's memory; we store in db instead, and only retrieve when a client needs
-// to see these. To stop the db file becoming enormous, we only store these if
-// the cmd failed (or if forceStorage is true: used when the job got buried) and
-// also delete these from db when the cmd completes successfully.
+// So that state can be restored if the server crashes and is restarted, the
+// job is rewritten in its current state in to the live bucket.
+//
+// It also updates the stdout/err associated with a job. We don't want to store
+// these in the job, since that would waste a lot of the queue's memory; we
+// store in db instead, and only retrieve when a client needs to see these. To
+// stop the db file becoming enormous, we only store these if the cmd failed (or
+// if forceStorage is true: used when the job got buried) and also delete these
+// from db when the cmd completes successfully.
 //
 // By doing the deletion upfront, we also ensure we have the latest std, which
 // may be nil even on cmd failure. Since it is not critical to the running of
 // jobs and workflows that this works 100% of the time, we ignore errors and
 // write to bolt in a goroutine, giving us a significant speed boost.
 func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorage bool) {
+	var encoded []byte
+	enc := codec.NewEncoderBytes(&encoded, db.ch)
 	db.RLock()
 	defer db.RUnlock()
 	if db.closed {
@@ -862,7 +870,13 @@ func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorag
 	jpr := job.PeakRAM
 	jpd := job.PeakDisk
 	jec := job.Exitcode
+	err := enc.Encode(job)
 	job.RUnlock()
+	if err != nil {
+		db.Error("Database operation updateJobAfterExit failed due to Encode failure", "err", err)
+		return
+	}
+
 	db.wg.Add(1)
 	go func() {
 		defer internal.LogPanic(db.Logger, "updateJobAfterExit", true)
@@ -872,10 +886,17 @@ func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorag
 		db.updatingAfterJobExit++
 		db.Unlock()
 		err := db.bolt.Batch(func(tx *bolt.Tx) error {
+			key := []byte(jobkey)
+
+			bjl := tx.Bucket(bucketJobsLive)
+			errf := bjl.Put(key, encoded)
+			if errf != nil {
+				return errf
+			}
+
 			bo := tx.Bucket(bucketStdO)
 			be := tx.Bucket(bucketStdE)
-			key := []byte(jobkey)
-			errf := bo.Delete(key)
+			errf = bo.Delete(key)
 			if errf != nil {
 				return errf
 			}
@@ -896,18 +917,18 @@ func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorag
 				return errf
 			}
 
-			b := tx.Bucket(bucketJobRAM)
-			errf = b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, jpr)), []byte(strconv.Itoa(jpr)))
-			if errf != nil {
-				return errf
+			switch job.FailReason {
+			case FailReasonRAM:
+				b := tx.Bucket(bucketJobRAM)
+				errf = b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, jpr)), []byte(strconv.Itoa(jpr)))
+			case FailReasonDisk:
+				b := tx.Bucket(bucketJobDisk)
+				errf = b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, jpd)), []byte(strconv.Itoa(int(jpd))))
+			case FailReasonTime:
+				b := tx.Bucket(bucketJobSecs)
+				errf = b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, secs)), []byte(strconv.Itoa(secs)))
 			}
-			b = tx.Bucket(bucketJobDisk)
-			errf = b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, jpd)), []byte(strconv.Itoa(int(jpd))))
-			if errf != nil {
-				return errf
-			}
-			b = tx.Bucket(bucketJobSecs)
-			return b.Put([]byte(fmt.Sprintf("%s%s%20d", jrg, dbDelimiter, secs)), []byte(strconv.Itoa(secs)))
+			return errf
 		})
 		if err != nil {
 			db.Error("Database operation updateJobAfterExit failed", "err", err)
@@ -915,6 +936,41 @@ func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorag
 		db.Lock()
 		db.updatingAfterJobExit--
 		db.Unlock()
+	}()
+}
+
+// updateJobAfterChange rewrites the job's entry in the live bucket, to enable
+// complete recovery after a crash. This happens in a goroutine, since it isn't
+// essential this happens, and we benefit from the speed.
+func (db *db) updateJobAfterChange(job *Job) {
+	var encoded []byte
+	enc := codec.NewEncoderBytes(&encoded, db.ch)
+	db.RLock()
+	defer db.RUnlock()
+	if db.closed {
+		return
+	}
+	key := []byte(job.Key())
+	job.RLock()
+	err := enc.Encode(job)
+	job.RUnlock()
+	if err != nil {
+		db.Error("Database operation updateJobAfterChange failed due to Encode failure", "err", err)
+		return
+	}
+
+	db.wg.Add(1)
+	go func() {
+		defer internal.LogPanic(db.Logger, "updateJobAfterChange", true)
+		defer db.wg.Done()
+
+		err := db.bolt.Batch(func(tx *bolt.Tx) error {
+			bjl := tx.Bucket(bucketJobsLive)
+			return bjl.Put(key, encoded)
+		})
+		if err != nil {
+			db.Error("Database operation updateJobAfterChange failed", "err", err)
+		}
 	}()
 }
 

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1062,18 +1062,15 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		var prev []int
 		for k, v := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, v = c.Next() {
 			max, _ = strconv.Atoi(string(v))
-			fmt.Printf("max now %d\n", max)
 
 			count++
 			if count > 100 {
 				window = (float32(count) / 100) * jobStatWindowPercent
-				fmt.Printf("window now %f (%d /100 * %f)\n", window, count, jobStatWindowPercent)
 			}
 
 			prev = append(prev, max)
 			if float32(len(prev)) > window {
 				recommendation, prev = prev[0], prev[1:]
-				fmt.Printf("len(prev) %d > window %f, recommendation now %d\n", len(prev), window, recommendation)
 			}
 		}
 
@@ -1094,8 +1091,11 @@ func (db *db) recommendedReqGroupStat(statBucket []byte, reqGroup string, roundA
 		recommendation = max
 	}
 
+	if recommendation < roundAmount {
+		recommendation = roundAmount
+	}
+
 	if recommendation%roundAmount > 0 {
-		fmt.Printf("recommendation = ceil(%d / %d) * %d\n", recommendation, roundAmount, roundAmount)
 		recommendation = int(math.Ceil(float64(recommendation)/float64(roundAmount))) * roundAmount
 	}
 

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3585,7 +3585,7 @@ func TestJobqueueRunners(t *testing.T) {
 			done = make(chan bool, 1)
 			twoHundredCount := 0
 			go func() {
-				limit := time.After(240 * time.Second)
+				limit := time.After(180 * time.Second)
 				ticker := time.NewTicker(50 * time.Millisecond)
 				for {
 					select {
@@ -3595,6 +3595,7 @@ func TestJobqueueRunners(t *testing.T) {
 							// switch to a new job array could leave us with no
 							// runners temporarily
 							jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
+							fmt.Printf("\nno runners, %d jobs, err %s, expected %d\n", len(jobs), err, count+count2)
 							if err == nil && len(jobs) == count+count2 {
 								ticker.Stop()
 								done <- true
@@ -3604,6 +3605,7 @@ func TestJobqueueRunners(t *testing.T) {
 							server.sgcmutex.Lock()
 							if countg, existed := server.sgroupcounts["200:30:1:0"]; existed {
 								twoHundredCount = countg
+								fmt.Printf("\ntwoHundredCount: %d\n", countg)
 							}
 							server.sgcmutex.Unlock()
 						}

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2883,54 +2883,332 @@ func TestJobqueueRunners(t *testing.T) {
 		maxCPU := runtime.NumCPU()
 		runtime.GOMAXPROCS(maxCPU)
 
-		if false {
-			Convey("You can connect, and add a job that you can kill while it's running", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
+		Convey("You can connect, and add a job that you can kill while it's running", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
 
-				var jobs []*Job
-				jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
 
-				// wait for the job to start running
-				started := make(chan bool, 1)
+			// wait for the job to start running
+			started := make(chan bool, 1)
+			go func() {
+				limit := time.After(10 * time.Second)
+				ticker := time.NewTicker(50 * time.Millisecond)
+				for {
+					select {
+					case <-ticker.C:
+						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+						if err != nil {
+							continue
+						}
+						if len(jobs) == 1 {
+							ticker.Stop()
+							started <- true
+							return
+						}
+						continue
+					case <-limit:
+						ticker.Stop()
+						started <- false
+						return
+					}
+				}
+			}()
+			So(<-started, ShouldBeTrue)
+
+			killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
+			So(err, ShouldBeNil)
+			So(killCount, ShouldEqual, 1)
+
+			// wait for the job to get killed
+			killed := make(chan bool, 1)
+			go func() {
+				limit := time.After(20 * time.Second)
+				ticker := time.NewTicker(50 * time.Millisecond)
+				for {
+					select {
+					case <-ticker.C:
+						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+						if err != nil {
+							continue
+						}
+						if len(jobs) == 1 {
+							ticker.Stop()
+							killed <- true
+							return
+						}
+						continue
+					case <-limit:
+						ticker.Stop()
+						killed <- false
+						return
+					}
+				}
+			}()
+			So(<-killed, ShouldBeTrue)
+
+			jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+			So(err, ShouldBeNil)
+			So(len(jobs), ShouldEqual, 1)
+			So(jobs[0].State, ShouldEqual, JobStateBuried)
+			So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
+			So(jobs[0].Exitcode, ShouldEqual, -1)
+		})
+
+		Convey("You can connect, and add some real jobs", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			count := maxCPU * 2
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
 				go func() {
-					limit := time.After(10 * time.Second)
-					ticker := time.NewTicker(50 * time.Millisecond)
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
 					for {
 						select {
 						case <-ticker.C:
-							jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-							if err != nil {
-								continue
-							}
-							if len(jobs) == 1 {
+							if !server.HasRunners() {
 								ticker.Stop()
-								started <- true
+								done <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							started <- false
+							done <- false
 							return
 						}
 					}
 				}()
-				So(<-started, ShouldBeTrue)
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
 
-				killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
 				So(err, ShouldBeNil)
-				So(killCount, ShouldEqual, 1)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
 
-				// wait for the job to get killed
-				killed := make(chan bool, 1)
+				// we shouldn't have executed any unnecessary runners, and those
+				// we did run should have exited without error, even if there
+				// were no more jobs left
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for range files {
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
+			})
+		})
+
+		Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			count := maxCPU * 2
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				var simultaneous int
 				go func() {
-					limit := time.After(20 * time.Second)
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
+								ticker.Stop()
+								done <- true
+								return
+							}
+							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+							if errj == nil && len(running) > simultaneous {
+								simultaneous = len(running)
+							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
+						}
+					}
+				}()
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+				So(simultaneous, ShouldBeGreaterThan, maxCPU)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
+
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for range files {
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
+			})
+		})
+
+		Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			maxMem, errp := internal.ProcMeminfoMBs()
+			So(errp, ShouldBeNil)
+
+			var jobs []*Job
+			jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
+			count := maxCPU * 3
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				var simultaneous int
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
+								ticker.Stop()
+								done <- true
+								return
+							}
+							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+							if errj == nil && len(running) > simultaneous {
+								simultaneous = len(running)
+							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
+						}
+					}
+				}()
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+				So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
+			})
+		})
+
+		Convey("You can connect, and add a job that buries with no retries", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run without excess runners", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				waitForBury := func() {
+					limit := time.After(30 * time.Second)
 					ticker := time.NewTicker(50 * time.Millisecond)
 					for {
 						select {
@@ -2941,554 +3219,274 @@ func TestJobqueueRunners(t *testing.T) {
 							}
 							if len(jobs) == 1 {
 								ticker.Stop()
-								killed <- true
+								done <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							killed <- false
+							done <- false
 							return
 						}
 					}
-				}()
-				So(<-killed, ShouldBeTrue)
-
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, 1)
-				So(jobs[0].State, ShouldEqual, JobStateBuried)
-				So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
-				So(jobs[0].Exitcode, ShouldEqual, -1)
-			})
-
-			Convey("You can connect, and add some real jobs", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
 				}
-				defer os.RemoveAll(tmpdir)
+				go waitForBury()
+				So(<-done, ShouldBeTrue)
 
-				var jobs []*Job
-				count := maxCPU * 2
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-
-					// we shouldn't have executed any unnecessary runners, and those
-					// we did run should have exited without error, even if there
-					// were no more jobs left
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for range files {
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
-				})
-			})
-
-			Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				var jobs []*Job
-				count := maxCPU * 2
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					var simultaneous int
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-								if errj == nil && len(running) > simultaneous {
-									simultaneous = len(running)
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-					So(simultaneous, ShouldBeGreaterThan, maxCPU)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for range files {
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
-				})
-			})
-
-			Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				maxMem, errp := internal.ProcMeminfoMBs()
-				So(errp, ShouldBeNil)
-
-				var jobs []*Job
-				jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
-				count := maxCPU * 3
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					var simultaneous int
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-								if errj == nil && len(running) > simultaneous {
-									simultaneous = len(running)
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-					So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-				})
-			})
-
-			Convey("You can connect, and add a job that buries with no retries", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				var jobs []*Job
-				jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
+				jobs = nil
+				jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
 				inserts, already, err := jq.Add(jobs, envVars, true)
 				So(err, ShouldBeNil)
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				Convey("After some time the jobs get automatically run without excess runners", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					waitForBury := func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(50 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-								if err != nil {
-									continue
-								}
-								if len(jobs) == 1 {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
+				done2 := make(chan bool, 1)
+				waitForNoRunners := func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
 								ticker.Stop()
-								done <- false
+								done2 <- true
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done2 <- false
+							return
 						}
 					}
+				}
+				go waitForNoRunners()
+				So(<-done2, ShouldBeTrue)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, 1)
+				buriedKey := jobs[0].Key()
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, 1)
+
+				// we shouldn't have executed any unnecessary runners
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for _, file := range files {
+					if !strings.HasPrefix(file.Name(), "ok") {
+						continue
+					}
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, 1)
+
+				Convey("Retrying buried jobs works multiple times in a row", func() {
+					kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
+					So(err, ShouldBeNil)
+					So(kicked, ShouldEqual, 1)
+
 					go waitForBury()
 					So(<-done, ShouldBeTrue)
 
-					jobs = nil
-					jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
-					inserts, already, err := jq.Add(jobs, envVars, true)
+					kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
 					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+					So(kicked, ShouldEqual, 1)
 
-					done2 := make(chan bool, 1)
-					waitForNoRunners := func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done2 <- true
-									return
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done2 <- false
-								return
-							}
-						}
-					}
+					go waitForBury()
+					So(<-done, ShouldBeTrue)
+
 					go waitForNoRunners()
 					So(<-done2, ShouldBeTrue)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, 1)
-					buriedKey := jobs[0].Key()
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, 1)
-
-					// we shouldn't have executed any unnecessary runners
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for _, file := range files {
-						if !strings.HasPrefix(file.Name(), "ok") {
-							continue
-						}
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, 1)
-
-					Convey("Retrying buried jobs works multiple times in a row", func() {
-						kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-						So(err, ShouldBeNil)
-						So(kicked, ShouldEqual, 1)
-
-						go waitForBury()
-						So(<-done, ShouldBeTrue)
-
-						kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-						So(err, ShouldBeNil)
-						So(kicked, ShouldEqual, 1)
-
-						go waitForBury()
-						So(<-done, ShouldBeTrue)
-
-						go waitForNoRunners()
-						So(<-done2, ShouldBeTrue)
-					})
 				})
 			})
+		})
 
-			if maxCPU > 2 {
-				Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
-					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-					So(err, ShouldBeNil)
-					defer jq.Disconnect()
+		if maxCPU > 2 {
+			Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
 
-					req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
-					jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
-					inserts, already, err := jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
+				jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					// let them all complete
-					done := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
+				// let them all complete
+				done := make(chan bool, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
 								ticker.Stop()
-								done <- false
+								done <- true
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
 						}
-					}()
-					So(<-done, ShouldBeTrue)
-				})
-			} else {
-				SkipConvey("Skipping a test that needs at least 3 cores", func() {})
-			}
+					}
+				}()
+				So(<-done, ShouldBeTrue)
+			})
+		} else {
+			SkipConvey("Skipping a test that needs at least 3 cores", func() {})
+		}
 
-			if runtime.NumCPU() >= 2 {
-				Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
-					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-					So(err, ShouldBeNil)
-					defer jq.Disconnect()
+		if runtime.NumCPU() >= 2 {
+			Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
 
-					jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+				jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
 
-					inserts, already, err := jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					// wait for this first command to start running
-					running := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								pids, errf := process.Pids()
-								if errf == nil {
-									for _, pid := range pids {
-										p, errf := process.NewProcess(pid)
+				// wait for this first command to start running
+				running := make(chan bool, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							pids, errf := process.Pids()
+							if errf == nil {
+								for _, pid := range pids {
+									p, errf := process.NewProcess(pid)
+									if errf == nil {
+										cmd, errf := p.Cmdline()
 										if errf == nil {
-											cmd, errf := p.Cmdline()
-											if errf == nil {
-												if strings.Contains(cmd, runnertmpdir+"2sim") {
-													status, errf := p.Status()
-													if errf == nil && status == "S" {
-														ticker.Stop()
-														running <- true
-														return
-													}
+											if strings.Contains(cmd, runnertmpdir+"2sim") {
+												status, errf := p.Status()
+												if errf == nil && status == "S" {
+													ticker.Stop()
+													running <- true
+													return
 												}
 											}
 										}
 									}
 								}
-								if !server.HasRunners() {
-									ticker.Stop()
-									running <- false
-									return
-								}
-								continue
-							case <-limit:
+							}
+							if !server.HasRunners() {
 								ticker.Stop()
 								running <- false
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							running <- false
+							return
 						}
-					}()
-					So(<-running, ShouldBeTrue)
+					}
+				}()
+				So(<-running, ShouldBeTrue)
 
-					jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+				jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
 
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					// wait for the jobs to get run, and while waiting we'll check to
-					// see if we get both of our commands running at once
-					numRanSimultaneously := make(chan int, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						maxSimultaneous := 0
-						for {
-							select {
-							case <-ticker.C:
-								pids, err := process.Pids()
-								if err == nil {
-									simultaneous := 0
-									for _, pid := range pids {
-										p, err := process.NewProcess(pid)
+				// wait for the jobs to get run, and while waiting we'll check to
+				// see if we get both of our commands running at once
+				numRanSimultaneously := make(chan int, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					maxSimultaneous := 0
+					for {
+						select {
+						case <-ticker.C:
+							pids, err := process.Pids()
+							if err == nil {
+								simultaneous := 0
+								for _, pid := range pids {
+									p, err := process.NewProcess(pid)
+									if err == nil {
+										cmd, err := p.Cmdline()
 										if err == nil {
-											cmd, err := p.Cmdline()
-											if err == nil {
-												if strings.Contains(cmd, runnertmpdir+"2sim") {
-													status, err := p.Status()
-													if err == nil && status == "S" {
-														simultaneous++
-													}
+											if strings.Contains(cmd, runnertmpdir+"2sim") {
+												status, err := p.Status()
+												if err == nil && status == "S" {
+													simultaneous++
 												}
 											}
 										}
 									}
-									if simultaneous > maxSimultaneous {
-										maxSimultaneous = simultaneous
-									}
 								}
-								if !server.HasRunners() {
-									ticker.Stop()
-									numRanSimultaneously <- maxSimultaneous
-									return
+								if simultaneous > maxSimultaneous {
+									maxSimultaneous = simultaneous
 								}
-								continue
-							case <-limit:
+							}
+							if !server.HasRunners() {
 								ticker.Stop()
 								numRanSimultaneously <- maxSimultaneous
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							numRanSimultaneously <- maxSimultaneous
+							return
 						}
-					}()
-					So(<-numRanSimultaneously, ShouldEqual, 2)
-				})
-			}
+					}
+				}()
+				So(<-numRanSimultaneously, ShouldEqual, 2)
+			})
 		}
 
 		Convey("You can connect, and add 2 large batches of jobs sequentially", func() {
@@ -3591,24 +3589,16 @@ func TestJobqueueRunners(t *testing.T) {
 									done <- true
 									return
 								}
-								fmt.Printf("got %d complete jobs\n", len(jobs))
 							} else if twoHundredCount == 0 {
 								server.sgcmutex.Lock()
 								if countg, existed := server.sgroupcounts["200:30:1:0"]; existed {
 									twoHundredCount = countg
-									fmt.Printf("twoHundredCount now %d\n", countg)
 								}
 								server.sgcmutex.Unlock()
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							fmt.Printf("\nhit limit, sgroupcounts:\n")
-							server.sgcmutex.Lock()
-							for key, val := range server.sgroupcounts {
-								fmt.Printf(" %s => %d\n", key, val)
-							}
-							server.sgcmutex.Unlock()
 							done <- false
 							return
 						}
@@ -3673,7 +3663,6 @@ func TestJobqueueRunners(t *testing.T) {
 			}
 		})
 	})
-	return
 
 	// start these tests anew because these tests have the server spawn runners
 	// that fail, simulating some network issue

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2883,332 +2883,54 @@ func TestJobqueueRunners(t *testing.T) {
 		maxCPU := runtime.NumCPU()
 		runtime.GOMAXPROCS(maxCPU)
 
-		Convey("You can connect, and add a job that you can kill while it's running", func() {
-			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-			So(err, ShouldBeNil)
-			defer jq.Disconnect()
+		if false {
+			Convey("You can connect, and add a job that you can kill while it's running", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
 
-			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
-			inserts, already, err := jq.Add(jobs, envVars, true)
-			So(err, ShouldBeNil)
-			So(inserts, ShouldEqual, 1)
-			So(already, ShouldEqual, 0)
+				var jobs []*Job
+				jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-			// wait for the job to start running
-			started := make(chan bool, 1)
-			go func() {
-				limit := time.After(10 * time.Second)
-				ticker := time.NewTicker(50 * time.Millisecond)
-				for {
-					select {
-					case <-ticker.C:
-						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-						if err != nil {
-							continue
-						}
-						if len(jobs) == 1 {
-							ticker.Stop()
-							started <- true
-							return
-						}
-						continue
-					case <-limit:
-						ticker.Stop()
-						started <- false
-						return
-					}
-				}
-			}()
-			So(<-started, ShouldBeTrue)
-
-			killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
-			So(err, ShouldBeNil)
-			So(killCount, ShouldEqual, 1)
-
-			// wait for the job to get killed
-			killed := make(chan bool, 1)
-			go func() {
-				limit := time.After(20 * time.Second)
-				ticker := time.NewTicker(50 * time.Millisecond)
-				for {
-					select {
-					case <-ticker.C:
-						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-						if err != nil {
-							continue
-						}
-						if len(jobs) == 1 {
-							ticker.Stop()
-							killed <- true
-							return
-						}
-						continue
-					case <-limit:
-						ticker.Stop()
-						killed <- false
-						return
-					}
-				}
-			}()
-			So(<-killed, ShouldBeTrue)
-
-			jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-			So(err, ShouldBeNil)
-			So(len(jobs), ShouldEqual, 1)
-			So(jobs[0].State, ShouldEqual, JobStateBuried)
-			So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
-			So(jobs[0].Exitcode, ShouldEqual, -1)
-		})
-
-		Convey("You can connect, and add some real jobs", func() {
-			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-			So(err, ShouldBeNil)
-			defer jq.Disconnect()
-
-			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.RemoveAll(tmpdir)
-
-			var jobs []*Job
-			count := maxCPU * 2
-			for i := 0; i < count; i++ {
-				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
-			}
-			inserts, already, err := jq.Add(jobs, envVars, true)
-			So(err, ShouldBeNil)
-			So(inserts, ShouldEqual, count)
-			So(already, ShouldEqual, 0)
-
-			Convey("After some time the jobs get automatically run", func() {
-				// wait for the jobs to get run
-				done := make(chan bool, 1)
+				// wait for the job to start running
+				started := make(chan bool, 1)
 				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
+					limit := time.After(10 * time.Second)
+					ticker := time.NewTicker(50 * time.Millisecond)
 					for {
 						select {
 						case <-ticker.C:
-							if !server.HasRunners() {
+							jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+							if err != nil {
+								continue
+							}
+							if len(jobs) == 1 {
 								ticker.Stop()
-								done <- true
+								started <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							done <- false
+							started <- false
 							return
 						}
 					}
 				}()
-				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+				So(<-started, ShouldBeTrue)
 
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+				killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
 				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, count)
-				ran := 0
-				for _, job := range jobs {
-					files, err := ioutil.ReadDir(job.ActualCwd)
-					if err != nil {
-						log.Fatal(err)
-					}
-					for range files {
-						ran++
-					}
-				}
-				So(ran, ShouldEqual, count)
+				So(killCount, ShouldEqual, 1)
 
-				// we shouldn't have executed any unnecessary runners, and those
-				// we did run should have exited without error, even if there
-				// were no more jobs left
-				files, err := ioutil.ReadDir(runnertmpdir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				ranClean := 0
-				for range files {
-					ranClean++
-				}
-				So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
-			})
-		})
-
-		Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
-			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-			So(err, ShouldBeNil)
-			defer jq.Disconnect()
-
-			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.RemoveAll(tmpdir)
-
-			var jobs []*Job
-			count := maxCPU * 2
-			for i := 0; i < count; i++ {
-				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
-			}
-			inserts, already, err := jq.Add(jobs, envVars, true)
-			So(err, ShouldBeNil)
-			So(inserts, ShouldEqual, count)
-			So(already, ShouldEqual, 0)
-
-			Convey("After some time the jobs get automatically run", func() {
-				// wait for the jobs to get run
-				done := make(chan bool, 1)
-				var simultaneous int
+				// wait for the job to get killed
+				killed := make(chan bool, 1)
 				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					for {
-						select {
-						case <-ticker.C:
-							if !server.HasRunners() {
-								ticker.Stop()
-								done <- true
-								return
-							}
-							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-							if errj == nil && len(running) > simultaneous {
-								simultaneous = len(running)
-							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							done <- false
-							return
-						}
-					}
-				}()
-				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-				So(simultaneous, ShouldBeGreaterThan, maxCPU)
-
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, count)
-				ran := 0
-				for _, job := range jobs {
-					files, err := ioutil.ReadDir(job.ActualCwd)
-					if err != nil {
-						log.Fatal(err)
-					}
-					for range files {
-						ran++
-					}
-				}
-				So(ran, ShouldEqual, count)
-
-				files, err := ioutil.ReadDir(runnertmpdir)
-				if err != nil {
-					log.Fatal(err)
-				}
-				ranClean := 0
-				for range files {
-					ranClean++
-				}
-				So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
-			})
-		})
-
-		Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
-			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-			So(err, ShouldBeNil)
-			defer jq.Disconnect()
-
-			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.RemoveAll(tmpdir)
-
-			maxMem, errp := internal.ProcMeminfoMBs()
-			So(errp, ShouldBeNil)
-
-			var jobs []*Job
-			jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
-			count := maxCPU * 3
-			for i := 0; i < count; i++ {
-				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
-			}
-			inserts, already, err := jq.Add(jobs, envVars, true)
-			So(err, ShouldBeNil)
-			So(inserts, ShouldEqual, count)
-			So(already, ShouldEqual, 0)
-
-			Convey("After some time the jobs get automatically run", func() {
-				// wait for the jobs to get run
-				done := make(chan bool, 1)
-				var simultaneous int
-				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					for {
-						select {
-						case <-ticker.C:
-							if !server.HasRunners() {
-								ticker.Stop()
-								done <- true
-								return
-							}
-							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-							if errj == nil && len(running) > simultaneous {
-								simultaneous = len(running)
-							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							done <- false
-							return
-						}
-					}
-				}()
-				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-				So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
-
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, count)
-				ran := 0
-				for _, job := range jobs {
-					files, err := ioutil.ReadDir(job.ActualCwd)
-					if err != nil {
-						log.Fatal(err)
-					}
-					for range files {
-						ran++
-					}
-				}
-				So(ran, ShouldEqual, count)
-			})
-		})
-
-		Convey("You can connect, and add a job that buries with no retries", func() {
-			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-			So(err, ShouldBeNil)
-			defer jq.Disconnect()
-
-			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.RemoveAll(tmpdir)
-
-			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
-			inserts, already, err := jq.Add(jobs, envVars, true)
-			So(err, ShouldBeNil)
-			So(inserts, ShouldEqual, 1)
-			So(already, ShouldEqual, 0)
-
-			Convey("After some time the jobs get automatically run without excess runners", func() {
-				// wait for the jobs to get run
-				done := make(chan bool, 1)
-				waitForBury := func() {
-					limit := time.After(30 * time.Second)
+					limit := time.After(20 * time.Second)
 					ticker := time.NewTicker(50 * time.Millisecond)
 					for {
 						select {
@@ -3219,274 +2941,554 @@ func TestJobqueueRunners(t *testing.T) {
 							}
 							if len(jobs) == 1 {
 								ticker.Stop()
-								done <- true
+								killed <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							done <- false
+							killed <- false
 							return
 						}
 					}
-				}
-				go waitForBury()
-				So(<-done, ShouldBeTrue)
-
-				jobs = nil
-				jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
-
-				done2 := make(chan bool, 1)
-				waitForNoRunners := func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					for {
-						select {
-						case <-ticker.C:
-							if !server.HasRunners() {
-								ticker.Stop()
-								done2 <- true
-								return
-							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							done2 <- false
-							return
-						}
-					}
-				}
-				go waitForNoRunners()
-				So(<-done2, ShouldBeTrue)
+				}()
+				So(<-killed, ShouldBeTrue)
 
 				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
 				So(err, ShouldBeNil)
 				So(len(jobs), ShouldEqual, 1)
-				buriedKey := jobs[0].Key()
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
-				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, 1)
+				So(jobs[0].State, ShouldEqual, JobStateBuried)
+				So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
+				So(jobs[0].Exitcode, ShouldEqual, -1)
+			})
 
-				// we shouldn't have executed any unnecessary runners
-				files, err := ioutil.ReadDir(runnertmpdir)
+			Convey("You can connect, and add some real jobs", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
+
+				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
 				if err != nil {
 					log.Fatal(err)
 				}
-				ranClean := 0
-				for _, file := range files {
-					if !strings.HasPrefix(file.Name(), "ok") {
-						continue
-					}
-					ranClean++
+				defer os.RemoveAll(tmpdir)
+
+				var jobs []*Job
+				count := maxCPU * 2
+				for i := 0; i < count; i++ {
+					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
 				}
-				So(ranClean, ShouldEqual, 1)
-
-				Convey("Retrying buried jobs works multiple times in a row", func() {
-					kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-					So(err, ShouldBeNil)
-					So(kicked, ShouldEqual, 1)
-
-					go waitForBury()
-					So(<-done, ShouldBeTrue)
-
-					kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-					So(err, ShouldBeNil)
-					So(kicked, ShouldEqual, 1)
-
-					go waitForBury()
-					So(<-done, ShouldBeTrue)
-
-					go waitForNoRunners()
-					So(<-done2, ShouldBeTrue)
-				})
-			})
-		})
-
-		if maxCPU > 2 {
-			Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
-				jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
 				inserts, already, err := jq.Add(jobs, envVars, true)
 				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
+				So(inserts, ShouldEqual, count)
 				So(already, ShouldEqual, 0)
 
-				<-time.After(1 * time.Second)
-
-				job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
-				So(err, ShouldBeNil)
-				So(job, ShouldNotBeNil)
-				So(job.State, ShouldEqual, JobStateRunning)
-
-				jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
-				inserts, already, err = jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
-
-				<-time.After(1 * time.Second)
-
-				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
-				So(err, ShouldBeNil)
-				So(job, ShouldNotBeNil)
-				So(job.State, ShouldEqual, JobStateRunning)
-
-				jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
-				inserts, already, err = jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
-
-				<-time.After(1 * time.Second)
-
-				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
-				So(err, ShouldBeNil)
-				So(job, ShouldNotBeNil)
-				So(job.State, ShouldEqual, JobStateRunning)
-
-				// let them all complete
-				done := make(chan bool, 1)
-				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					for {
-						select {
-						case <-ticker.C:
-							if !server.HasRunners() {
+				Convey("After some time the jobs get automatically run", func() {
+					// wait for the jobs to get run
+					done := make(chan bool, 1)
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								if !server.HasRunners() {
+									ticker.Stop()
+									done <- true
+									return
+								}
+								continue
+							case <-limit:
 								ticker.Stop()
-								done <- true
+								done <- false
 								return
 							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							done <- false
-							return
+						}
+					}()
+					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+
+					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+					So(err, ShouldBeNil)
+					So(len(jobs), ShouldEqual, count)
+					ran := 0
+					for _, job := range jobs {
+						files, err := ioutil.ReadDir(job.ActualCwd)
+						if err != nil {
+							log.Fatal(err)
+						}
+						for range files {
+							ran++
 						}
 					}
-				}()
-				So(<-done, ShouldBeTrue)
-			})
-		} else {
-			SkipConvey("Skipping a test that needs at least 3 cores", func() {})
-		}
+					So(ran, ShouldEqual, count)
 
-		if runtime.NumCPU() >= 2 {
-			Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
+					// we shouldn't have executed any unnecessary runners, and those
+					// we did run should have exited without error, even if there
+					// were no more jobs left
+					files, err := ioutil.ReadDir(runnertmpdir)
+					if err != nil {
+						log.Fatal(err)
+					}
+					ranClean := 0
+					for range files {
+						ranClean++
+					}
+					So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
+				})
+			})
+
+			Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
 				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldBeNil)
 				defer jq.Disconnect()
 
-				jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+				if err != nil {
+					log.Fatal(err)
+				}
+				defer os.RemoveAll(tmpdir)
 
+				var jobs []*Job
+				count := maxCPU * 2
+				for i := 0; i < count; i++ {
+					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
+				}
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, count)
+				So(already, ShouldEqual, 0)
+
+				Convey("After some time the jobs get automatically run", func() {
+					// wait for the jobs to get run
+					done := make(chan bool, 1)
+					var simultaneous int
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								if !server.HasRunners() {
+									ticker.Stop()
+									done <- true
+									return
+								}
+								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+								if errj == nil && len(running) > simultaneous {
+									simultaneous = len(running)
+								}
+								continue
+							case <-limit:
+								ticker.Stop()
+								done <- false
+								return
+							}
+						}
+					}()
+					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+					So(simultaneous, ShouldBeGreaterThan, maxCPU)
+
+					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+					So(err, ShouldBeNil)
+					So(len(jobs), ShouldEqual, count)
+					ran := 0
+					for _, job := range jobs {
+						files, err := ioutil.ReadDir(job.ActualCwd)
+						if err != nil {
+							log.Fatal(err)
+						}
+						for range files {
+							ran++
+						}
+					}
+					So(ran, ShouldEqual, count)
+
+					files, err := ioutil.ReadDir(runnertmpdir)
+					if err != nil {
+						log.Fatal(err)
+					}
+					ranClean := 0
+					for range files {
+						ranClean++
+					}
+					So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
+				})
+			})
+
+			Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
+
+				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+				if err != nil {
+					log.Fatal(err)
+				}
+				defer os.RemoveAll(tmpdir)
+
+				maxMem, errp := internal.ProcMeminfoMBs()
+				So(errp, ShouldBeNil)
+
+				var jobs []*Job
+				jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
+				count := maxCPU * 3
+				for i := 0; i < count; i++ {
+					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
+				}
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, count)
+				So(already, ShouldEqual, 0)
+
+				Convey("After some time the jobs get automatically run", func() {
+					// wait for the jobs to get run
+					done := make(chan bool, 1)
+					var simultaneous int
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								if !server.HasRunners() {
+									ticker.Stop()
+									done <- true
+									return
+								}
+								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+								if errj == nil && len(running) > simultaneous {
+									simultaneous = len(running)
+								}
+								continue
+							case <-limit:
+								ticker.Stop()
+								done <- false
+								return
+							}
+						}
+					}()
+					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+					So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
+
+					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+					So(err, ShouldBeNil)
+					So(len(jobs), ShouldEqual, count)
+					ran := 0
+					for _, job := range jobs {
+						files, err := ioutil.ReadDir(job.ActualCwd)
+						if err != nil {
+							log.Fatal(err)
+						}
+						for range files {
+							ran++
+						}
+					}
+					So(ran, ShouldEqual, count)
+				})
+			})
+
+			Convey("You can connect, and add a job that buries with no retries", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
+
+				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+				if err != nil {
+					log.Fatal(err)
+				}
+				defer os.RemoveAll(tmpdir)
+
+				var jobs []*Job
+				jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
 				inserts, already, err := jq.Add(jobs, envVars, true)
 				So(err, ShouldBeNil)
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				// wait for this first command to start running
-				running := make(chan bool, 1)
-				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					for {
-						select {
-						case <-ticker.C:
-							pids, errf := process.Pids()
-							if errf == nil {
-								for _, pid := range pids {
-									p, errf := process.NewProcess(pid)
-									if errf == nil {
-										cmd, errf := p.Cmdline()
+				Convey("After some time the jobs get automatically run without excess runners", func() {
+					// wait for the jobs to get run
+					done := make(chan bool, 1)
+					waitForBury := func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(50 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+								if err != nil {
+									continue
+								}
+								if len(jobs) == 1 {
+									ticker.Stop()
+									done <- true
+									return
+								}
+								continue
+							case <-limit:
+								ticker.Stop()
+								done <- false
+								return
+							}
+						}
+					}
+					go waitForBury()
+					So(<-done, ShouldBeTrue)
+
+					jobs = nil
+					jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
+					inserts, already, err := jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
+
+					done2 := make(chan bool, 1)
+					waitForNoRunners := func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								if !server.HasRunners() {
+									ticker.Stop()
+									done2 <- true
+									return
+								}
+								continue
+							case <-limit:
+								ticker.Stop()
+								done2 <- false
+								return
+							}
+						}
+					}
+					go waitForNoRunners()
+					So(<-done2, ShouldBeTrue)
+
+					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+					So(err, ShouldBeNil)
+					So(len(jobs), ShouldEqual, 1)
+					buriedKey := jobs[0].Key()
+					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
+					So(err, ShouldBeNil)
+					So(len(jobs), ShouldEqual, 1)
+
+					// we shouldn't have executed any unnecessary runners
+					files, err := ioutil.ReadDir(runnertmpdir)
+					if err != nil {
+						log.Fatal(err)
+					}
+					ranClean := 0
+					for _, file := range files {
+						if !strings.HasPrefix(file.Name(), "ok") {
+							continue
+						}
+						ranClean++
+					}
+					So(ranClean, ShouldEqual, 1)
+
+					Convey("Retrying buried jobs works multiple times in a row", func() {
+						kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
+						So(err, ShouldBeNil)
+						So(kicked, ShouldEqual, 1)
+
+						go waitForBury()
+						So(<-done, ShouldBeTrue)
+
+						kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
+						So(err, ShouldBeNil)
+						So(kicked, ShouldEqual, 1)
+
+						go waitForBury()
+						So(<-done, ShouldBeTrue)
+
+						go waitForNoRunners()
+						So(<-done2, ShouldBeTrue)
+					})
+				})
+			})
+
+			if maxCPU > 2 {
+				Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
+					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+					So(err, ShouldBeNil)
+					defer jq.Disconnect()
+
+					req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
+					jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+					inserts, already, err := jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
+
+					<-time.After(1 * time.Second)
+
+					job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
+					So(err, ShouldBeNil)
+					So(job, ShouldNotBeNil)
+					So(job.State, ShouldEqual, JobStateRunning)
+
+					jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
+					inserts, already, err = jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
+
+					<-time.After(1 * time.Second)
+
+					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
+					So(err, ShouldBeNil)
+					So(job, ShouldNotBeNil)
+					So(job.State, ShouldEqual, JobStateRunning)
+
+					jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+					inserts, already, err = jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
+
+					<-time.After(1 * time.Second)
+
+					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
+					So(err, ShouldBeNil)
+					So(job, ShouldNotBeNil)
+					So(job.State, ShouldEqual, JobStateRunning)
+
+					// let them all complete
+					done := make(chan bool, 1)
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								if !server.HasRunners() {
+									ticker.Stop()
+									done <- true
+									return
+								}
+								continue
+							case <-limit:
+								ticker.Stop()
+								done <- false
+								return
+							}
+						}
+					}()
+					So(<-done, ShouldBeTrue)
+				})
+			} else {
+				SkipConvey("Skipping a test that needs at least 3 cores", func() {})
+			}
+
+			if runtime.NumCPU() >= 2 {
+				Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
+					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+					So(err, ShouldBeNil)
+					defer jq.Disconnect()
+
+					jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+
+					inserts, already, err := jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
+
+					// wait for this first command to start running
+					running := make(chan bool, 1)
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						for {
+							select {
+							case <-ticker.C:
+								pids, errf := process.Pids()
+								if errf == nil {
+									for _, pid := range pids {
+										p, errf := process.NewProcess(pid)
 										if errf == nil {
-											if strings.Contains(cmd, runnertmpdir+"2sim") {
-												status, errf := p.Status()
-												if errf == nil && status == "S" {
-													ticker.Stop()
-													running <- true
-													return
+											cmd, errf := p.Cmdline()
+											if errf == nil {
+												if strings.Contains(cmd, runnertmpdir+"2sim") {
+													status, errf := p.Status()
+													if errf == nil && status == "S" {
+														ticker.Stop()
+														running <- true
+														return
+													}
 												}
 											}
 										}
 									}
 								}
-							}
-							if !server.HasRunners() {
+								if !server.HasRunners() {
+									ticker.Stop()
+									running <- false
+									return
+								}
+								continue
+							case <-limit:
 								ticker.Stop()
 								running <- false
 								return
 							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							running <- false
-							return
 						}
-					}
-				}()
-				So(<-running, ShouldBeTrue)
+					}()
+					So(<-running, ShouldBeTrue)
 
-				jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+					jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
 
-				inserts, already, err = jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
+					inserts, already, err = jq.Add(jobs, envVars, true)
+					So(err, ShouldBeNil)
+					So(inserts, ShouldEqual, 1)
+					So(already, ShouldEqual, 0)
 
-				// wait for the jobs to get run, and while waiting we'll check to
-				// see if we get both of our commands running at once
-				numRanSimultaneously := make(chan int, 1)
-				go func() {
-					limit := time.After(30 * time.Second)
-					ticker := time.NewTicker(500 * time.Millisecond)
-					maxSimultaneous := 0
-					for {
-						select {
-						case <-ticker.C:
-							pids, err := process.Pids()
-							if err == nil {
-								simultaneous := 0
-								for _, pid := range pids {
-									p, err := process.NewProcess(pid)
-									if err == nil {
-										cmd, err := p.Cmdline()
+					// wait for the jobs to get run, and while waiting we'll check to
+					// see if we get both of our commands running at once
+					numRanSimultaneously := make(chan int, 1)
+					go func() {
+						limit := time.After(30 * time.Second)
+						ticker := time.NewTicker(500 * time.Millisecond)
+						maxSimultaneous := 0
+						for {
+							select {
+							case <-ticker.C:
+								pids, err := process.Pids()
+								if err == nil {
+									simultaneous := 0
+									for _, pid := range pids {
+										p, err := process.NewProcess(pid)
 										if err == nil {
-											if strings.Contains(cmd, runnertmpdir+"2sim") {
-												status, err := p.Status()
-												if err == nil && status == "S" {
-													simultaneous++
+											cmd, err := p.Cmdline()
+											if err == nil {
+												if strings.Contains(cmd, runnertmpdir+"2sim") {
+													status, err := p.Status()
+													if err == nil && status == "S" {
+														simultaneous++
+													}
 												}
 											}
 										}
 									}
+									if simultaneous > maxSimultaneous {
+										maxSimultaneous = simultaneous
+									}
 								}
-								if simultaneous > maxSimultaneous {
-									maxSimultaneous = simultaneous
+								if !server.HasRunners() {
+									ticker.Stop()
+									numRanSimultaneously <- maxSimultaneous
+									return
 								}
-							}
-							if !server.HasRunners() {
+								continue
+							case <-limit:
 								ticker.Stop()
 								numRanSimultaneously <- maxSimultaneous
 								return
 							}
-							continue
-						case <-limit:
-							ticker.Stop()
-							numRanSimultaneously <- maxSimultaneous
-							return
 						}
-					}
-				}()
-				So(<-numRanSimultaneously, ShouldEqual, 2)
-			})
+					}()
+					So(<-numRanSimultaneously, ShouldEqual, 2)
+				})
+			}
 		}
 
 		Convey("You can connect, and add 2 large batches of jobs sequentially", func() {
@@ -3589,16 +3591,24 @@ func TestJobqueueRunners(t *testing.T) {
 									done <- true
 									return
 								}
+								fmt.Printf("got %d complete jobs\n", len(jobs))
 							} else if twoHundredCount == 0 {
 								server.sgcmutex.Lock()
 								if countg, existed := server.sgroupcounts["200:30:1:0"]; existed {
 									twoHundredCount = countg
+									fmt.Printf("twoHundredCount now %d\n", countg)
 								}
 								server.sgcmutex.Unlock()
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
+							fmt.Printf("\nhit limit, sgroupcounts:\n")
+							server.sgcmutex.Lock()
+							for key, val := range server.sgroupcounts {
+								fmt.Printf(" %s => %d\n", key, val)
+							}
+							server.sgcmutex.Unlock()
 							done <- false
 							return
 						}
@@ -3663,6 +3673,7 @@ func TestJobqueueRunners(t *testing.T) {
 			}
 		})
 	})
+	return
 
 	// start these tests anew because these tests have the server spawn runners
 	// that fail, simulating some network issue

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3585,7 +3585,7 @@ func TestJobqueueRunners(t *testing.T) {
 			done = make(chan bool, 1)
 			twoHundredCount := 0
 			go func() {
-				limit := time.After(180 * time.Second)
+				limit := time.After(240 * time.Second)
 				ticker := time.NewTicker(50 * time.Millisecond)
 				for {
 					select {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -624,6 +624,13 @@ func TestJobqueueBasics(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(stdout, ShouldEqual, "b")
 
+				// make sure the stdout is actually stored in the database
+				retrieved, err := jq.GetByEssence(job.ToEssense(), true, false)
+				So(err, ShouldBeNil)
+				stdout, err = retrieved.StdOut()
+				So(err, ShouldBeNil)
+				So(stdout, ShouldEqual, "b")
+
 				// by comparison, compare normal behaviour, where the initial
 				// value of the envvar gets used for the job
 				os.Setenv("wr_jobqueue_test_no_envvar", "a")

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -1083,6 +1083,9 @@ func TestJobqueueMedium(t *testing.T) {
 					cmd := "perl -e '@a; for (1..3) { push(@a, q[a] x 50000000); sleep(1) }'"
 					jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "highmem", Requirements: standardReqs, Retries: uint8(0), RepGroup: "too_much_mem"})
 					RecMBRound = 1
+					defer func() {
+						RecMBRound = 100 // revert back to normal
+					}()
 					inserts, already, err := jq.Add(jobs, envVars, true)
 					So(err, ShouldBeNil)
 					So(inserts, ShouldEqual, 1)
@@ -2883,54 +2886,332 @@ func TestJobqueueRunners(t *testing.T) {
 		maxCPU := runtime.NumCPU()
 		runtime.GOMAXPROCS(maxCPU)
 
-		if false {
-			Convey("You can connect, and add a job that you can kill while it's running", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
+		Convey("You can connect, and add a job that you can kill while it's running", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
 
-				var jobs []*Job
-				jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, 1)
-				So(already, ShouldEqual, 0)
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
 
-				// wait for the job to start running
-				started := make(chan bool, 1)
+			// wait for the job to start running
+			started := make(chan bool, 1)
+			go func() {
+				limit := time.After(10 * time.Second)
+				ticker := time.NewTicker(50 * time.Millisecond)
+				for {
+					select {
+					case <-ticker.C:
+						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+						if err != nil {
+							continue
+						}
+						if len(jobs) == 1 {
+							ticker.Stop()
+							started <- true
+							return
+						}
+						continue
+					case <-limit:
+						ticker.Stop()
+						started <- false
+						return
+					}
+				}
+			}()
+			So(<-started, ShouldBeTrue)
+
+			killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
+			So(err, ShouldBeNil)
+			So(killCount, ShouldEqual, 1)
+
+			// wait for the job to get killed
+			killed := make(chan bool, 1)
+			go func() {
+				limit := time.After(20 * time.Second)
+				ticker := time.NewTicker(50 * time.Millisecond)
+				for {
+					select {
+					case <-ticker.C:
+						jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+						if err != nil {
+							continue
+						}
+						if len(jobs) == 1 {
+							ticker.Stop()
+							killed <- true
+							return
+						}
+						continue
+					case <-limit:
+						ticker.Stop()
+						killed <- false
+						return
+					}
+				}
+			}()
+			So(<-killed, ShouldBeTrue)
+
+			jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+			So(err, ShouldBeNil)
+			So(len(jobs), ShouldEqual, 1)
+			So(jobs[0].State, ShouldEqual, JobStateBuried)
+			So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
+			So(jobs[0].Exitcode, ShouldEqual, -1)
+		})
+
+		Convey("You can connect, and add some real jobs", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			count := maxCPU * 2
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
 				go func() {
-					limit := time.After(10 * time.Second)
-					ticker := time.NewTicker(50 * time.Millisecond)
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
 					for {
 						select {
 						case <-ticker.C:
-							jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-							if err != nil {
-								continue
-							}
-							if len(jobs) == 1 {
+							if !server.HasRunners() {
 								ticker.Stop()
-								started <- true
+								done <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							started <- false
+							done <- false
 							return
 						}
 					}
 				}()
-				So(<-started, ShouldBeTrue)
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
 
-				killCount, err := jq.Kill([]*JobEssence{{Cmd: "sleep 20"}})
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
 				So(err, ShouldBeNil)
-				So(killCount, ShouldEqual, 1)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
 
-				// wait for the job to get killed
-				killed := make(chan bool, 1)
+				// we shouldn't have executed any unnecessary runners, and those
+				// we did run should have exited without error, even if there
+				// were no more jobs left
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for range files {
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
+			})
+		})
+
+		Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			count := maxCPU * 2
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				var simultaneous int
 				go func() {
-					limit := time.After(20 * time.Second)
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
+								ticker.Stop()
+								done <- true
+								return
+							}
+							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+							if errj == nil && len(running) > simultaneous {
+								simultaneous = len(running)
+							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
+						}
+					}
+				}()
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+				So(simultaneous, ShouldBeGreaterThan, maxCPU)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
+
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for range files {
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
+			})
+		})
+
+		Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			maxMem, errp := internal.ProcMeminfoMBs()
+			So(errp, ShouldBeNil)
+
+			var jobs []*Job
+			jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
+			count := maxCPU * 3
+			for i := 0; i < count; i++ {
+				jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
+			}
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, count)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				var simultaneous int
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
+								ticker.Stop()
+								done <- true
+								return
+							}
+							running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
+							if errj == nil && len(running) > simultaneous {
+								simultaneous = len(running)
+							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
+						}
+					}
+				}()
+				So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
+				So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, count)
+				ran := 0
+				for _, job := range jobs {
+					files, err := ioutil.ReadDir(job.ActualCwd)
+					if err != nil {
+						log.Fatal(err)
+					}
+					for range files {
+						ran++
+					}
+				}
+				So(ran, ShouldEqual, count)
+			})
+		})
+
+		Convey("You can connect, and add a job that buries with no retries", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer jq.Disconnect()
+
+			tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer os.RemoveAll(tmpdir)
+
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
+			inserts, already, err := jq.Add(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
+
+			Convey("After some time the jobs get automatically run without excess runners", func() {
+				// wait for the jobs to get run
+				done := make(chan bool, 1)
+				waitForBury := func() {
+					limit := time.After(30 * time.Second)
 					ticker := time.NewTicker(50 * time.Millisecond)
 					for {
 						select {
@@ -2941,554 +3222,274 @@ func TestJobqueueRunners(t *testing.T) {
 							}
 							if len(jobs) == 1 {
 								ticker.Stop()
-								killed <- true
+								done <- true
 								return
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							killed <- false
+							done <- false
 							return
 						}
 					}
-				}()
-				So(<-killed, ShouldBeTrue)
-
-				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-				So(err, ShouldBeNil)
-				So(len(jobs), ShouldEqual, 1)
-				So(jobs[0].State, ShouldEqual, JobStateBuried)
-				So(jobs[0].FailReason, ShouldEqual, FailReasonKilled)
-				So(jobs[0].Exitcode, ShouldEqual, -1)
-			})
-
-			Convey("You can connect, and add some real jobs", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
 				}
-				defer os.RemoveAll(tmpdir)
+				go waitForBury()
+				So(<-done, ShouldBeTrue)
 
-				var jobs []*Job
-				count := maxCPU * 2
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-
-					// we shouldn't have executed any unnecessary runners, and those
-					// we did run should have exited without error, even if there
-					// were no more jobs left
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for range files {
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, maxCPU+1) // +1 for the runner exe
-				})
-			})
-
-			Convey("You can connect, and add some jobs with fractional CPU requirements", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				var jobs []*Job
-				count := maxCPU * 2
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 0.5}, Retries: uint8(0), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					var simultaneous int
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-								if errj == nil && len(running) > simultaneous {
-									simultaneous = len(running)
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-					So(simultaneous, ShouldBeGreaterThan, maxCPU)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for range files {
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, count+1) // +1 for the runner exe
-				})
-			})
-
-			Convey("You can connect, and add some 0 CPU jobs, which are limited by memory", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				maxMem, errp := internal.ProcMeminfoMBs()
-				So(errp, ShouldBeNil)
-
-				var jobs []*Job
-				jobMB := int(math.Floor(float64(maxMem) / float64(maxCPU*2)))
-				count := maxCPU * 3
-				for i := 0; i < count; i++ {
-					jobs = append(jobs, &Job{Cmd: fmt.Sprintf("sleep 2 && perl -e 'open($fh, q[>%d]); print $fh q[foo]; close($fh)'", i), Cwd: tmpdir, ReqGroup: "perl", Requirements: &jqs.Requirements{RAM: jobMB, Time: 1 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "manually_added"})
-				}
-				inserts, already, err := jq.Add(jobs, envVars, true)
-				So(err, ShouldBeNil)
-				So(inserts, ShouldEqual, count)
-				So(already, ShouldEqual, 0)
-
-				Convey("After some time the jobs get automatically run", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					var simultaneous int
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								running, errj := jq.GetByRepGroup("manually_added", false, 0, JobStateRunning, false, false)
-								if errj == nil && len(running) > simultaneous {
-									simultaneous = len(running)
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done <- false
-								return
-							}
-						}
-					}()
-					So(<-done, ShouldBeTrue) // we shouldn't have hit our time limit
-					So(simultaneous, ShouldBeBetweenOrEqual, maxCPU, maxCPU*2)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, "", false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, count)
-					ran := 0
-					for _, job := range jobs {
-						files, err := ioutil.ReadDir(job.ActualCwd)
-						if err != nil {
-							log.Fatal(err)
-						}
-						for range files {
-							ran++
-						}
-					}
-					So(ran, ShouldEqual, count)
-				})
-			})
-
-			Convey("You can connect, and add a job that buries with no retries", func() {
-				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-				So(err, ShouldBeNil)
-				defer jq.Disconnect()
-
-				tmpdir, err := ioutil.TempDir("", "wr_jobqueue_test_output_dir_")
-				if err != nil {
-					log.Fatal(err)
-				}
-				defer os.RemoveAll(tmpdir)
-
-				var jobs []*Job
-				jobs = append(jobs, &Job{Cmd: "echo 1 && false", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
+				jobs = nil
+				jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
 				inserts, already, err := jq.Add(jobs, envVars, true)
 				So(err, ShouldBeNil)
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				Convey("After some time the jobs get automatically run without excess runners", func() {
-					// wait for the jobs to get run
-					done := make(chan bool, 1)
-					waitForBury := func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(50 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-								if err != nil {
-									continue
-								}
-								if len(jobs) == 1 {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
+				done2 := make(chan bool, 1)
+				waitForNoRunners := func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
 								ticker.Stop()
-								done <- false
+								done2 <- true
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done2 <- false
+							return
 						}
 					}
+				}
+				go waitForNoRunners()
+				So(<-done2, ShouldBeTrue)
+
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, 1)
+				buriedKey := jobs[0].Key()
+				jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
+				So(err, ShouldBeNil)
+				So(len(jobs), ShouldEqual, 1)
+
+				// we shouldn't have executed any unnecessary runners
+				files, err := ioutil.ReadDir(runnertmpdir)
+				if err != nil {
+					log.Fatal(err)
+				}
+				ranClean := 0
+				for _, file := range files {
+					if !strings.HasPrefix(file.Name(), "ok") {
+						continue
+					}
+					ranClean++
+				}
+				So(ranClean, ShouldEqual, 1)
+
+				Convey("Retrying buried jobs works multiple times in a row", func() {
+					kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
+					So(err, ShouldBeNil)
+					So(kicked, ShouldEqual, 1)
+
 					go waitForBury()
 					So(<-done, ShouldBeTrue)
 
-					jobs = nil
-					jobs = append(jobs, &Job{Cmd: "echo 2 && true", Cwd: tmpdir, ReqGroup: "echo", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
-					inserts, already, err := jq.Add(jobs, envVars, true)
+					kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
 					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+					So(kicked, ShouldEqual, 1)
 
-					done2 := make(chan bool, 1)
-					waitForNoRunners := func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done2 <- true
-									return
-								}
-								continue
-							case <-limit:
-								ticker.Stop()
-								done2 <- false
-								return
-							}
-						}
-					}
+					go waitForBury()
+					So(<-done, ShouldBeTrue)
+
 					go waitForNoRunners()
 					So(<-done2, ShouldBeTrue)
-
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateBuried, false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, 1)
-					buriedKey := jobs[0].Key()
-					jobs, err = jq.GetByRepGroup("manually_added", false, 0, JobStateComplete, false, false)
-					So(err, ShouldBeNil)
-					So(len(jobs), ShouldEqual, 1)
-
-					// we shouldn't have executed any unnecessary runners
-					files, err := ioutil.ReadDir(runnertmpdir)
-					if err != nil {
-						log.Fatal(err)
-					}
-					ranClean := 0
-					for _, file := range files {
-						if !strings.HasPrefix(file.Name(), "ok") {
-							continue
-						}
-						ranClean++
-					}
-					So(ranClean, ShouldEqual, 1)
-
-					Convey("Retrying buried jobs works multiple times in a row", func() {
-						kicked, err := jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-						So(err, ShouldBeNil)
-						So(kicked, ShouldEqual, 1)
-
-						go waitForBury()
-						So(<-done, ShouldBeTrue)
-
-						kicked, err = jq.Kick([]*JobEssence{{JobKey: buriedKey}})
-						So(err, ShouldBeNil)
-						So(kicked, ShouldEqual, 1)
-
-						go waitForBury()
-						So(<-done, ShouldBeTrue)
-
-						go waitForNoRunners()
-						So(<-done2, ShouldBeTrue)
-					})
 				})
 			})
+		})
 
-			if maxCPU > 2 {
-				Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
-					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-					So(err, ShouldBeNil)
-					defer jq.Disconnect()
+		if maxCPU > 2 {
+			Convey("You can connect and add jobs in alternating scheduler groups and they don't pend", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
 
-					req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
-					jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
-					inserts, already, err := jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				req1 := &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}
+				jobs := []*Job{{Cmd: "echo 1 && sleep 4", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 4"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				jobs = []*Job{{Cmd: "echo 2 && sleep 3", Cwd: "/tmp", ReqGroup: "req2", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Hour, Cores: 1}, RepGroup: "a"}}
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 3"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				jobs = []*Job{{Cmd: "echo 3 && sleep 2", Cwd: "/tmp", ReqGroup: "req1", Requirements: req1, RepGroup: "a"}}
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					<-time.After(1 * time.Second)
+				<-time.After(1 * time.Second)
 
-					job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
-					So(err, ShouldBeNil)
-					So(job, ShouldNotBeNil)
-					So(job.State, ShouldEqual, JobStateRunning)
+				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
+				So(err, ShouldBeNil)
+				So(job, ShouldNotBeNil)
+				So(job.State, ShouldEqual, JobStateRunning)
 
-					// let them all complete
-					done := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								if !server.HasRunners() {
-									ticker.Stop()
-									done <- true
-									return
-								}
-								continue
-							case <-limit:
+				// let them all complete
+				done := make(chan bool, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							if !server.HasRunners() {
 								ticker.Stop()
-								done <- false
+								done <- true
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							done <- false
+							return
 						}
-					}()
-					So(<-done, ShouldBeTrue)
-				})
-			} else {
-				SkipConvey("Skipping a test that needs at least 3 cores", func() {})
-			}
+					}
+				}()
+				So(<-done, ShouldBeTrue)
+			})
+		} else {
+			SkipConvey("Skipping a test that needs at least 3 cores", func() {})
+		}
 
-			if runtime.NumCPU() >= 2 {
-				Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
-					jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
-					So(err, ShouldBeNil)
-					defer jq.Disconnect()
+		if runtime.NumCPU() >= 2 {
+			Convey("You can connect, and add 2 real jobs with the same reqs sequentially that run simultaneously", func() {
+				jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+				So(err, ShouldBeNil)
+				defer jq.Disconnect()
 
-					jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+				jobs := []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 1), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
 
-					inserts, already, err := jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				inserts, already, err := jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					// wait for this first command to start running
-					running := make(chan bool, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						for {
-							select {
-							case <-ticker.C:
-								pids, errf := process.Pids()
-								if errf == nil {
-									for _, pid := range pids {
-										p, errf := process.NewProcess(pid)
+				// wait for this first command to start running
+				running := make(chan bool, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					for {
+						select {
+						case <-ticker.C:
+							pids, errf := process.Pids()
+							if errf == nil {
+								for _, pid := range pids {
+									p, errf := process.NewProcess(pid)
+									if errf == nil {
+										cmd, errf := p.Cmdline()
 										if errf == nil {
-											cmd, errf := p.Cmdline()
-											if errf == nil {
-												if strings.Contains(cmd, runnertmpdir+"2sim") {
-													status, errf := p.Status()
-													if errf == nil && status == "S" {
-														ticker.Stop()
-														running <- true
-														return
-													}
+											if strings.Contains(cmd, runnertmpdir+"2sim") {
+												status, errf := p.Status()
+												if errf == nil && status == "S" {
+													ticker.Stop()
+													running <- true
+													return
 												}
 											}
 										}
 									}
 								}
-								if !server.HasRunners() {
-									ticker.Stop()
-									running <- false
-									return
-								}
-								continue
-							case <-limit:
+							}
+							if !server.HasRunners() {
 								ticker.Stop()
 								running <- false
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							running <- false
+							return
 						}
-					}()
-					So(<-running, ShouldBeTrue)
+					}
+				}()
+				So(<-running, ShouldBeTrue)
 
-					jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
+				jobs = []*Job{{Cmd: fmt.Sprintf("perl -e 'print q[%s2sim%d]; sleep(5);'", runnertmpdir, 2), Cwd: runnertmpdir, ReqGroup: "perl2sim", Requirements: &jqs.Requirements{RAM: 1, Time: 1 * time.Second, Cores: 1}, Retries: uint8(3), RepGroup: "manually_added"}}
 
-					inserts, already, err = jq.Add(jobs, envVars, true)
-					So(err, ShouldBeNil)
-					So(inserts, ShouldEqual, 1)
-					So(already, ShouldEqual, 0)
+				inserts, already, err = jq.Add(jobs, envVars, true)
+				So(err, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
 
-					// wait for the jobs to get run, and while waiting we'll check to
-					// see if we get both of our commands running at once
-					numRanSimultaneously := make(chan int, 1)
-					go func() {
-						limit := time.After(30 * time.Second)
-						ticker := time.NewTicker(500 * time.Millisecond)
-						maxSimultaneous := 0
-						for {
-							select {
-							case <-ticker.C:
-								pids, err := process.Pids()
-								if err == nil {
-									simultaneous := 0
-									for _, pid := range pids {
-										p, err := process.NewProcess(pid)
+				// wait for the jobs to get run, and while waiting we'll check to
+				// see if we get both of our commands running at once
+				numRanSimultaneously := make(chan int, 1)
+				go func() {
+					limit := time.After(30 * time.Second)
+					ticker := time.NewTicker(500 * time.Millisecond)
+					maxSimultaneous := 0
+					for {
+						select {
+						case <-ticker.C:
+							pids, err := process.Pids()
+							if err == nil {
+								simultaneous := 0
+								for _, pid := range pids {
+									p, err := process.NewProcess(pid)
+									if err == nil {
+										cmd, err := p.Cmdline()
 										if err == nil {
-											cmd, err := p.Cmdline()
-											if err == nil {
-												if strings.Contains(cmd, runnertmpdir+"2sim") {
-													status, err := p.Status()
-													if err == nil && status == "S" {
-														simultaneous++
-													}
+											if strings.Contains(cmd, runnertmpdir+"2sim") {
+												status, err := p.Status()
+												if err == nil && status == "S" {
+													simultaneous++
 												}
 											}
 										}
 									}
-									if simultaneous > maxSimultaneous {
-										maxSimultaneous = simultaneous
-									}
 								}
-								if !server.HasRunners() {
-									ticker.Stop()
-									numRanSimultaneously <- maxSimultaneous
-									return
+								if simultaneous > maxSimultaneous {
+									maxSimultaneous = simultaneous
 								}
-								continue
-							case <-limit:
+							}
+							if !server.HasRunners() {
 								ticker.Stop()
 								numRanSimultaneously <- maxSimultaneous
 								return
 							}
+							continue
+						case <-limit:
+							ticker.Stop()
+							numRanSimultaneously <- maxSimultaneous
+							return
 						}
-					}()
-					So(<-numRanSimultaneously, ShouldEqual, 2)
-				})
-			}
+					}
+				}()
+				So(<-numRanSimultaneously, ShouldEqual, 2)
+			})
 		}
 
 		Convey("You can connect, and add 2 large batches of jobs sequentially", func() {
@@ -3591,24 +3592,16 @@ func TestJobqueueRunners(t *testing.T) {
 									done <- true
 									return
 								}
-								fmt.Printf("got %d complete jobs\n", len(jobs))
 							} else if twoHundredCount == 0 {
 								server.sgcmutex.Lock()
 								if countg, existed := server.sgroupcounts["200:30:1:0"]; existed {
 									twoHundredCount = countg
-									fmt.Printf("twoHundredCount now %d\n", countg)
 								}
 								server.sgcmutex.Unlock()
 							}
 							continue
 						case <-limit:
 							ticker.Stop()
-							fmt.Printf("\nhit limit, sgroupcounts:\n")
-							server.sgcmutex.Lock()
-							for key, val := range server.sgroupcounts {
-								fmt.Printf(" %s => %d\n", key, val)
-							}
-							server.sgcmutex.Unlock()
 							done <- false
 							return
 						}
@@ -3673,7 +3666,6 @@ func TestJobqueueRunners(t *testing.T) {
 			}
 		})
 	})
-	return
 
 	// start these tests anew because these tests have the server spawn runners
 	// that fail, simulating some network issue

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2421,7 +2421,7 @@ func TestJobqueueHighMem(t *testing.T) {
 			So(deleted, ShouldEqual, 1)
 		})
 	} else {
-		SkipConvey("Skipping test that uses most of machine memory", func() {})
+		SkipConvey("Skipping test that uses most of machine memory", t, func() {})
 	}
 }
 

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3589,10 +3589,12 @@ func TestJobqueueRunners(t *testing.T) {
 									done <- true
 									return
 								}
+								fmt.Printf("got %d complete jobs\n", len(jobs))
 							} else if twoHundredCount == 0 {
 								server.sgcmutex.Lock()
 								if countg, existed := server.sgroupcounts["200:30:1:0"]; existed {
 									twoHundredCount = countg
+									fmt.Printf("twoHundredCount now %d\n", countg)
 								}
 								server.sgcmutex.Unlock()
 							}

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3601,6 +3601,12 @@ func TestJobqueueRunners(t *testing.T) {
 							continue
 						case <-limit:
 							ticker.Stop()
+							fmt.Printf("\nhit limit, sgroupcounts:\n")
+							server.sgcmutex.Lock()
+							for key, val := range server.sgroupcounts {
+								fmt.Printf(" %s => %d\n", key, val)
+							}
+							server.sgcmutex.Unlock()
 							done <- false
 							return
 						}

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2892,7 +2892,7 @@ func TestJobqueueRunners(t *testing.T) {
 			defer jq.Disconnect()
 
 			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(3), Override: uint8(2), RepGroup: "manually_added"})
+			jobs = append(jobs, &Job{Cmd: "sleep 20", Cwd: "/tmp", ReqGroup: "sleep", Requirements: &jqs.Requirements{RAM: 1, Time: 20 * time.Second, Cores: 1}, Retries: uint8(0), Override: uint8(2), RepGroup: "manually_added"})
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 1)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -325,6 +325,8 @@ func TestJobqueueBasics(t *testing.T) {
 	}
 	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
 
+	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
+
 	var server *Server
 	var token []byte
 	var errs error
@@ -741,6 +743,8 @@ func TestJobqueueMedium(t *testing.T) {
 		return
 	}
 	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
+
+	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
 
 	// start these tests anew because I don't want to mess with the timings in
 	// the above tests
@@ -2346,6 +2350,8 @@ func TestJobqueueHighMem(t *testing.T) {
 	}
 	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
 
+	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
+
 	// start these tests anew because they need a long TTR
 	maxRAM, errp := internal.ProcMeminfoMBs()
 	if errp == nil && maxRAM > 80000 { // authors high memory system
@@ -2422,6 +2428,9 @@ func TestJobqueueProduction(t *testing.T) {
 		return
 	}
 	config, serverConfig, addr, _, clientConnectTime := jobqueueTestInit(true)
+
+	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
+
 	managerDBBkFile := serverConfig.DBFileBackup
 
 	// start these tests anew because I need to disable dev-mode wiping of the
@@ -2830,6 +2839,8 @@ func TestJobqueueRunners(t *testing.T) {
 		return
 	}
 	config, serverConfig, addr, _, clientConnectTime := jobqueueTestInit(true)
+
+	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
 
 	// start these tests anew because these tests have the server spawn runners
 	Convey("Once a new jobqueue server is up", t, func() {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -266,6 +266,8 @@ func TestJobqueueSignal(t *testing.T) {
 					if err != nil {
 						if jqerr, ok := err.(Error); ok && jqerr.Err == FailReasonTime && job2.State == JobStateBuried && job2.Exited && job2.Exitcode == -1 && job2.FailReason == FailReasonTime {
 							j2worked <- true
+						} else {
+							fmt.Printf("\njob2 didn't behave correctly: %s, %s, %v, %d, %s\n", jqerr.Err, job2.State, job2.Exited, job2.Exitcode, job2.FailReason)
 						}
 					}
 					j2worked <- false

--- a/jobqueue/scheduler/kubernetes.go
+++ b/jobqueue/scheduler/kubernetes.go
@@ -399,6 +399,7 @@ func (s *k8s) runCmd(cmd string, req *Requirements, reservedCh chan bool) error 
 	if val, defined := req.Other["cloud_script"]; defined {
 		cmap, err := s.libclient.CreateInitScriptConfigMap(val)
 		if err != nil {
+			reservedCh <- false
 			return err
 		}
 		configMapName = cmap.ObjectMeta.Name

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -245,7 +245,7 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 	}
 	s.mutex.Lock()
 
-	item, err := s.queue.Add(key, "", data, priority, 0*time.Second, 30*time.Second) // the ttr just has to be long enough for processQueue() to process a job, not actually run the cmds
+	item, err := s.queue.Add(key, "", data, priority, 0*time.Second, 30*time.Second, "") // the ttr just has to be long enough for processQueue() to process a job, not actually run the cmds
 	if err != nil {
 		if qerr, ok := err.(queue.Error); ok && qerr.Err == queue.ErrAlreadyExists {
 			// update the job's count (only)

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -261,7 +261,9 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 	}
 	s.mutex.Unlock()
 
-	s.startAutoProcessing()
+	if count > 0 {
+		s.startAutoProcessing()
+	}
 
 	// try and run the jobs in the queue
 	return s.processQueue()

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -552,6 +552,10 @@ func (s *local) startAutoProcessing() {
 		return
 	}
 
+	// processQueue() calls removeKey() which calls stopAutoProcessing() which
+	// can wait to send on stopAuto, but we only read from stopAuto when our
+	// processQueue() call is not running; solve the deadlock potential by
+	// buffering stopAuto
 	s.stopAuto = make(chan bool, 100)
 	go func() {
 		defer internal.LogPanic(s.Logger, "auto processQueue", false)

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -1154,6 +1154,9 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 
 // cancelRun fails standins for the given cmd. Only call when you have the lock!
 func (s *opst) cancelRun(cmd string, desiredCount int) {
+	s.runMutex.Lock()
+	defer s.runMutex.Unlock()
+
 	if lookup, existed := s.cmdToStandins[cmd]; existed {
 		numStandins := len(lookup)
 		cancelCount := numStandins - desiredCount

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -982,6 +982,8 @@ func (s *Server) createQueue() {
 		}
 		s.ssmutex.RUnlock()
 
+		fmt.Printf("\nReadyAddedCallback got %d items\n", len(allitemdata))
+
 		// calculate, set and count jobs by schedulerGroup
 		groups := make(map[string]int)
 		groupToReqs := make(map[string]*scheduler.Requirements)
@@ -1160,6 +1162,7 @@ func (s *Server) createQueue() {
 					job.setScheduledRunner(true)
 				}
 				groups[schedulerGroup]++
+				fmt.Printf("groups[%s] now %d\n", schedulerGroup, groups[schedulerGroup])
 
 				if noRec {
 					noRecGroups[schedulerGroup] = true
@@ -1223,6 +1226,7 @@ func (s *Server) createQueue() {
 					countIncRunning -= groupsScheduledCounts[group]
 				}
 				s.sgroupcounts[group] = countIncRunning
+				fmt.Printf("set s.sgroupcounts[%s] = %d\n", group, countIncRunning)
 
 				// if we got no resource requirement recommendations for
 				// this group, we'll set up a retrigger of this ready

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -982,14 +982,12 @@ func (s *Server) createQueue() {
 		}
 		s.ssmutex.RUnlock()
 
-		fmt.Printf("\nReadyAddedCallback got %d items\n", len(allitemdata))
-
 		// calculate, set and count jobs by schedulerGroup
 		groups := make(map[string]int)
 		groupToReqs := make(map[string]*scheduler.Requirements)
 		groupsScheduledCounts := make(map[string]int)
 		noRecGroups := make(map[string]bool)
-		for i, inter := range allitemdata {
+		for _, inter := range allitemdata {
 			job := inter.(*Job)
 
 			// depending on job.Override, get memory, disk and time
@@ -1001,9 +999,6 @@ func (s *Server) createQueue() {
 				recommendedReq = rec
 			} else {
 				recm, errm := s.db.recommendedReqGroupMemory(job.ReqGroup)
-				if i == 0 {
-					fmt.Printf("\nrecm: %v\n", recm)
-				}
 				recd, errd := s.db.recommendedReqGroupDisk(job.ReqGroup)
 				recs, errs := s.db.recommendedReqGroupTime(job.ReqGroup)
 				if errm != nil || errd != nil || errs != nil {
@@ -1049,9 +1044,6 @@ func (s *Server) createQueue() {
 					} else {
 						job.Requirements.RAM = recommendedReq.RAM
 					}
-				}
-				if i == 0 {
-					fmt.Printf("\njob.Requirements.RAM now: %v\n", job.Requirements.RAM)
 				}
 
 				if recommendedReq.Disk > 0 {
@@ -1102,7 +1094,6 @@ func (s *Server) createQueue() {
 					newRAM := int(math.Ceil(updatedMB/100) * 100)
 					if newRAM > job.Requirements.RAM {
 						job.Requirements.RAM = newRAM
-						fmt.Printf("\ndue to failure, job.Requirements.RAM now: %v\n", job.Requirements.RAM)
 					}
 				case FailReasonDisk:
 					// flat increase of 30%
@@ -1144,9 +1135,6 @@ func (s *Server) createQueue() {
 
 			prevSchedGroup := job.getSchedulerGroup()
 			schedulerGroup := req.Stringify()
-			if i == 0 {
-				fmt.Printf("\njob.Requirements.RAM finally %v, == group %s\n", req.RAM, schedulerGroup)
-			}
 			if prevSchedGroup != schedulerGroup {
 				job.setSchedulerGroup(schedulerGroup)
 				if prevSchedGroup != "" {
@@ -1172,9 +1160,6 @@ func (s *Server) createQueue() {
 					job.setScheduledRunner(true)
 				}
 				groups[schedulerGroup]++
-				if groups[schedulerGroup] == 1 || i == 0 || i == len(allitemdata)-1 {
-					fmt.Printf("groups[%s] now %d\n", schedulerGroup, groups[schedulerGroup])
-				}
 
 				if noRec {
 					noRecGroups[schedulerGroup] = true
@@ -1238,7 +1223,6 @@ func (s *Server) createQueue() {
 					countIncRunning -= groupsScheduledCounts[group]
 				}
 				s.sgroupcounts[group] = countIncRunning
-				fmt.Printf("set s.sgroupcounts[%s] = %d\n", group, countIncRunning)
 
 				// if we got no resource requirement recommendations for
 				// this group, we'll set up a retrigger of this ready

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -989,7 +989,7 @@ func (s *Server) createQueue() {
 		groupToReqs := make(map[string]*scheduler.Requirements)
 		groupsScheduledCounts := make(map[string]int)
 		noRecGroups := make(map[string]bool)
-		for _, inter := range allitemdata {
+		for i, inter := range allitemdata {
 			job := inter.(*Job)
 
 			// depending on job.Override, get memory, disk and time
@@ -1001,6 +1001,9 @@ func (s *Server) createQueue() {
 				recommendedReq = rec
 			} else {
 				recm, errm := s.db.recommendedReqGroupMemory(job.ReqGroup)
+				if i == 0 {
+					fmt.Printf("\nrecm: %v\n", recm)
+				}
 				recd, errd := s.db.recommendedReqGroupDisk(job.ReqGroup)
 				recs, errs := s.db.recommendedReqGroupTime(job.ReqGroup)
 				if errm != nil || errd != nil || errs != nil {
@@ -1046,6 +1049,9 @@ func (s *Server) createQueue() {
 					} else {
 						job.Requirements.RAM = recommendedReq.RAM
 					}
+				}
+				if i == 0 {
+					fmt.Printf("\njob.Requirements.RAM now: %v\n", job.Requirements.RAM)
 				}
 
 				if recommendedReq.Disk > 0 {
@@ -1096,6 +1102,7 @@ func (s *Server) createQueue() {
 					newRAM := int(math.Ceil(updatedMB/100) * 100)
 					if newRAM > job.Requirements.RAM {
 						job.Requirements.RAM = newRAM
+						fmt.Printf("\ndue to failure, job.Requirements.RAM now: %v\n", job.Requirements.RAM)
 					}
 				case FailReasonDisk:
 					// flat increase of 30%
@@ -1137,6 +1144,9 @@ func (s *Server) createQueue() {
 
 			prevSchedGroup := job.getSchedulerGroup()
 			schedulerGroup := req.Stringify()
+			if i == 0 {
+				fmt.Printf("\njob.Requirements.RAM finally %v, == group %s\n", req.RAM, schedulerGroup)
+			}
 			if prevSchedGroup != schedulerGroup {
 				job.setSchedulerGroup(schedulerGroup)
 				if prevSchedGroup != "" {
@@ -1162,7 +1172,9 @@ func (s *Server) createQueue() {
 					job.setScheduledRunner(true)
 				}
 				groups[schedulerGroup]++
-				fmt.Printf("groups[%s] now %d\n", schedulerGroup, groups[schedulerGroup])
+				if groups[schedulerGroup] == 1 || i == 0 || i == len(allitemdata)-1 {
+					fmt.Printf("groups[%s] now %d\n", schedulerGroup, groups[schedulerGroup])
+				}
 
 				if noRec {
 					noRecGroups[schedulerGroup] = true

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -373,7 +373,9 @@ func (s *Server) handleRequest(m *mangos.Message) error {
 			var job *Job
 			_, job, srerr = s.getij(cr)
 			if srerr == "" {
-				errq := s.releaseJob(job, cr.JobEndState, cr.Job.FailReason)
+				cr.JobEndState.Stdout = cr.Job.StdOutC
+				cr.JobEndState.Stderr = cr.Job.StdErrC
+				errq := s.releaseJob(job, cr.JobEndState, cr.Job.FailReason, true)
 				if errq != nil {
 					srerr = ErrInternalError
 					qerr = errq.Error()

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -50,7 +50,7 @@ func TestQueue(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					key := fmt.Sprintf("key_%d", i)
 					t := time.Duration((i+1)*100) * time.Millisecond
-					queue.Add(key, "", "data", 0, t, 0*time.Millisecond)
+					queue.Add(key, "", "data", 0, t, 0*time.Millisecond, "")
 				}
 				queue.Destroy()
 			}
@@ -71,7 +71,7 @@ func TestQueue(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					key := fmt.Sprintf("key_%d", i)
 					t := time.Duration((i+1)*100) * time.Millisecond
-					queue.Add(key, "", "data", 0, 0*time.Millisecond, t)
+					queue.Add(key, "", "data", 0, 0*time.Millisecond, t, "")
 				}
 				for i := 0; i < 10; i++ {
 					queue.Reserve()
@@ -182,7 +182,7 @@ func TestQueue(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			key := fmt.Sprintf("key_%d", i)
 			t := time.Duration((i+1)*100) * time.Millisecond
-			item, err := queue.Add(key, "", "data", 0, t, t)
+			item, err := queue.Add(key, "", "data", 0, t, t, "")
 			So(err, ShouldBeNil)
 			items[key] = item
 		}
@@ -221,7 +221,7 @@ func TestQueue(t *testing.T) {
 		})
 
 		Convey("You can't add the same item again", func() {
-			item, err := queue.Add("key_0", "", "data new", 0, 100*time.Millisecond, 100*time.Millisecond)
+			item, err := queue.Add("key_0", "", "data new", 0, 100*time.Millisecond, 100*time.Millisecond, "")
 			qerr, ok := err.(Error)
 			So(ok, ShouldBeTrue)
 			So(qerr.Err, ShouldEqual, ErrAlreadyExists)
@@ -582,8 +582,8 @@ func TestQueue(t *testing.T) {
 				Convey("Touching doesn't mess with the correct queue order", func() {
 					queue = New("new queue")
 					defer queue.Destroy()
-					queue.Add("item1", "", "data", 0, 0*time.Millisecond, 50*time.Millisecond)
-					queue.Add("item2", "", "data", 0, 0*time.Millisecond, 52*time.Millisecond)
+					queue.Add("item1", "", "data", 0, 0*time.Millisecond, 50*time.Millisecond, "")
+					queue.Add("item2", "", "data", 0, 0*time.Millisecond, 52*time.Millisecond, "")
 					<-time.After(1 * time.Millisecond)
 					item1, _ := queue.Reserve()
 					So(item1.Key, ShouldEqual, "item1")
@@ -617,7 +617,7 @@ func TestQueue(t *testing.T) {
 					So(stats.Running, ShouldEqual, 0)
 					So(stats.Buried, ShouldEqual, 0)
 
-					_, err = queue.Add("fake", "", "data", 0, 0*time.Second, 0*time.Second)
+					_, err = queue.Add("fake", "", "data", 0, 0*time.Second, 0*time.Second, "")
 					So(err, ShouldNotBeNil)
 					qerr, ok := err.(Error)
 					So(ok, ShouldBeTrue)
@@ -754,7 +754,7 @@ func TestQueue(t *testing.T) {
 	Convey("Once an item been added to the queue", t, func() {
 		queue := New("myqueue")
 		defer queue.Destroy()
-		item, _ := queue.Add("item1", "", "data", 0, 50*time.Millisecond, 50*time.Millisecond)
+		item, _ := queue.Add("item1", "", "data", 0, 50*time.Millisecond, 50*time.Millisecond, "")
 
 		Convey("It can be removed from the queue immediately prior to it getting switched to the ready queue", func() {
 			<-time.After(49 * time.Millisecond)
@@ -882,6 +882,32 @@ func TestQueue(t *testing.T) {
 		})
 	})
 
+	Convey("You can add items to the queue that start in the run or bury sub-queues", t, func() {
+		queue := New("run/bury queue")
+		defer queue.Destroy()
+
+		_, err := queue.Add("key_run", "", "data", 0, 100*time.Millisecond, 100*time.Millisecond, SubQueueRun)
+		So(err, ShouldBeNil)
+		_, err = queue.Add("key_bury", "", "data", 0, 100*time.Millisecond, 100*time.Millisecond, SubQueueBury)
+		So(err, ShouldBeNil)
+
+		stats := queue.Stats()
+		So(stats.Items, ShouldEqual, 2)
+		So(stats.Delayed, ShouldEqual, 0)
+		So(stats.Ready, ShouldEqual, 0)
+		So(stats.Running, ShouldEqual, 1)
+		So(stats.Buried, ShouldEqual, 1)
+
+		<-time.After(110 * time.Millisecond)
+
+		stats = queue.Stats()
+		So(stats.Items, ShouldEqual, 2)
+		So(stats.Delayed, ShouldEqual, 0)
+		So(stats.Ready, ShouldEqual, 1)
+		So(stats.Running, ShouldEqual, 0)
+		So(stats.Buried, ShouldEqual, 1)
+	})
+
 	Convey("Once a thousand items with no delay have been added to the queue", t, func() {
 		queue := New("1000 queue")
 		defer queue.Destroy()
@@ -891,7 +917,7 @@ func TestQueue(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			key := fmt.Sprintf("key_%d", i)
 			dataid := rand.Intn(999)
-			_, err := queue.Add(key, "", &testdata{ID: dataid}, 0, 0*time.Second, 30*time.Second)
+			_, err := queue.Add(key, "", &testdata{ID: dataid}, 0, 0*time.Second, 30*time.Second, "")
 			So(err, ShouldBeNil)
 		}
 
@@ -968,7 +994,7 @@ func TestQueue(t *testing.T) {
 			key := fmt.Sprintf("key_%d", i)
 			dataid := rand.Intn(999)
 			dataids = append(dataids, dataid)
-			_, err := queue.Add(key, fmt.Sprintf("%d", dataid), &testdata{ID: dataid}, 0, 0*time.Second, 30*time.Second)
+			_, err := queue.Add(key, fmt.Sprintf("%d", dataid), &testdata{ID: dataid}, 0, 0*time.Second, 30*time.Second, "")
 			So(err, ShouldBeNil)
 		}
 
@@ -1020,7 +1046,7 @@ func TestQueue(t *testing.T) {
 		t := time.Now()
 		for i := 0; i < 1000; i++ {
 			key := fmt.Sprintf("key_%d", i)
-			_, err := queue.Add(key, "", "data", 0, 100*time.Millisecond, 30*time.Second)
+			_, err := queue.Add(key, "", "data", 0, 100*time.Millisecond, 30*time.Second, "")
 			So(err, ShouldBeNil)
 		}
 		e := time.Since(t)
@@ -1124,25 +1150,71 @@ func TestQueue(t *testing.T) {
 		})
 	})
 
+	Convey("You can add many items to the queue that start in the run or bury sub-queues, all in one go", t, func() {
+		queue := New("run/bury queue")
+		defer queue.Destroy()
+
+		queues := []SubQueue{SubQueueRun, SubQueueBury}
+		var itemdefs []*ItemDef
+		for i := 0; i < 10; i++ {
+			for _, subQueue := range queues {
+				itemdefs = append(itemdefs, &ItemDef{
+					Key:        fmt.Sprintf("key_%d_%s", i, subQueue),
+					Data:       "data",
+					Priority:   0,
+					Delay:      100 * time.Millisecond,
+					TTR:        100 * time.Millisecond,
+					StartQueue: subQueue,
+				})
+			}
+		}
+
+		added, dups, err := queue.AddMany(itemdefs)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 20)
+		So(dups, ShouldEqual, 0)
+
+		added, dups, err = queue.AddMany(itemdefs)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 0)
+		So(dups, ShouldEqual, 20)
+
+		stats := queue.Stats()
+		So(stats.Items, ShouldEqual, 20)
+		So(stats.Delayed, ShouldEqual, 0)
+		So(stats.Ready, ShouldEqual, 0)
+		So(stats.Running, ShouldEqual, 10)
+		So(stats.Buried, ShouldEqual, 10)
+
+		<-time.After(110 * time.Millisecond)
+
+		stats = queue.Stats()
+		So(stats.Items, ShouldEqual, 20)
+		So(stats.Delayed, ShouldEqual, 0)
+		So(stats.Ready, ShouldEqual, 10)
+		So(stats.Running, ShouldEqual, 0)
+		So(stats.Buried, ShouldEqual, 10)
+	})
+
 	Convey("Once some items with dependencies have been added to the queue", t, func() {
 		// https://i-msdn.sec.s-msft.com/dynimg/IC332764.gif
 		queue := New("dep queue")
 		defer queue.Destroy()
-		_, err := queue.Add("key_1", "", "1", 0, 0*time.Second, 30*time.Second)
+		_, err := queue.Add("key_1", "", "1", 0, 0*time.Second, 30*time.Second, "")
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_2", "", "2", 0, 0*time.Second, 30*time.Second)
+		_, err = queue.Add("key_2", "", "2", 0, 0*time.Second, 30*time.Second, "")
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_3", "", "3", 0, 0*time.Second, 30*time.Second)
+		_, err = queue.Add("key_3", "", "3", 0, 0*time.Second, 30*time.Second, "")
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_4", "", "4", 0, 0*time.Second, 30*time.Second, []string{"key_1"})
+		_, err = queue.Add("key_4", "", "4", 0, 0*time.Second, 30*time.Second, "", []string{"key_1"})
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_5", "five", "5", 0, 0*time.Second, 30*time.Second, []string{"key_1", "key_2", "key_3"})
+		_, err = queue.Add("key_5", "five", "5", 0, 0*time.Second, 30*time.Second, "", []string{"key_1", "key_2", "key_3"})
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_6", "", "6", 0, 0*time.Second, 30*time.Second, []string{"key_3", "key_4"})
+		_, err = queue.Add("key_6", "", "6", 0, 0*time.Second, 30*time.Second, "", []string{"key_3", "key_4"})
 		So(err, ShouldBeNil)
-		fivesixdep, err := queue.Add("key_7", "", "7", 0, 0*time.Second, 30*time.Second, []string{"key_5", "key_6"})
+		fivesixdep, err := queue.Add("key_7", "", "7", 0, 0*time.Second, 30*time.Second, "", []string{"key_5", "key_6"})
 		So(err, ShouldBeNil)
-		_, err = queue.Add("key_8", "", "8", 0, 0*time.Second, 30*time.Second, []string{"key_5"})
+		_, err = queue.Add("key_8", "", "8", 0, 0*time.Second, 30*time.Second, "", []string{"key_5"})
 		So(err, ShouldBeNil)
 
 		So(fivesixdep.Dependencies(), ShouldResemble, []string{"key_5", "key_6"})
@@ -1290,11 +1362,11 @@ func TestQueue(t *testing.T) {
 		})
 
 		Convey("You can add dependencies on non-exist items and resolve them later", func() {
-			ten, err := queue.Add("key_10", "", "10", 0, 0*time.Second, 30*time.Second, []string{"key_9"})
+			ten, err := queue.Add("key_10", "", "10", 0, 0*time.Second, 30*time.Second, "", []string{"key_9"})
 			So(err, ShouldBeNil)
 			So(ten.Stats().State, ShouldEqual, ItemStateDependent)
 
-			_, err = queue.Add("key_9", "", "9", 0, 0*time.Second, 30*time.Second, []string{})
+			_, err = queue.Add("key_9", "", "9", 0, 0*time.Second, 30*time.Second, "", []string{})
 			So(err, ShouldBeNil)
 			So(ten.Stats().State, ShouldEqual, ItemStateDependent)
 
@@ -1322,12 +1394,12 @@ func TestQueue(t *testing.T) {
 			Data: "2",
 			TTR:  30 * time.Second,
 		})
-		itemdefs = append(itemdefs, &ItemDef{"key_3", "", "3", 0, 0 * time.Second, 30 * time.Second, []string{}})
-		itemdefs = append(itemdefs, &ItemDef{"key_4", "", "4", 0, 0 * time.Second, 30 * time.Second, []string{"key_1"}})
-		itemdefs = append(itemdefs, &ItemDef{"key_5", "", "5", 0, 0 * time.Second, 30 * time.Second, []string{"key_2", "key_3"}})
-		itemdefs = append(itemdefs, &ItemDef{"key_6", "", "6", 0, 0 * time.Second, 30 * time.Second, []string{"key_3", "key_4"}})
-		itemdefs = append(itemdefs, &ItemDef{"key_7", "", "7", 0, 0 * time.Second, 30 * time.Second, []string{"key_5", "key_6"}})
-		itemdefs = append(itemdefs, &ItemDef{"key_8", "", "8", 0, 0 * time.Second, 30 * time.Second, []string{"key_5"}})
+		itemdefs = append(itemdefs, &ItemDef{"key_3", "", "3", 0, 0 * time.Second, 30 * time.Second, "", []string{}})
+		itemdefs = append(itemdefs, &ItemDef{"key_4", "", "4", 0, 0 * time.Second, 30 * time.Second, "", []string{"key_1"}})
+		itemdefs = append(itemdefs, &ItemDef{"key_5", "", "5", 0, 0 * time.Second, 30 * time.Second, "", []string{"key_2", "key_3"}})
+		itemdefs = append(itemdefs, &ItemDef{"key_6", "", "6", 0, 0 * time.Second, 30 * time.Second, "", []string{"key_3", "key_4"}})
+		itemdefs = append(itemdefs, &ItemDef{"key_7", "", "7", 0, 0 * time.Second, 30 * time.Second, "", []string{"key_5", "key_6"}})
+		itemdefs = append(itemdefs, &ItemDef{"key_8", "", "8", 0, 0 * time.Second, 30 * time.Second, "", []string{"key_5"}})
 
 		added, dups, err := queue.AddMany(itemdefs)
 		So(err, ShouldBeNil)
@@ -1358,7 +1430,7 @@ func TestQueue(t *testing.T) {
 
 		for i := 0; i < 10; i++ {
 			key := fmt.Sprintf("key_%d", i)
-			_, err := queue.Add(key, "", "data", 0, 0*time.Millisecond, 10*time.Millisecond)
+			_, err := queue.Add(key, "", "data", 0, 0*time.Millisecond, 10*time.Millisecond, "")
 			So(err, ShouldBeNil)
 			if i == 0 {
 				time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
Job buried state is recorded to disk, so that if the manager dies and is
restarted, jobs that were buried remain buried instead of restarting.
(Jobs that were running are not yet handled properly; you still have to kill
all existing runners before restarting the manager, and those jobs start from
scratch.)

queue.Add() and AddMany() can now be told to start an item in the Run or Bury
sub-queues, for queue recovery purposes.

Memory/time/disk learning now only occurs on successful jobs, or those that
failed because they ran out of one of those resources.

Increases to job memory/time/disk due to using too much of one of those now
occur in the ready added callback along with recommendation changes, and the
time increase is fixed to be an hour longer than it took, not an hour longer
than requested. Removed job.updateRecsAfterFailure().

If a job uses more than expected memory and then fails, it is now regarded as
having failed due to memory. (Jobs are still only forcefully killed if they use
up all the machine's memory.)

TestJobqueue() tests split up in to more test functions, to isolate and help
reproduce failures.