### PR TITLE
OpenStack scheduler can now use all hardware by repicking flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ the config options available. The main things you need to know are:
   If you'll be using OpenStack, it is strongly recommended to configure
   database backups to go to S3.
 * The wr executable must be available at that same absolute path on all
-  compute nodes in your cluster, so you either need to place it on a shared
-  disk, or install it in the same place on all machines (eg. have it as part of
-  your OS image). If you use config files, these must also be readable by all
-  nodes (when you don't have a shared disk, it's best to configure using
+  compute nodes in your cluster, so you need to place it on a shared disk or
+  install it in the same place on all machines. In cloud environments, the wr
+  executable is copied for you to new cloud servers, so it doesn't need to be
+  part of your OS images. If you use config files, these must also be readable
+  by all nodes (when you don't have a shared disk, it's best to configure using
   environment variables).
 * If you are ssh tunnelling to the node where you are running wr and wish
   to use the web interface, you will have to forward the host and port that it

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -528,7 +528,7 @@ FLAVORS:
 }
 
 // CheapestServerFlavors is like CheapestServerFlavor(), taking the same first
-// 3 arguements, but also a slice of slices that describe sets of flavors.
+// 3 arguments, but also a slice of slices that describe sets of flavors.
 // For example, [][]string{{"f1","f2"},{"f3","f4"}}. Here, flavors f1 and f2 are
 // in one set, and f3 and f4 are in another. The names are treated as regular
 // expressions so you can describe multiple flavors in a set with a single
@@ -585,9 +585,7 @@ func (p *Provider) CheapestServerFlavors(cores, ramMB int, regex string, sets []
 
 			for _, fr := range set {
 				if fr.MatchString(f.Name) {
-					for _, fr := range set {
-						exclusions = append(exclusions, fr)
-					}
+					exclusions = append(exclusions, set...)
 					excludedSets[i] = true
 					found = true
 					break SETS

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -576,6 +576,10 @@ func (p *Provider) Spawn(os string, osUser string, flavorID string, diskGB int, 
 	}()
 	serverID, serverIP, serverName, adminPass, err := p.impl.spawn(p.resources, os, flavorID, diskGB, externalIP, usingQuota)
 
+	if err != nil && serverID == "" {
+		return nil, err
+	}
+
 	maxDisk := f.Disk
 	if diskGB > maxDisk {
 		maxDisk = diskGB

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -784,6 +784,7 @@ func (p *openstackp) spawn(resources *Resources, osPrefix string, flavorID strin
 	usingQuotaCh <- true
 
 	if err != nil {
+		p.spawnFailed = true
 		return serverID, serverIP, serverName, adminPass, err
 	}
 
@@ -906,6 +907,12 @@ func (p *openstackp) spawn(resources *Resources, osPrefix string, flavorID strin
 	}
 
 	return serverID, serverIP, serverName, adminPass, err
+}
+
+// errIsNoHardware returns true if error contains "There are not enough hosts
+// available".
+func (p *openstackp) errIsNoHardware(err error) bool {
+	return strings.Contains(err.Error(), "There are not enough hosts available")
 }
 
 // getServerIP tries to find the auto-assigned internal ip address of the server

--- a/cloud/server.go
+++ b/cloud/server.go
@@ -813,7 +813,7 @@ func (s *Server) MountSharedDisk(nfsServerIP string) error {
 		return nil
 	}
 
-	_, _, err := s.RunCmd("sudo apt-get install nfs-common -y", false)
+	_, _, err := s.RunCmd("sudo apt-get update && sudo apt-get install nfs-common -y", false)
 	if err != nil {
 		return err
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -160,11 +160,12 @@ OpenStack, where hardware is limited. If some flavors can only be created on a
 subset of your hardware, and other flavors can only be created on a different
 subset of your hardware, then you should describe those flavors as being in
 different sets, using the form f1,f2;f3,f4 where f1 and f2 are in the same set
-and f3 and f4 are in a different set. Doing this will result in the following
-behaviour: if a flavor is picked to run a job (according to your --flavor
-regex), but a server of that flavor can't be created due to lack of hardware,
-then the next best flavor - excluding flavors in the initial pick's flavor set -
-will be picked and tried instead.
+and f3 and f4 are in a different set (these names are treated as regular
+expressions). Doing this will result in the following behaviour: if a flavor is
+picked to run a job (according to your --flavor regex), but a server of that
+flavor can't be created due to lack of hardware, then the next best flavor -
+excluding flavors in the initial pick's flavor set - will be picked and tried
+instead.
 
 Deploy can work with any given OS image because it uploads wr to any server it
 creates; your OS image does not have to have wr installed on it. The only

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -105,13 +105,13 @@ tenant (project) also running wr.
 Instead you can use 'wr cloud deploy -p openstack' to create an OpenStack server
 on which wr manager will be started in OpenStack mode for you. See 'wr cloud
 deploy -h' for the details of which environment variables you need to use the
-OpenStack scheduler.
+OpenStack scheduler. That help also explains some of the --cloud* options in
+further detail.
 
 Similarly, If using the Kubernetes scheduler you must already be running in a
 pod. Be sure to pass a namespace for wr to use that will not have another wr
 user attempting to use it.
-Instead it is recommended to use 'wr kubernetes deploy' to bootstrap wr to a
-cluster.
+Instead it is recommended to use 'wr k8s deploy' to bootstrap wr to a cluster.
 
 The --use_cert_domain option is intended for use when you have configured your
 own security certificates and want the manager to be reachable at a given
@@ -538,6 +538,7 @@ func init() {
 	managerStartCmd.Flags().IntVarP(&osRAM, "cloud_ram", "r", defaultConfig.CloudRAM, "for cloud schedulers, ram (MB) needed by the OS image specified by --cloud_os")
 	managerStartCmd.Flags().IntVarP(&osDisk, "cloud_disk", "d", defaultConfig.CloudDisk, "for cloud schedulers, minimum disk (GB) for servers")
 	managerStartCmd.Flags().StringVarP(&flavorRegex, "cloud_flavor", "l", defaultConfig.CloudFlavor, "for cloud schedulers, a regular expression to limit server flavors that can be automatically picked")
+	managerStartCmd.Flags().StringVar(&flavorSets, "cloud_flavor_sets", defaultConfig.CloudFlavorSets, "for cloud schedulers, sets of flavors assigned to different hardware, in the form f1,f2;f3,f4")
 	managerStartCmd.Flags().StringVarP(&postCreationScript, "cloud_script", "p", defaultConfig.CloudScript, "for cloud schedulers, path to a start-up script that will be run on each server created")
 	managerStartCmd.Flags().StringVarP(&kubeNamespace, "namespace", "", "", "for the kubernetes scheduler, the namespace to use")
 	managerStartCmd.Flags().StringVarP(&configMapName, "config_map", "", "", "for the kubernetes scheduler, provide an existing config map to initialise all pods with. To be used instead of --cloud_script")
@@ -641,6 +642,7 @@ func startJQ(postCreation []byte) {
 			OSRAM:                osRAM,
 			OSDisk:               osDisk,
 			FlavorRegex:          flavorRegex,
+			FlavorSets:           flavorSets,
 			PostCreationScript:   postCreation,
 			ConfigFiles:          cloudConfigFiles,
 			ServerKeepTime:       time.Duration(serverKeepAlive) * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/onsi/gomega v1.4.2 // indirect
 	github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2 // indirect
 	github.com/opencontainers/image-spec v0.0.0-20180411145040-e562b0440392 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.0.0-20180311214515-816c9085562c // indirect
 	github.com/pkg/sftp v0.0.0-20180824225003-b9345f483dc3
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2 h1:QhPf3A
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v0.0.0-20180411145040-e562b0440392 h1:rBwY4zl6Rvzh0RyFbELnswKxVfiq7xB/d2sfgy3PmHI=
 github.com/opencontainers/image-spec v0.0.0-20180411145040-e562b0440392/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.0.0-20180311214515-816c9085562c h1:F5RoIh7F9wB47PvXvpP1+Ihq1TkyC8iRdvwfKkESEZQ=
 github.com/pkg/errors v0.0.0-20180311214515-816c9085562c/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v0.0.0-20180824225003-b9345f483dc3 h1:WoQsKxLkGC71OjqWitPdENKSndT8B/AoO6Tr+BJPLeY=

--- a/internal/config.go
+++ b/internal/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	RunnerExecShell     string `default:"bash"`
 	Deployment          string `default:"production"`
 	CloudFlavor         string `default:""`
+	CloudFlavorSets     string `default:""`
 	CloudKeepAlive      int    `default:"120"`
 	CloudServers        int    `default:"-1"`
 	CloudCIDR           string `default:"192.168.0.0/18"`

--- a/jobqueue/scheduler/kubernetes.go
+++ b/jobqueue/scheduler/kubernetes.go
@@ -390,7 +390,7 @@ func (s *k8s) cleanup() {
 // 100. ToDO: If any job is pending with the given requirements, return 0 until
 // that pend fails. This should reduce overall load on the cluster when adding
 // lots of jobs at once.
-func (s *k8s) canCount(req *Requirements) int {
+func (s *k8s) canCount(req *Requirements, call string) int {
 	s.Debug("canCount Called, returning 100")
 	// 100 is  a big enough block for anyone...
 	return 100
@@ -398,7 +398,7 @@ func (s *k8s) canCount(req *Requirements) int {
 
 // RunFunc calls spawn() and exits with an error = nil when pod has terminated
 // (Runner exited). Or an error if there was a problem.
-func (s *k8s) runCmd(cmd string, req *Requirements, reservedCh chan bool) error {
+func (s *k8s) runCmd(cmd string, req *Requirements, reservedCh chan bool, call string) error {
 	s.Debug("RunCmd Called", "cmd", cmd, "requirements", req)
 	// The first 'argument' to cmd will be the absolute path to the manager's
 	// executable. Work out the local binary's name from localBinaryPath.

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -36,6 +36,7 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/inconshreveable/log15"
+	logext "github.com/inconshreveable/log15/ext"
 	"github.com/shirou/gopsutil/process"
 )
 
@@ -65,8 +66,11 @@ type maxResourceGetter func() int
 // canCounters are functions used by processQueue() to see how many of a job
 // can be run. (We make use of this in the local struct so that other
 // implementers of scheduleri can embed local, use local's processQueue(), but
-// have their own canCounter implementation.)
-type canCounter func(req *Requirements) (canCount int)
+// have their own canCounter implementation.) The call argument will be a random
+// string. That same string will also be supplied to the cmdRunner function, so
+// you can tie together cmdRunner invocations that are all a result of a
+// particular canCounter call.
+type canCounter func(req *Requirements, call string) (canCount int)
 
 // stateUpdaters are functions used by processQueue() to update any global state
 // that might have become invalid due to changes external to our own actions.
@@ -79,7 +83,7 @@ type stateUpdater func()
 // (Their reason for being is the same as for canCounters.) The reservedCh
 // should be sent true as soon as resources have been reserved to run the cmd,
 // or sent false if something went wrong before that.
-type cmdRunner func(cmd string, req *Requirements, reservedCh chan bool) error
+type cmdRunner func(cmd string, req *Requirements, reservedCh chan bool, call string) error
 
 // cancelCmdRunner are functions used by processQueue() to cancel the running
 // of cmdRunners that started but didn't really start to run the cmd. You give
@@ -463,7 +467,8 @@ func (s *local) processQueue() error {
 		}
 
 		// now see if there's remaining capacity to run the job
-		canCount := s.canCountFunc(req)
+		call := logext.RandId(8)
+		canCount := s.canCountFunc(req, call)
 		s.Debug("processQueue canCount", "can", canCount, "running", running, "should", shouldCount)
 		if canCount > shouldCount {
 			canCount = shouldCount
@@ -484,7 +489,7 @@ func (s *local) processQueue() error {
 			go func() {
 				defer internal.LogPanic(s.Logger, "runCmd", true)
 
-				err := s.runCmdFunc(cmd, req, reserved)
+				err := s.runCmdFunc(cmd, req, reserved, call)
 
 				s.mutex.Lock()
 				s.resourceMutex.Lock()
@@ -549,7 +554,7 @@ func (s *local) processQueue() error {
 
 // canCount tells you how many jobs with the given RAM and core requirements it
 // is possible to run, given remaining resources.
-func (s *local) canCount(req *Requirements) int {
+func (s *local) canCount(req *Requirements, call string) int {
 	s.resourceMutex.RLock()
 	defer s.resourceMutex.RUnlock()
 
@@ -585,7 +590,7 @@ func (s *local) canCount(req *Requirements) int {
 // NB: we only return an error if we can't start the cmd, not if the command
 // fails (schedule() only guarantees that the cmds are run count times, not that
 // they run /successful/ that many times).
-func (s *local) runCmd(cmd string, req *Requirements, reservedCh chan bool) error {
+func (s *local) runCmd(cmd string, req *Requirements, reservedCh chan bool, call string) error {
 	ec := exec.Command(s.config.Shell, "-c", cmd) // #nosec
 	err := ec.Start()
 	if err != nil {

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
+	"github.com/patrickmn/go-cache"
 )
 
 const (
@@ -55,6 +56,7 @@ type opst struct {
 	local
 	config            *ConfigOpenStack
 	provider          *cloud.Provider
+	flavorSets        [][]string
 	quotaMaxInstances int
 	quotaMaxCores     int
 	quotaMaxRAM       int
@@ -80,6 +82,9 @@ type opst struct {
 	recoveredServers  map[string]bool
 	rsMutex           sync.Mutex
 	stopRSMonitoring  chan struct{}
+	failedFlavors     map[string]time.Time
+	ffMutex           sync.RWMutex
+	dfCache           *cache.Cache
 	log15.Logger
 }
 
@@ -125,11 +130,9 @@ type ConfigOpenStack struct {
 	// that flavor because there is no more available hardware to back it, then
 	// the next best flavor in a different flavor set will be attempted. The
 	// value here is a string in the form f1,f2;f3,f4 where f1 and f2 are in the
-	// same set, and f3 and f4 are in a different set. If you have many flavors
-	// in a set, you can describe them all with a regular expression, as long
-	// as it is possible to have such a regular expression that also does not
-	// match any flavors in your other sets (and that does not use commas or
-	// semicolons).
+	// same set, and f3 and f4 are in a different set. The names of each flavor
+	// are treates as regular expressions, so you may be able to describe all
+	// the flavors in a set with a single entry.
 	FlavorSets string
 
 	// PostCreationScript is the []byte content of a script you want executed
@@ -545,6 +548,17 @@ func (s *opst) initialize(config interface{}, logger log15.Logger) error {
 	s.recoveredServers = make(map[string]bool)
 	s.stopRSMonitoring = make(chan struct{})
 
+	if s.config.FlavorSets != "" {
+		sets := strings.Split(s.config.FlavorSets, ";")
+		for _, set := range sets {
+			flavors := strings.Split(set, ",")
+			s.flavorSets = append(s.flavorSets, flavors)
+		}
+	}
+
+	s.failedFlavors = make(map[string]time.Time)
+	s.dfCache = cache.New(5*time.Minute, 10*time.Minute)
+
 	return err
 }
 
@@ -576,7 +590,7 @@ func (s *opst) reqCheck(req *Requirements) error {
 		}
 	} else {
 		// check if possible vs flavors
-		_, err := s.determineFlavor(req)
+		_, err := s.determineFlavor(req, "")
 		return err
 	}
 	return nil
@@ -594,13 +608,69 @@ func (s *opst) maxCPU() int {
 
 // determineFlavor picks a server flavor, preferring the smallest (cheapest)
 // amongst those that are capable of running it.
-func (s *opst) determineFlavor(req *Requirements) (*cloud.Flavor, error) {
-	flavor, err := s.provider.CheapestServerFlavor(int(math.Ceil(req.Cores)), req.RAM, s.config.FlavorRegex)
-	if err != nil {
+//
+// If the initial pick is for a flavor that has been marked as unusable (because
+// the last time we tried to spawn a server of the flavor it failed due to lack
+// of hardware), we return the next best pick from a different flavor set. If
+// all possible picks from all flavor sets have been marked unusable, we return
+// the flavor that was marked unusable longest ago, to give it another try.
+//
+// Since this is called during our canCount and then during runCmd for each
+// "can", we want the return value to be the same for that set of calls, so we
+// cache based on the "call" argument that processQueue sent in to canCount and
+// runCmd, which in turn pass through to here.
+func (s *opst) determineFlavor(req *Requirements, call string) (*cloud.Flavor, error) {
+	if call != "" {
+		if flavor, cached := s.dfCache.Get(call); cached {
+			return flavor.(*cloud.Flavor), nil
+		}
+	}
+
+	flavors, err := s.provider.CheapestServerFlavors(int(math.Ceil(req.Cores)), req.RAM, s.config.FlavorRegex, s.flavorSets)
+	if len(flavors) == 0 {
+		err = Error{"openstack", "determineFlavor", ErrImpossible}
+	} else if err != nil {
 		if perr, ok := err.(cloud.Error); ok && perr.Err == cloud.ErrNoFlavor {
 			err = Error{"openstack", "determineFlavor", ErrImpossible}
 		}
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	s.ffMutex.RLock()
+	defer s.ffMutex.RUnlock()
+
+	var flavor *cloud.Flavor
+	oldest := time.Now()
+	pickedOld := true
+	var pickedI int
+	for i, f := range flavors {
+		if t, failed := s.failedFlavors[f.ID]; failed {
+			if t.Before(oldest) {
+				oldest = t
+				flavor = f
+				pickedI = i
+			}
+			continue
+		}
+
+		flavor = f
+		pickedOld = false
+		pickedI = i
+		break
+	}
+
+	if pickedOld {
+		s.Debug("determineFlavor's picks were all failed, picking the oldest to fail", "rank", pickedI, "flavor", flavor.Name)
+	} else if pickedI != 0 {
+		s.Debug("determineFlavor's preferred pick was failed, picking one that is unfailed", "rank", pickedI, "flavor", flavor.Name)
+	}
+
+	if call != "" {
+		s.dfCache.Set(call, flavor, cache.DefaultExpiration)
+	}
+
 	return flavor, err
 }
 
@@ -664,7 +734,7 @@ func (s *opst) serverReqs(req *Requirements) (osPrefix string, osScript []byte, 
 
 // canCount tells you how many jobs with the given RAM and core requirements it
 // is possible to run, given remaining resources.
-func (s *opst) canCount(req *Requirements) int {
+func (s *opst) canCount(req *Requirements, call string) int {
 	s.resourceMutex.RLock()
 	defer s.resourceMutex.RUnlock()
 
@@ -708,7 +778,7 @@ func (s *opst) canCount(req *Requirements) int {
 	// before exceeding our quota
 	flavor := requestedFlavor
 	if flavor == nil {
-		flavor, err = s.determineFlavor(reqForSpawn)
+		flavor, err = s.determineFlavor(reqForSpawn, call)
 		if err != nil {
 			s.Warn("Failed to determine a server flavor", "err", err)
 			return canCount
@@ -870,7 +940,7 @@ func (s *opst) reqForSpawn(req *Requirements) *Requirements {
 // not if the command fails (schedule() only guarantees that the cmds are run
 // count times, not that they are /successful/ that many times). New servers are
 // created sequentially to avoid overloading OpenStack's sub-systems.
-func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error {
+func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call string) error {
 	// since we can have many simultaneous calls to this method running at once,
 	// we make a new logger with a unique "call" context key to keep track of
 	// which runCmd call is doing what
@@ -962,7 +1032,7 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 		flavor := requestedFlavor
 		if flavor == nil {
 			var errd error
-			flavor, errd = s.determineFlavor(s.reqForSpawn(req))
+			flavor, errd = s.determineFlavor(s.reqForSpawn(req), call)
 			if errd != nil {
 				s.runMutex.Unlock()
 				s.notifyMessage(fmt.Sprintf("OpenStack: Was unable to determine a server flavor to use for requirements %s: %s", req.Stringify(), errd))
@@ -984,6 +1054,22 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 		reservedCh <- true
 		s.resourceMutex.Unlock()
 
+		// later on, immediately after the spawn request goes through (and so
+		// presumably is using up quota), but before the new server powers up,
+		// drop our reserved values down or we'll end up double-counting
+		// resource usage in canCount(), since that takes in to account
+		// resources used by an in-progress spawn.
+		usingQuotaCB := func() {
+			s.resourceMutex.Lock()
+			s.reservedInstances--
+			s.reservedCores -= flavor.Cores
+			s.reservedRAM -= flavor.RAM
+			if volumeAffected {
+				s.reservedVolume -= req.Disk
+			}
+			s.resourceMutex.Unlock()
+		}
+
 		u, _ := uuid.NewV4()
 		standinID := u.String()
 		standinServer := newStandin(standinID, flavor, req.Disk, requestedOS, requestedScript, requestedConfigFiles, needsSharedDisk, s.Logger)
@@ -995,7 +1081,14 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 		// now spawn, but don't overload the system by trying to spawn too many
 		// at once; wait until we are no longer in the middle of spawning
 		// another
+		doSpawn := true
 		if s.spawningNow || s.waitingToSpawn > 0 {
+			// before waiting to spawn, find out if we've come in here on a
+			// retry of a known failed flavor
+			s.ffMutex.RLock()
+			_, flavorAlreadyFailed := s.failedFlavors[flavor.ID]
+			s.ffMutex.RUnlock()
+
 			s.waitingToSpawn++
 			s.runMutex.Unlock()
 			done := make(chan error)
@@ -1020,6 +1113,18 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 				s.resourceMutex.Unlock()
 				return err
 			}
+
+			// now that we've waited and it's our turn to spawn, check if our
+			// flavor is failed. It it wasn't failed before we started to wait,
+			// we won't waste time trying to spawn later
+			if !flavorAlreadyFailed {
+				s.ffMutex.RLock()
+				if _, currentlyFailed := s.failedFlavors[flavor.ID]; currentlyFailed {
+					doSpawn = false
+				}
+				s.ffMutex.RUnlock()
+			}
+
 			s.runMutex.Lock()
 			logger.Debug("using the standin after waiting")
 		} else {
@@ -1035,7 +1140,6 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 			osUser = s.config.OSUser
 		}
 
-		logger.Debug("will spawn")
 		if debugEffect == "slowSecondSpawn" && thisDebugCount == 3 {
 			s.runMutex.Unlock()
 			<-time.After(10 * time.Second)
@@ -1046,30 +1150,23 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 		// that to complete
 		s.runMutex.Unlock()
 
-		// immediately after the spawn request goes through (and so presumably is
-		// using up quota), but before the new server powers up, drop our
-		// reserved values down or we'll end up double-counting resource usage
-		// in canCount(), since that takes in to account resources used by an
-		// in-progress spawn.
-		usingQuotaCB := func() {
-			s.resourceMutex.Lock()
-			s.reservedInstances--
-			s.reservedCores -= flavor.Cores
-			s.reservedRAM -= flavor.RAM
-			if volumeAffected {
-				s.reservedVolume -= req.Disk
-			}
-			s.resourceMutex.Unlock()
-		}
-
 		// spawn
-		server, err = s.provider.Spawn(requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime, false, usingQuotaCB)
-		serverID := "failed"
-		if server != nil {
-			serverID = server.ID
+		failMsg := "server failed spawn"
+		if doSpawn {
+			logger.Debug("will spawn", "flavor", flavor.Name)
+			server, err = s.provider.Spawn(requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime, false, usingQuotaCB)
+			if server != nil {
+				logger = logger.New("server", server.ID)
+				logger.Debug("spawned")
+			} else {
+				logger.Debug("spawn failed")
+			}
+		} else {
+			logger.Debug("will not spawn, since while we waited we ran out of hardware for flavor", "flavor", flavor.Name)
+			usingQuotaCB()
+			failMsg = "skipped spawn"
+			err = errors.New("skipped spawn attempt since ran out of hardware suitable for desired flavor")
 		}
-		logger = logger.New("server", serverID)
-		logger.Debug("spawned")
 
 		// spawn completed; if we have standins that are waiting to spawn, tell
 		// one of them to go ahead
@@ -1092,9 +1189,9 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 
 		// unlock again prior to waiting until the server is ready and trying to
 		// check and upload our exe, since that could take quite a long time
-		s.runMutex.Unlock()
-		failMsg := "server failed spawn"
 		if err == nil && server != nil {
+			s.runMutex.Unlock()
+
 			// wait until boot is finished, ssh is ready and osScript has
 			// completed
 			logger.Debug("waiting for server ready")
@@ -1145,9 +1242,9 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 					err = fmt.Errorf("Could not look for exe [%s]: %s", exePath, err)
 				}
 			}
-		}
 
-		s.runMutex.Lock()
+			s.runMutex.Lock()
+		}
 
 		if debugEffect == "failFirstSpawn" && thisDebugCount == 1 {
 			err = errors.New("forced fail")
@@ -1162,14 +1259,27 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 				if errd != nil {
 					logger.Debug("server also failed to destroy", "err", errd)
 				}
+			} else if s.provider.ErrIsNoHardware(err) {
+				s.ffMutex.Lock()
+				s.failedFlavors[flavor.ID] = time.Now()
+				s.ffMutex.Unlock()
+				s.Warn("server failed to spawn due to lack of hardware", "flavor", flavor.Name)
 			}
 			standinServer.failed(fmt.Sprintf("New server failed to spawn correctly: %s", err))
 			s.runMutex.Unlock()
-			s.notifyMessage(fmt.Sprintf("OpenStack: Failed to create a usable server: %s", err))
+			if doSpawn {
+				s.notifyMessage(fmt.Sprintf("OpenStack: Failed to create a usable server: %s", err))
+			}
 			return err
 		}
 
 		logger.Debug("server ready")
+		s.ffMutex.Lock()
+		if _, failed := s.failedFlavors[flavor.ID]; failed {
+			s.Debug("server successfully spawned on previously failed flavor", "flavor", flavor.Name)
+			delete(s.failedFlavors, flavor.ID)
+		}
+		s.ffMutex.Unlock()
 
 		s.serversMutex.Lock()
 		s.servers[server.ID] = server
@@ -1209,7 +1319,7 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool) error
 		go func() {
 			<-reserved
 		}()
-		err = s.local.runCmd(cmd, req, reserved)
+		err = s.local.runCmd(cmd, req, reserved, call)
 	} else {
 		logger.Debug("running command remotely", "cmd", cmd)
 		_, _, err = server.RunCmd(cmd, false)

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -125,7 +125,11 @@ type ConfigOpenStack struct {
 	// that flavor because there is no more available hardware to back it, then
 	// the next best flavor in a different flavor set will be attempted. The
 	// value here is a string in the form f1,f2;f3,f4 where f1 and f2 are in the
-	// same set, and f3 and f4 are in a different set.
+	// same set, and f3 and f4 are in a different set. If you have many flavors
+	// in a set, you can describe them all with a regular expression, as long
+	// as it is possible to have such a regular expression that also does not
+	// match any flavors in your other sets (and that does not use commas or
+	// semicolons).
 	FlavorSets string
 
 	// PostCreationScript is the []byte content of a script you want executed

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -119,14 +119,13 @@ type ConfigOpenStack struct {
 	// also satisfies this regex.)
 	FlavorRegex string
 
-	// FlavorSets is a list of flavors that are "independent". That is, the
-	// flavors in different sets run on different physical hardware, meaning
-	// that if a flavor in set 1 is chosen, but OpenStack reports it isn't
-	// possible to create a server with that flavor because there is no more
-	// available hardware to back it, then the next best flavor in a different
-	// flavor set will be attempted. The value here is a string in the form
-	// f1,f2;f3,f4 where f1 and f2 are in the same set, and f3 and f4 are in a
-	// different set.
+	// FlavorSets is used to describe sets of flavors that will only run on
+	// certain subsets of your available hardware. If a flavor in set 1 is
+	// chosen, but OpenStack reports it isn't possible to create a server with
+	// that flavor because there is no more available hardware to back it, then
+	// the next best flavor in a different flavor set will be attempted. The
+	// value here is a string in the form f1,f2;f3,f4 where f1 and f2 are in the
+	// same set, and f3 and f4 are in a different set.
 	FlavorSets string
 
 	// PostCreationScript is the []byte content of a script you want executed

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -119,6 +119,16 @@ type ConfigOpenStack struct {
 	// also satisfies this regex.)
 	FlavorRegex string
 
+	// FlavorSets is a list of flavors that are "independent". That is, the
+	// flavors in different sets run on different physical hardware, meaning
+	// that if a flavor in set 1 is chosen, but OpenStack reports it isn't
+	// possible to create a server with that flavor because there is no more
+	// available hardware to back it, then the next best flavor in a different
+	// flavor set will be attempted. The value here is a string in the form
+	// f1,f2;f3,f4 where f1 and f2 are in the same set, and f3 and f4 are in a
+	// different set.
+	FlavorSets string
+
 	// PostCreationScript is the []byte content of a script you want executed
 	// after a server is Spawn()ed. (Overridden during Schedule() by a
 	// Requirements.Other["cloud_script"] value.)

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -581,7 +581,7 @@ func TestOpenstack(t *testing.T) {
 		// expected server types are
 		if host == "vr-2-2-02" {
 			Convey("determineFlavor() picks the best server flavor depending on given resource requirements", func() {
-				flavor, err := oss.determineFlavor(possibleReq)
+				flavor, err := oss.determineFlavor(possibleReq, "a")
 				So(err, ShouldBeNil)
 
 				if os.Getenv("OS_TENANT_ID") != "" {
@@ -591,62 +591,62 @@ func TestOpenstack(t *testing.T) {
 					So(flavor.Disk, ShouldEqual, 8)
 					So(flavor.Cores, ShouldEqual, 1)
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 1, 20, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 1, 20, true, otherReqs}, "b")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2000") // we now ignore the 20GB disk requirement
 
-					flavor, err = oss.determineFlavor(oss.reqForSpawn(possibleReq))
+					flavor, err = oss.determineFlavor(oss.reqForSpawn(possibleReq), "c")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2001")
 					So(flavor.RAM, ShouldEqual, 4096)
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 2, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 2, 1, true, otherReqs}, "d")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2001")
 					So(flavor.RAM, ShouldEqual, 4096)
 					So(flavor.Disk, ShouldEqual, 12)
 					So(flavor.Cores, ShouldEqual, 2)
 
-					flavor, err = oss.determineFlavor(&Requirements{5000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{5000, 1 * time.Minute, 1, 1, true, otherReqs}, "e")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2002")
 					So(flavor.RAM, ShouldEqual, 16384)
 					So(flavor.Disk, ShouldEqual, 20)
 					So(flavor.Cores, ShouldEqual, 4)
 
-					flavor, err = oss.determineFlavor(&Requirements{64000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{64000, 1 * time.Minute, 1, 1, true, otherReqs}, "f")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2003")
 					So(flavor.RAM, ShouldEqual, 65536)
 					So(flavor.Disk, ShouldEqual, 20)
 					So(flavor.Cores, ShouldEqual, 8)
 
-					flavor, err = oss.determineFlavor(&Requirements{66000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{66000, 1 * time.Minute, 1, 1, true, otherReqs}, "g")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2004")
 					So(flavor.RAM, ShouldEqual, 122880)
 					So(flavor.Disk, ShouldEqual, 128)
 					So(flavor.Cores, ShouldEqual, 16)
 
-					flavor, err = oss.determineFlavor(&Requirements{261000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{261000, 1 * time.Minute, 1, 1, true, otherReqs}, "h")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2005")
 					So(flavor.RAM, ShouldEqual, 262144)
 					So(flavor.Disk, ShouldEqual, 128)
 					So(flavor.Cores, ShouldEqual, 52)
 
-					flavor, err = oss.determineFlavor(&Requirements{263000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{263000, 1 * time.Minute, 1, 1, true, otherReqs}, "i")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2006")
 					So(flavor.RAM, ShouldEqual, 496640)
 					So(flavor.Disk, ShouldEqual, 128)
 					So(flavor.Cores, ShouldEqual, 56)
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 3, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 3, 1, true, otherReqs}, "j")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2002")
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 5, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 5, 1, true, otherReqs}, "k")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2003")
 				} else {
@@ -656,47 +656,47 @@ func TestOpenstack(t *testing.T) {
 					So(flavor.Disk, ShouldEqual, 15)
 					So(flavor.Cores, ShouldEqual, 1)
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 1, 20, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 1, 20, true, otherReqs}, "l")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2000")
 
-					flavor, err = oss.determineFlavor(oss.reqForSpawn(possibleReq))
+					flavor, err = oss.determineFlavor(oss.reqForSpawn(possibleReq), "m")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2000")
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 2, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 2, 1, true, otherReqs}, "n")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2001")
 					So(flavor.RAM, ShouldEqual, 17200)
 					So(flavor.Disk, ShouldEqual, 31)
 					So(flavor.Cores, ShouldEqual, 2)
 
-					flavor, err = oss.determineFlavor(&Requirements{30000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{30000, 1 * time.Minute, 1, 1, true, otherReqs}, "o")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2002")
 					So(flavor.RAM, ShouldEqual, 34400)
 					So(flavor.Disk, ShouldEqual, 62)
 					So(flavor.Cores, ShouldEqual, 4)
 
-					flavor, err = oss.determineFlavor(&Requirements{64000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{64000, 1 * time.Minute, 1, 1, true, otherReqs}, "p")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2003")
 					So(flavor.RAM, ShouldEqual, 68800)
 					So(flavor.Disk, ShouldEqual, 125)
 					So(flavor.Cores, ShouldEqual, 8)
 
-					flavor, err = oss.determineFlavor(&Requirements{120000, 1 * time.Minute, 1, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{120000, 1 * time.Minute, 1, 1, true, otherReqs}, "q")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2004")
 					So(flavor.RAM, ShouldEqual, 137600)
 					So(flavor.Disk, ShouldEqual, 250)
 					So(flavor.Cores, ShouldEqual, 16)
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 3, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 3, 1, true, otherReqs}, "r")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2002")
 
-					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 5, 1, true, otherReqs})
+					flavor, err = oss.determineFlavor(&Requirements{100, 1 * time.Minute, 5, 1, true, otherReqs}, "s")
 					So(err, ShouldBeNil)
 					So(flavor.ID, ShouldEqual, "2003")
 				}
@@ -757,10 +757,10 @@ func TestOpenstack(t *testing.T) {
 				}
 				numServers := len(oss.servers)
 
-				flavor, err := oss.determineFlavor(r)
+				flavor, err := oss.determineFlavor(r, "t")
 				So(err, ShouldBeNil)
 				testReq := &Requirements{flavor.RAM, 1 * time.Minute, float64(flavor.Cores), 0, true, otherReqs}
-				can := oss.canCount(testReq)
+				can := oss.canCount(testReq, "random")
 
 				done := make(chan bool, 1)
 				go func() {
@@ -771,7 +771,7 @@ func TestOpenstack(t *testing.T) {
 						go func() {
 							<-reserved
 						}()
-						err := oss.runCmd("sleep 4", testReq, reserved)
+						err := oss.runCmd("sleep 4", testReq, reserved, "random")
 						if err == nil || i == 3 {
 							done <- true
 							break
@@ -786,7 +786,7 @@ func TestOpenstack(t *testing.T) {
 				So(len(oss.servers)+len(oss.standins), ShouldEqual, numServers+1)
 				oss.serversMutex.RUnlock()
 				oss.runMutex.Unlock()
-				So(oss.canCount(testReq), ShouldEqual, can-1)
+				So(oss.canCount(testReq, "random2"), ShouldEqual, can-1)
 
 				<-done
 
@@ -798,7 +798,7 @@ func TestOpenstack(t *testing.T) {
 				}
 				So(len(oss.servers), ShouldEqual, numServers+1)
 				oss.serversMutex.Unlock()
-				So(oss.canCount(testReq), ShouldEqual, can)
+				So(oss.canCount(testReq, "random3"), ShouldEqual, can)
 
 				<-time.After(20 * time.Second)
 
@@ -810,7 +810,7 @@ func TestOpenstack(t *testing.T) {
 				}
 				So(len(oss.servers), ShouldEqual, numServers)
 				oss.serversMutex.Unlock()
-				So(oss.canCount(testReq), ShouldEqual, can)
+				So(oss.canCount(testReq, "random4"), ShouldEqual, can)
 			})
 
 			Convey("Schedule() lets you...", func() {
@@ -1040,12 +1040,12 @@ func TestOpenstack(t *testing.T) {
 
 				numCores := 5
 				oReqsm := make(map[string]string)
-				multiCoreFlavor, err := oss.determineFlavor(&Requirements{1024, 1 * time.Minute, float64(numCores), 0, true, oReqsm})
+				multiCoreFlavor, err := oss.determineFlavor(&Requirements{1024, 1 * time.Minute, float64(numCores), 0, true, oReqsm}, "u")
 				if err == nil && multiCoreFlavor.Cores >= numCores {
 					oReqs := make(map[string]string)
 					oReqs["cloud_os_ram"] = strconv.Itoa(multiCoreFlavor.RAM)
 					jobReq := &Requirements{int(multiCoreFlavor.RAM / numCores), 1 * time.Minute, 1, 0, true, oReqs}
-					confirmFlavor, err := oss.determineFlavor(oss.reqForSpawn(jobReq))
+					confirmFlavor, err := oss.determineFlavor(oss.reqForSpawn(jobReq), "v")
 					if err == nil && confirmFlavor.Cores >= numCores {
 						Convey("Run multiple jobs at once on multi-core servers", func() {
 							cmd := "sleep 30"
@@ -1092,6 +1092,10 @@ func TestOpenstack(t *testing.T) {
 				} else {
 					SkipConvey("Skipping multi-core server tests due to lack of suitable multi-core server flavors", func() {})
 				}
+
+				// *** when we have mocks, need to test that flavor sets work
+				// as expected by filling up hardware in one set and seeing that
+				// we fail over to the other set etc.
 			})
 
 			// wait a while for any remaining jobs to finish

--- a/wr_config.yml
+++ b/wr_config.yml
@@ -296,6 +296,30 @@ runnerexecshell: "bash"
 # to wr's knowledge of how much RAM and how many cores it needs to run).
 # cloudflavor: ""
 
+# cloudflavorsets: What server flavors are assigned to different hardware?
+# Without being provided, all flavors are assumed to be able to be used on all
+# available hardware. This is overridden by the --flavor_sets option to `wr
+# cloud deploy` and the --cloud_flavor_sets option of `wr manager start`.
+# Note, this takes the form f1,f2;f3,f4 to describe flavors f1 and f2 being in
+# the same set, and flavors f3 and f4 being in a different set. Flavors in the
+# same set should be those that can only be used on a certain subset of your
+# hardware, and flavors in a different set should be those that can only be
+# brought up on a diffferent subset of hardware.
+#
+# This option is only relevant when you are using a cloud scheduler such as
+# OpenStack.
+#
+# wr will pick a certain flavor to run a job on, as per the cloudflavor option.
+# If it isn't possible to create a server with that flavor due to lack of
+# physical hardware, wr will repick a flavor (again as per the cloudflavor
+# option), but this time excluding flavors in the same flavor set as the initial
+# pick. This is repeated until a flavor is found in a set where there is
+# sufficient hardware to create a new server to run the job.
+#
+# If a flavor is picked that isn't in one of your flavor sets (or if you only
+# have one set), it will never be repicked.
+# cloudflavorsets: ""
+
 # cloudkeepalive: How long should idle spawned server stay alive?
 # This defaults to 120. It is overridden by the --keepalive option to
 # `wr cloud deploy` and the --cloud_keepalive option of `wr manager start`.

--- a/wr_config.yml
+++ b/wr_config.yml
@@ -304,7 +304,9 @@ runnerexecshell: "bash"
 # the same set, and flavors f3 and f4 being in a different set. Flavors in the
 # same set should be those that can only be used on a certain subset of your
 # hardware, and flavors in a different set should be those that can only be
-# brought up on a diffferent subset of hardware.
+# brought up on a diffferent subset of hardware. The flavor names are treated
+# as regular expressions, so you can have 1 expression that matches all the
+# flavors in a set.
 #
 # This option is only relevant when you are using a cloud scheduler such as
 # OpenStack.


### PR DESCRIPTION
User defines "flavor sets" in config, eg. `cloudflavorsets: "m1;m2"`, then if m1s can't be spawned due to lack of hardware, the best m2 flavor will be tried instead.