### PR TITLE
WaitUntilReady() should error when a postCreationScript takes too long.

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -274,7 +274,9 @@ flavor (normally the cheapest flavor is chosen for you based on the command's
 resource requirements). The format for cloud_config_files is described under the
 help text for "wr cloud deploy"'s --config_files option. The per-job config
 files you specify will be treated as in addition to any specified during cloud
-deploy or when starting the manager.
+deploy or when starting the manager. Note that your cloud_script must complete
+within 15 mins; if your script is slow because it installs a lot of software,
+consider creating a new image instead and using cloud_os.
 
 "cloud_shared" only works when using a cloud scheduler where both the manager
 and jobs will run on Ubuntu. It will cause /shared on the manager's server to be

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -120,7 +120,9 @@ The --script option value can be, for example, the path to a bash script that
 you want to run on any created cloud server before any commands run on them. You
 might install some software for example. Note that the script is run as the user
 defined by --username; if necessary, your bash script may have to prefix its
-commands with 'sudo' if the command would only work as root user.
+commands with 'sudo' if the command would only work as root user. Also, there is
+a time limit of 15 mins for the script to run. If you're installing lots of
+software, consider creating a new image instead, and using the --os option.
 
 The --config_files option lets you specify comma separated arbitrary text file
 paths that should be copied from your local system to any created cloud servers.
@@ -168,8 +170,8 @@ flavor can't be created due to lack of hardware, then the next best flavor -
 excluding flavors in the initial pick's flavor set - will be picked and tried
 instead.
 
-Deploy can work with any given OS image because it uploads wr to any server it
-creates; your OS image does not have to have wr installed on it. The only
+Deploy can work with any given --os OS image because it uploads wr to any server
+it creates; your OS image does not have to have wr installed on it. The only
 requirements of the OS image are that it support ssh and sftp on port 22, and
 that it be a 64bit linux-like system with /proc/*/smaps, /tmp and some local
 writeable disk space in the home directory. For --mounts to work, fuse-utils

--- a/wr_config.yml
+++ b/wr_config.yml
@@ -479,7 +479,9 @@ clouddisk: 1
 # OpenStack.
 #
 # When wr spawns a new server, cloudscript will be run on it when the server
-# first boots up.
+# first boots up. Note that there is a time limit of 15 mins for the script to
+# run. If your script installs lots of software and is exceeding the limit for
+# that reason, consider creating a new image instead and setting cloudos.
 # cloudscript: ""
 
 # cloudconfigfiles: What config files should be copied to newly spawned servers?


### PR DESCRIPTION
It was currently just waiting forever given a hanging script, meaning servers were up and using quota but were not usable.