### PR TITLE
ConfirmCloudServersDead() now kills jobs on those servers.

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -623,7 +623,7 @@ to destroy them.
 
 If --confirmdead results in wr successfully destroying servers or confirming
 they no longer exist, any jobs that were running on those servers (which most
-likley would have reached "lost contact" status) will be killed or confirmed
+likely would have reached "lost contact" status) will be killed or confirmed
 dead, so that they will either become buried or retry according to their
 configured number of retries. If jobs hadn't yet reached  "lost contact" status,
 they will have a status of running until the time they would normally become

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -87,7 +87,7 @@ same file you gave to "wr add" in -f mode.`,
 		jes := jobsToJobEssenses(jobs)
 		killed, err := jq.Kill(jes)
 		if err != nil {
-			die("failed to remove desired jobs: %s", err)
+			die("failed to kill desired jobs: %s", err)
 		}
 		info("Initiated the termination of %d running commands (out of %d eligible)", killed, len(jobs))
 	},


### PR DESCRIPTION
Now, when you find that there are maybe bad OpenStack servers, you only have to run `wr cloud servers --confirmdead -a`. This will delete any bad servers that still exist, and bury or retry (according to retry count of the job) jobs that were running on those servers.