### PR TITLE
Update to latest gophercloud, with reauth fix.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367 // indirect
 	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d // indirect
-	github.com/gophercloud/gophercloud v0.0.0-20181009192228-f2f15d653e07
+	github.com/gophercloud/gophercloud v0.0.0-20181202211702-fac2636416a9
 	github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/gotestyourself/gotestyourself v2.1.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/gophercloud/gophercloud v0.0.0-20181006170026-546f1f72e004 h1:SQYCwLS
 github.com/gophercloud/gophercloud v0.0.0-20181006170026-546f1f72e004/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20181009192228-f2f15d653e07 h1:tqvhHvbpc+m52nj1NxOBSvtPgf2iptPt39p/7U7GRZQ=
 github.com/gophercloud/gophercloud v0.0.0-20181009192228-f2f15d653e07/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
+github.com/gophercloud/gophercloud v0.0.0-20181202211702-fac2636416a9 h1:MSnKEq5bbYeK31CTMpUYhZboIoTxSoDXfbun8hKl3+o=
+github.com/gophercloud/gophercloud v0.0.0-20181202211702-fac2636416a9/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c h1:16eHWuMGvCjSfgRJKqIzapE78onvvTbdi1rMkU00lZw=
 github.com/gopherjs/gopherjs v0.0.0-20180825215210-0210a2f0f73c/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=


### PR DESCRIPTION
Thanks to a recent regression in gophercloud SDK, we hit a bug where if authentication fails, we can fail to ever reauthenticate.

https://github.com/gophercloud/gophercloud/pull/1327 fixes this.