### PR TITLE
 Resolve #127: removing jobs via the command line updates scheduler.

### DIFF
--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -618,6 +618,29 @@ func (db *db) deleteLiveJob(key string) {
 	//*** we're not removing the lookup entries from the bucket*TK buckets...
 }
 
+// deleteLiveJobs remove multiple jobs from the live bucket.
+func (db *db) deleteLiveJobs(keys []string) error {
+	err := db.bolt.Batch(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucketJobsLive)
+		for _, key := range keys {
+			errd := b.Delete([]byte(key))
+			if errd != nil {
+				return errd
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	db.backgroundBackup()
+	//*** we're not removing the lookup entries from the bucket*TK buckets...
+
+	return nil
+}
+
 // recoverIncompleteJobs returns all jobs in the live bucket, for use when
 // restarting the server, allowing you start working on any jobs that were
 // stored with storeNewJobs() but not yet archived with archiveJob().

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -193,7 +193,6 @@ func (s *local) reserveTimeout(req *Requirements) int {
 			s.Error("Failed to convert rtimeout to integer", "error", err)
 			return localReserveTimeout
 		}
-		s.Debug("setting runner rtimeout", "timeout", timeout)
 		return timeout
 	}
 	return localReserveTimeout


### PR DESCRIPTION
Removing jobs via the command line also now much faster, using
new deleteLiveJobs() method and improvement to decrementGroupCount()
so it can decrement many at once.