### PR TITLE
Defer LogPanic() in all go routines in the critical path.

### DIFF
--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -439,6 +439,7 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 
 		db.wg.Add(1)
 		go func() {
+			defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs rglookups", true)
 			defer db.wg.Done()
 			sort.Sort(rgLookups)
 			errors <- db.storeBatched(bucketRTK, rgLookups, db.storeLookups)
@@ -446,6 +447,7 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 
 		db.wg.Add(1)
 		go func() {
+			defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs repGroups", true)
 			defer db.wg.Done()
 			var rgs sobsd
 			for rg := range repGroups {
@@ -460,6 +462,7 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 		if len(dgLookups) > 0 {
 			db.wg.Add(1)
 			go func() {
+				defer internal.LogPanic(db.Logger, "jobqueue database dgLookups", true)
 				defer db.wg.Done()
 				sort.Sort(dgLookups)
 				errors <- db.storeBatched(bucketDTK, dgLookups, db.storeLookups)
@@ -469,6 +472,7 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 		if len(rdgLookups) > 0 {
 			db.wg.Add(1)
 			go func() {
+				defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs rdgLookups", true)
 				defer db.wg.Done()
 				sort.Sort(rdgLookups)
 				errors <- db.storeBatched(bucketRDTK, rdgLookups, db.storeLookups)
@@ -477,6 +481,7 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 
 		db.wg.Add(1)
 		go func() {
+			defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs encodedJobs", true)
 			defer db.wg.Done()
 			sort.Sort(encodedJobs)
 			errors <- db.storeBatched(bucketJobsLive, encodedJobs, db.storeEncodedJobs)
@@ -1163,6 +1168,7 @@ func (db *db) retrieve(bucket []byte, key string) []byte {
 func (db *db) remove(bucket []byte, key string) {
 	db.wg.Add(1)
 	go func() {
+		defer internal.LogPanic(db.Logger, "jobqueue database remove", true)
 		defer db.wg.Done()
 		err := db.bolt.Batch(func(tx *bolt.Tx) error {
 			b := tx.Bucket(bucket)

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -315,6 +315,8 @@ func (s *local) recover(cmd string, req *Requirements, host *RecoveredHostDetail
 			s.resourceMutex.Unlock()
 
 			go func() {
+				defer internal.LogPanic(s.Logger, "recover", true)
+
 				// periodically check on this pid; when it has exited, update
 				// our resource usage
 				ticker := time.NewTicker(1 * time.Second)
@@ -487,7 +489,7 @@ func (s *local) processQueue() error {
 			s.running[key]++
 
 			go func() {
-				defer internal.LogPanic(s.Logger, "runCmd", true)
+				defer internal.LogPanic(s.Logger, "processQueue runCmd loop", true)
 
 				err := s.runCmdFunc(cmd, req, reserved, call)
 
@@ -533,6 +535,8 @@ func (s *local) processQueue() error {
 		}
 
 		go func() {
+			defer internal.LogPanic(s.Logger, "processQueue recall setup", true)
+
 			s.mutex.Lock()
 			defer s.mutex.Unlock()
 			s.processing = false
@@ -540,6 +544,7 @@ func (s *local) processQueue() error {
 			s.recall = false
 			if recall {
 				go func() {
+					defer internal.LogPanic(s.Logger, "processQueue recall", true)
 					errp := s.processQueue()
 					if errp != nil {
 						s.Warn("processQueue recall failed", "err", errp)

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -411,6 +411,8 @@ func (s *standin) waitForServer() (*cloud.Server, error) {
 	s.mutex.Unlock()
 	done := make(chan *cloud.Server)
 	go func() {
+		defer internal.LogPanic(s.Logger, "waitForServer", true)
+
 		server := <-s.endWait
 		done <- server
 		s.mutex.Lock()
@@ -1094,6 +1096,8 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call 
 			s.runMutex.Unlock()
 			done := make(chan error)
 			go func() {
+				defer internal.LogPanic(s.Logger, "runCmd", true)
+
 				for {
 					select {
 					case <-standinServer.readyToSpawn:
@@ -1481,6 +1485,8 @@ func (s *opst) recover(cmd string, req *Requirements, host *RecoveredHostDetails
 	}
 
 	go func() {
+		defer internal.LogPanic(s.Logger, "recover", true)
+
 		// periodically check on this server; when it is no longer running
 		// anything, destroy it
 		ticker := time.NewTicker(host.TTD)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -715,6 +715,7 @@ func Serve(config ServerConfig) (s *Server, msg string, token []byte, err error)
 		srv := &http.Server{Addr: httpAddr, Handler: mux}
 		wg.Add(1)
 		go func() {
+			defer internal.LogPanic(s.Logger, "jobqueue web server listenAndServe", true)
 			defer wg.Done()
 			errs := srv.ListenAndServeTLS(certFile, keyFile)
 			if errs != nil && errs != http.ErrServerClosed {
@@ -725,16 +726,19 @@ func Serve(config ServerConfig) (s *Server, msg string, token []byte, err error)
 
 		wg.Add(1)
 		go func() {
+			defer internal.LogPanic(s.Logger, "jobqueue web server status casting", true)
 			defer wg.Done()
 			s.statusCaster.Broadcasting(0)
 		}()
 		wg.Add(1)
 		go func() {
+			defer internal.LogPanic(s.Logger, "jobqueue web server server casting", true)
 			defer wg.Done()
 			s.badServerCaster.Broadcasting(0)
 		}()
 		wg.Add(1)
 		go func() {
+			defer internal.LogPanic(s.Logger, "jobqueue web server scheduler casting", true)
 			defer wg.Done()
 			s.schedCaster.Broadcasting(0)
 		}()
@@ -1432,6 +1436,8 @@ func (s *Server) createQueue() {
 			if job.killCalled {
 				defer func() {
 					go func() {
+						defer internal.LogPanic(s.Logger, "jobqueue ttr callback releaseJob", true)
+
 						// wait for the item to go back to run queue
 						<-time.After(50 * time.Millisecond)
 


### PR DESCRIPTION
All go routines that the server ends up calling need to defer internal.LogPanic() so that panics don't kill the server without logging the panic. These were forgotten about, apparently.