### PR TITLE
Fix #155: Pick correct OpenStack network according to supplied CIDR.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -99,6 +99,7 @@ var (
 	ErrNoFlavor        = "no server flavor can meet your resource requirements"
 	ErrBadFlavor       = "no server flavor with that id/name exists"
 	ErrBadRegex        = "your flavor regular expression was not valid"
+	ErrBadCIDR         = "no subnet matches your supplied CIDR"
 )
 
 // sshTimeOut is how long we wait for ssh to work when an ssh request is made to

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -792,7 +792,7 @@ func bootstrapOnRemote(provider *cloud.Provider, server *cloud.Server, exe strin
 		if cloudDebug {
 			debugStr = " --debug"
 		}
-		mCmd := fmt.Sprintf("source %s && %s manager start --deployment %s -s %s -k %d -o '%s' -r %d -m %d -u %s%s%s%s%s --cloud_gateway_ip '%s' --cloud_cidr '%s' --cloud_dns '%s' --local_username '%s' --max_cores %d --max_ram %d --timeout %d%s && rm %s", wrEnvFileName, remoteExe, config.Deployment, providerName, serverKeepAlive, osPrefix, osRAM, m, osUsername, postCreationArg, flavorArg, osDiskArg, configFilesArg, cloudGatewayIP, cloudCIDR, cloudDNS, cloudResourceNameUniquer, maxManagerCores, maxManagerRAM, cloudManagerTimeoutSeconds, debugStr, wrEnvFileName)
+		mCmd := fmt.Sprintf("source %s && %s manager start --deployment %s -s %s -k %d -o '%s' -r %d -m %d -u %s%s%s%s%s  --cloud_cidr '%s' --local_username '%s' --max_cores %d --max_ram %d --timeout %d%s && rm %s", wrEnvFileName, remoteExe, config.Deployment, providerName, serverKeepAlive, osPrefix, osRAM, m, osUsername, postCreationArg, flavorArg, osDiskArg, configFilesArg, cloudCIDR, cloudResourceNameUniquer, maxManagerCores, maxManagerRAM, cloudManagerTimeoutSeconds, debugStr, wrEnvFileName)
 
 		var e string
 		_, e, err = server.RunCmd(mCmd, false)

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -444,9 +444,7 @@ func init() {
 	managerStartCmd.Flags().StringVarP(&configMapName, "config_map", "", "", " for the kubernetes scheduler, provide an existing config map to initialise with all pods with. To be used instead of --cloud_script")
 	managerStartCmd.Flags().IntVarP(&serverKeepAlive, "cloud_keepalive", "k", defaultConfig.CloudKeepAlive, "for cloud schedulers, how long in seconds to keep idle spawned servers alive for; 0 means forever")
 	managerStartCmd.Flags().IntVarP(&maxServers, "cloud_servers", "m", defaultConfig.CloudServers, "for cloud schedulers, maximum number of additional servers to spawn; -1 means unlimited")
-	managerStartCmd.Flags().StringVar(&cloudGatewayIP, "cloud_gateway_ip", defaultConfig.CloudGateway, "for cloud schedulers, gateway IP for the created subnet")
-	managerStartCmd.Flags().StringVar(&cloudCIDR, "cloud_cidr", defaultConfig.CloudCIDR, "for cloud schedulers, CIDR of the created subnet")
-	managerStartCmd.Flags().StringVar(&cloudDNS, "cloud_dns", defaultConfig.CloudDNS, "for cloud schedulers, comma separated DNS name server IPs to use in the created subnet")
+	managerStartCmd.Flags().StringVar(&cloudCIDR, "cloud_cidr", defaultConfig.CloudCIDR, "for cloud schedulers, CIDR of the subnet to spawn servers in")
 	managerStartCmd.Flags().StringVar(&cloudConfigFiles, "cloud_config_files", defaultConfig.CloudConfigFiles, "for cloud schedulers, comma separated paths of config files to copy to spawned servers")
 	managerStartCmd.Flags().BoolVar(&setDomainIP, "set_domain_ip", defaultConfig.ManagerSetDomainIP, "on success, use infoblox to set your domain's IP")
 	managerStartCmd.Flags().BoolVar(&managerDebug, "debug", false, "include extra debugging information in the logs")
@@ -542,9 +540,7 @@ func startJQ(postCreation []byte) {
 			MaxLocalCores:        &maxLocalCores,
 			MaxLocalRAM:          &maxLocalRAM,
 			Shell:                config.RunnerExecShell,
-			GatewayIP:            cloudGatewayIP,
 			CIDR:                 cloudCIDR,
-			DNSNameServers:       strings.Split(cloudDNS, ","),
 		}
 		serverCIDR = cloudCIDR
 	case kubernetes:


### PR DESCRIPTION
Now always create own security group, and use that plus default,
instead of picking a random security group to work with.

--cloud_cidr now a required option when starting the manager in
OpenStack mode.

--cloud_gateway_ip and --cloud_dns options removed from manager start,
since they did nothing.