### PR TITLE
Improved OpenStack scheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - WR_MANAGERPORT="11301"
     - GO111MODULE=on
 go:
-  - "1.12.5"
+  - "1.12.7"
 go_import_path: github.com/VertebrateResequencing/wr
 install:
   - "go mod verify"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Alternatively, build it yourself (at least v1.12 of go is required):
 An example way of setting up a personal Go installation in your home directory
 would be:
 
-        wget https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
-        tar -xvzf go1.12.5.linux-amd64.tar.gz && rm go1.12.5.linux-amd64.tar.gz
+        export GOV=1.12.7
+        wget https://dl.google.com/go/go$GOV.linux-amd64.tar.gz
+        tar -xvzf go$GOV.linux-amd64.tar.gz && rm go$GOV.linux-amd64.tar.gz
         export PATH=$PATH:$HOME/go/bin
 
 2. Download, compile, and install wr (not inside $GOPATH, if you set that):

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -52,7 +52,8 @@ than 1 process at a time.
     // spawn a server
     flavor := provider.CheapestServerFlavor(1, 1024, "")
     server, err = provider.Spawn("Ubuntu Xenial", "ubuntu", flavor.ID, 20, 2 * time.Minute, true)
-    server.WaitUntilReady("~/.s3cfg")
+    ctx := context.Background()
+    server.WaitUntilReady(ctx, "~/.s3cfg")
 
     // simplistic way of making the most of the server by running as many
     // commands as possible:
@@ -60,7 +61,7 @@ than 1 process at a time.
         if server.HasSpaceFor(1, 1024, 1) > 0 {
             server.Allocate(1, 1024, 1)
             go func() {
-                server.RunCmd(cmd, false)
+                server.RunCmd(ctx, cmd, false)
                 server.Release(1, 1024, 1)
             }()
         } else {
@@ -75,8 +76,6 @@ package cloud
 
 import (
 	"encoding/gob"
-	"errors"
-	"fmt"
 	"os"
 	"regexp"
 	"runtime"
@@ -87,7 +86,6 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/gofrs/uuid"
 	"github.com/inconshreveable/log15"
-	"golang.org/x/crypto/ssh"
 )
 
 // Err* constants are found in the returned Errors under err.Err, so you can
@@ -729,119 +727,6 @@ func (p *Provider) Spawn(os string, osUser string, flavorID string, diskGB int, 
 // server due to lack of hardware.
 func (p *Provider) ErrIsNoHardware(err error) bool {
 	return p.impl.errIsNoHardware(err)
-}
-
-// WaitUntilReady waits for the server to become fully ready: the boot process
-// will have completed and ssh will work. This is not part of provider.Spawn()
-// because you may not want or be able to ssh to your server, and so that you
-// can Spawn() another server while waiting for this one to become ready. If you
-// get an err, you will want to call server.Destroy() as this is not done for
-// you.
-//
-// files is a string in the format taken by the CopyOver() method; if supplied
-// non-blank it will CopyOver the specified files (after the server is ready,
-// before any postCreationScript is run).
-//
-// postCreationScript is the []byte content of a script that will be run on the
-// server (as the user supplied to Spawn()) once it is ready, and it will
-// complete before this function returns; empty slice means do nothing.
-func (s *Server) WaitUntilReady(files string, postCreationScript []byte) error {
-	// wait for ssh to come up
-	_, _, err := s.SSHClient()
-	if err != nil {
-		return err
-	}
-
-	// wait for sentinelFilePath to exist, indicating that the server is
-	// really ready to use
-	limit := time.After(sentinelTimeOut)
-	ticker := time.NewTicker(1 * time.Second)
-SENTINEL:
-	for {
-		select {
-		case <-ticker.C:
-			o, e, fileErr := s.RunCmd("file "+sentinelFilePath, false)
-			if fileErr == nil && !strings.Contains(o, "No such file") && !strings.Contains(e, "No such file") {
-				ticker.Stop()
-				// *** o contains "empty"; test for that instead? Does file
-				// behave the same way on all linux variants?
-				_, _, rmErr := s.RunCmd("sudo rm "+sentinelFilePath, false)
-				if rmErr != nil {
-					s.logger.Warn("failed to remove sentinel file", "path", sentinelFilePath, "err", rmErr)
-				}
-				break SENTINEL
-			}
-			continue SENTINEL
-		case <-limit:
-			ticker.Stop()
-			return errors.New("cloud server never became ready to use")
-		}
-	}
-
-	// copy over any desired files
-	if files != "" {
-		err = s.CopyOver(files)
-		if err != nil {
-			return fmt.Errorf("cloud server files failed to upload: %s", err)
-		}
-		s.ConfigFiles = files
-	}
-
-	// run the postCreationScript
-	if len(postCreationScript) > 0 {
-		pcsPath := "/tmp/.postCreationScript"
-		err = s.CreateFile(string(postCreationScript), pcsPath)
-		if err != nil {
-			return fmt.Errorf("cloud server start up script failed to upload: %s", err)
-		}
-
-		_, _, err = s.RunCmd("chmod u+x "+pcsPath, false)
-		if err != nil {
-			return fmt.Errorf("cloud server start up script could not be made executable: %s", err)
-		}
-
-		// protect running the script with a timeout
-		limit := time.After(pcsTimeOut)
-		exiterr := make(chan error, 1)
-		var stderr string
-		go func() {
-			var runerr error
-			_, stderr, runerr = s.RunCmd(pcsPath, false)
-			exiterr <- runerr
-		}()
-		select {
-		case err = <-exiterr:
-			if err != nil {
-				err = fmt.Errorf("cloud server start up script failed: %s", err.Error())
-				if len(stderr) > 0 {
-					err = fmt.Errorf("%s\nSTDERR:\n%s", err.Error(), stderr)
-				}
-				return err
-			}
-		case <-limit:
-			return fmt.Errorf("cloud server start up script failed to complete within %s", pcsTimeOut)
-		}
-
-		_, _, rmErr := s.RunCmd("rm "+pcsPath, false)
-		if rmErr != nil {
-			s.logger.Warn("failed to remove post creation script", "path", pcsPath, "err", rmErr)
-		}
-
-		s.Script = postCreationScript
-
-		// because the postCreationScript may have altered PATH and other things
-		// that subsequent RunCmd may rely on, clear the clients
-		for _, client := range s.sshClients {
-			err = client.Close()
-			if err != nil {
-				s.logger.Warn("failed to close client ssh connection", "err", err)
-			}
-		}
-		s.sshClients = []*ssh.Client{}
-		s.sshClientSessions = []int{}
-	}
-
-	return nil
 }
 
 // CheckServer asks the provider if the status of the given server (id retrieved

--- a/cloud/server.go
+++ b/cloud/server.go
@@ -107,6 +107,7 @@ type Server struct {
 	onDeathrow        bool
 	sshStarted        bool
 	createdShare      bool
+	used              bool
 }
 
 // Matches tells you if in principle a Server has the given os, script, config
@@ -122,6 +123,7 @@ func (s *Server) Matches(os string, script []byte, configFiles string, flavor *F
 func (s *Server) Allocate(cores float64, ramMB, diskGB int) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	s.used = true
 	s.usedCores = internal.FloatAdd(s.usedCores, cores)
 	s.usedRAM += ramMB
 	s.usedDisk += diskGB
@@ -132,6 +134,13 @@ func (s *Server) Allocate(cores float64, ramMB, diskGB int) {
 	if s.onDeathrow {
 		s.cancelDestruction <- true
 	}
+}
+
+// Used tells you if this server has ever had Allocate() called on it.
+func (s *Server) Used() bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.used
 }
 
 // Release records that the given resources have now been freed.

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -46,6 +46,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const serverRC = `echo %s %s %s %s %d %d`
+
 var runnermode bool
 var runnerfail bool
 var schedgrp string
@@ -798,7 +800,7 @@ func TestJobqueueBasics(t *testing.T) {
 		server, _, token, errs = serve(serverConfig)
 		So(errs, ShouldBeNil)
 
-		server.rc = `echo %s %s %s %s %d %d` // ReserveScheduled() only works if we have an rc
+		server.rc = serverRC // ReserveScheduled() only works if we have an rc
 
 		Convey("You can connect to the server and add jobs to the queue", func() {
 			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
@@ -2849,7 +2851,7 @@ func TestJobqueueLimitGroups(t *testing.T) {
 			server.Stop(true)
 		}()
 
-		server.rc = `echo %s %s %s %s %d %d`
+		server.rc = serverRC
 
 		Convey("You can connect, and add jobs with LimitGroups", func() {
 			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
@@ -2991,7 +2993,7 @@ func TestJobqueueModify(t *testing.T) {
 			server.Stop(true)
 		}()
 
-		server.rc = `echo %s %s %s %s %d %d`
+		server.rc = serverRC
 
 		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 		So(err, ShouldBeNil)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -496,8 +496,8 @@ func TestJobqueueSignal(t *testing.T) {
 			cmd := "sleep 10"
 			cmd2 := "perl -e 'for (1..10) { sleep(1) }'" // we want to kill this part way, but `sleep` processes don't seem to die straight away when killed
 			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 1, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "recover"})
-			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 1, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "buried"})
+			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "recover"})
+			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "buried"})
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 2)
@@ -582,6 +582,7 @@ func TestJobqueueSignal(t *testing.T) {
 						j2worked <- true
 						return
 					}
+					fmt.Printf("\njob2 had err %s\n", erre)
 					j2worked <- false
 					return
 				case <-giveUp2:

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -5093,7 +5093,10 @@ sudo usermod -aG docker ` + osUser
 	Convey("You can connect with an OpenStack scheduler", t, func() {
 		server, _, token, errs = serve(osConfig)
 		So(errs, ShouldBeNil)
-		defer server.Stop(true)
+		defer func() {
+			<-time.After(1 * time.Second) // give runners a chance to exit to avoid extraneous warnings
+			server.Stop(true)
+		}()
 
 		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 		So(err, ShouldBeNil)
@@ -5798,6 +5801,7 @@ sudo usermod -aG docker ` + osUser
 
 		Reset(func() {
 			if server != nil {
+				<-time.After(1 * time.Second)
 				server.Stop(true)
 			}
 		})

--- a/jobqueue/scheduler/kubernetes.go
+++ b/jobqueue/scheduler/kubernetes.go
@@ -194,6 +194,7 @@ func (s *k8s) initialize(config interface{}, logger log15.Logger) error {
 		s.stateUpdateFreq = 1 * time.Minute
 	}
 	s.postProcessFunc = s.postProcess
+	s.cmdNotNeededFunc = s.cmdNotNeeded
 
 	// pass through our shell config and logger to our local embed
 	s.local.config = &ConfigLocal{Shell: s.config.Shell}

--- a/jobqueue/scheduler/kubernetes.go
+++ b/jobqueue/scheduler/kubernetes.go
@@ -177,14 +177,13 @@ func (s *k8s) initialize(config interface{}, logger log15.Logger) error {
 	s.Debug("configuration passed", "configuration", s.config)
 
 	// make queue
-	s.queue = queue.New(localPlace)
+	s.queue = queue.New(localPlace, s.Logger)
 	s.running = make(map[string]int)
 
 	// set our functions for use in schedule() and processQueue()
 	s.reqCheckFunc = s.reqCheck
 	s.canCountFunc = s.canCount
 	s.runCmdFunc = s.runCmd
-	s.cancelRunCmdFunc = s.cancelRun
 	s.stateUpdateFunc = s.stateUpdate
 	s.maxMemFunc = s.maxMem
 	s.maxCPUFunc = s.maxCPU
@@ -194,6 +193,7 @@ func (s *k8s) initialize(config interface{}, logger log15.Logger) error {
 	if s.stateUpdateFreq == 0 {
 		s.stateUpdateFreq = 1 * time.Minute
 	}
+	s.postProcessFunc = s.postProcess
 
 	// pass through our shell config and logger to our local embed
 	s.local.config = &ConfigLocal{Shell: s.config.Shell}
@@ -390,7 +390,7 @@ func (s *k8s) cleanup() {
 // 100. ToDO: If any job is pending with the given requirements, return 0 until
 // that pend fails. This should reduce overall load on the cluster when adding
 // lots of jobs at once.
-func (s *k8s) canCount(req *Requirements, call string) int {
+func (s *k8s) canCount(cmd string, req *Requirements, call string) int {
 	s.Debug("canCount Called, returning 100")
 	// 100 is  a big enough block for anyone...
 	return 100

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -499,10 +499,6 @@ func (s *local) processQueue() error {
 				err := s.runCmdFunc(cmd, req, reserved, call)
 
 				s.mutex.Lock()
-				s.resourceMutex.Lock()
-				s.ram -= req.RAM
-				s.cores -= req.Cores
-				s.resourceMutex.Unlock()
 				s.running[key]--
 				if s.running[key] <= 0 {
 					delete(s.running, key)
@@ -633,6 +629,11 @@ func (s *local) runCmd(cmd string, req *Requirements, reservedCh chan bool, call
 		s.rcount = 0
 	}
 	s.rcMutex.Unlock()
+
+	s.resourceMutex.Lock()
+	s.ram -= req.RAM
+	s.cores -= req.Cores
+	s.resourceMutex.Unlock()
 
 	return nil // do not return error running the command
 }

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -803,9 +803,9 @@ func (s *local) cleanup() {
 	defer s.mutex.Unlock()
 	s.runMutex.Lock()
 	defer s.runMutex.Unlock()
+	s.stopAutoProcessing()
 	s.cleanMutex.Lock()
 	defer s.cleanMutex.Unlock()
-	s.stopAutoProcessing()
 	close(s.stopPidMonitoring)
 	s.cleaned = true
 	err := s.queue.Destroy()

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -70,7 +70,7 @@ type maxResourceGetter func() int
 // string. That same string will also be supplied to the cmdRunner function, so
 // you can tie together cmdRunner invocations that are all a result of a
 // particular canCounter call.
-type canCounter func(req *Requirements, call string) (canCount int)
+type canCounter func(cmd string, req *Requirements, call string) (canCount int)
 
 // stateUpdaters are functions used by processQueue() to update any global state
 // that might have become invalid due to changes external to our own actions.
@@ -85,12 +85,9 @@ type stateUpdater func()
 // or sent false if something went wrong before that.
 type cmdRunner func(cmd string, req *Requirements, reservedCh chan bool, call string) error
 
-// cancelCmdRunner are functions used by processQueue() to cancel the running
-// of cmdRunners that started but didn't really start to run the cmd. You give
-// the cmd and the number still needed and it will cancel any extras that have
-// been created but not started.
-// (Their reason for being is the same as for canCounters.)
-type cancelCmdRunner func(cmd string, desiredNumber int)
+// postProcessors are functions used by processQueue() to do something after
+// a postProcess() call does work.
+type postProcessor func()
 
 // local is our implementer of scheduleri.
 type local struct {
@@ -107,17 +104,19 @@ type local struct {
 	maxMemFunc        maxResourceGetter
 	maxCPUFunc        maxResourceGetter
 	canCountFunc      canCounter
+	postProcessFunc   postProcessor
 	stateUpdateFunc   stateUpdater
 	stateUpdateFreq   time.Duration
 	runCmdFunc        cmdRunner
-	cancelRunCmdFunc  cancelCmdRunner
 	stopAuto          chan bool
 	recoveredPids     map[int]bool
 	stopPidMonitoring chan struct{}
+	cleanMutex        sync.RWMutex
 	rcMutex           sync.RWMutex
 	resourceMutex     sync.RWMutex
 	mutex             sync.Mutex
 	rpMutex           sync.Mutex
+	runMutex          sync.Mutex
 	cleaned           bool
 	autoProcessing    bool
 	processing        bool
@@ -181,7 +180,7 @@ func (s *local) initialize(config interface{}, logger log15.Logger) error {
 	}
 
 	// make our queue
-	s.queue = queue.New(localPlace)
+	s.queue = queue.New(localPlace, s.Logger)
 	s.running = make(map[string]int)
 
 	// set our functions for use in schedule() and processQueue()
@@ -190,12 +189,12 @@ func (s *local) initialize(config interface{}, logger log15.Logger) error {
 	s.maxCPUFunc = s.maxCPU
 	s.canCountFunc = s.canCount
 	s.runCmdFunc = s.runCmd
-	s.cancelRunCmdFunc = s.cancelRun
 	s.stateUpdateFunc = s.stateUpdate
 	s.stateUpdateFreq = s.config.StateUpdateFrequency
 	if s.stateUpdateFreq == 0 {
 		s.stateUpdateFreq = 1 * time.Minute
 	}
+	s.postProcessFunc = s.postProcess
 
 	s.recoveredPids = make(map[int]bool)
 	s.stopPidMonitoring = make(chan struct{})
@@ -227,12 +226,9 @@ func (s *local) maxQueueTime(req *Requirements) time.Duration {
 
 // schedule achieves the aims of Schedule().
 func (s *local) schedule(cmd string, req *Requirements, count int) error {
-	s.mutex.Lock()
-	if s.cleaned {
-		s.mutex.Unlock()
+	if s.cleanedUp() {
 		return nil
 	}
-	s.mutex.Unlock()
 
 	// first find out if its at all possible to ever run this cmd
 	if count != 0 {
@@ -270,15 +266,24 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 	item, err := s.queue.Add(key, "", data, priority, 0*time.Second, 30*time.Second, "") // the ttr just has to be long enough for processQueue() to process a job, not actually run the cmds
 	if err != nil {
 		if qerr, ok := err.(queue.Error); ok && qerr.Err == queue.ErrAlreadyExists {
-			// update the job's count (only)
-			j := item.Data.(*job)
-			j.Lock()
-			j.count = count
-			j.Unlock()
+			if count == 0 {
+				s.removeKey(key)
+				s.Debug("schedule removed job", "cmd", cmd)
+			} else {
+				// update the job's count (only)
+				j := item.Data.(*job)
+				j.Lock()
+				before := j.count
+				j.count = count
+				j.Unlock()
+				s.Debug("schedule changed j.count", "cmd", cmd, "before", before, "needs", count)
+			}
 		} else {
 			s.mutex.Unlock()
 			return err
 		}
+	} else {
+		s.Debug("schedule added new job", "cmd", cmd, "needs", count)
 	}
 	s.mutex.Unlock()
 
@@ -287,7 +292,7 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 	}
 
 	// try and run the jobs in the queue
-	return s.processQueue()
+	return s.processQueue("schedule")
 }
 
 // recover achieves the aims of Recover(). Here we find an untracked pid
@@ -346,7 +351,7 @@ func (s *local) recover(cmd string, req *Requirements, host *RecoveredHostDetail
 							s.cores -= req.Cores
 							s.resourceMutex.Unlock()
 
-							errp := s.processQueue()
+							errp := s.processQueue("recover")
 							if errp != nil {
 								s.Error("processQueue call after recovery failed", "err", errp)
 							}
@@ -389,7 +394,7 @@ func (s *local) maxCPU() int {
 // that key. If this results in an empty queue, stops autoProcessing. You must
 // hold the lock on s before calling this!
 func (s *local) removeKey(key string) {
-	if s.cleaned {
+	if s.cleanedUp() {
 		return
 	}
 	err := s.queue.Remove(key)
@@ -407,21 +412,27 @@ func (s *local) removeKey(key string) {
 // processQueue goes through the jobs in the queue by size, sees if it's
 // possible to run any, does so if it is, otherwise returns the jobs to the
 // queue.
-func (s *local) processQueue() error {
+func (s *local) processQueue(reason string) error {
+	if s.cleanedUp() {
+		return nil
+	}
+
+	s.Debug("processQueue starting", "reason", reason)
+
 	// first perform any global state update needed by the scheduler
 	s.stateUpdateFunc()
 
+	// only process the queue once at a time; other calls to this function
+	// will return immeditely but cause us to recall ourselves when we
+	// complete
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	if s.cleaned {
-		return nil
-	}
-
 	if s.processing {
 		s.recall = true
+		s.Debug("processQueue returning early since still running")
 		return nil
 	}
+	s.processing = true
 
 	stats := s.queue.Stats()
 	toRelease := make([]string, 0, stats.Items)
@@ -432,11 +443,27 @@ func (s *local) processQueue() error {
 				s.Warn("processQueue item release failed", "err", errr)
 			}
 		}
+		s.postProcessFunc()
+
+		s.processing = false
+		recall := s.recall
+		s.recall = false
+		if recall {
+			go func() {
+				defer internal.LogPanic(s.Logger, "processQueue recall", true)
+				errp := s.processQueue("recall")
+				if errp != nil {
+					s.Warn("processQueue recall failed", "err", errp)
+				}
+			}()
+		}
+
+		s.Debug("processQueue ending")
 	}()
 
 	// go through the jobs largest to smallest (standard bin packing approach)
 	for {
-		item, err := s.queue.Reserve()
+		item, err := s.queue.Reserve("", 0)
 		if err != nil {
 			if qerr, ok := err.(queue.Error); ok && qerr.Err == queue.ErrNothingReady {
 				return nil
@@ -453,11 +480,6 @@ func (s *local) processQueue() error {
 
 		running := s.running[key]
 		s.Debug("processQueue running", "needs", count, "current", running, "cmd", cmd)
-		if count < running {
-			// "running" things may not actually be running the cmd yet, so tell
-			// extraneous ones to cancel and not start running
-			s.cancelRunCmdFunc(cmd, count)
-		}
 		if count == 0 && running == 0 {
 			// a cancellation has come in, and somehow we didn't remove this
 			// from the queue; do so now
@@ -475,7 +497,7 @@ func (s *local) processQueue() error {
 
 		// now see if there's remaining capacity to run the job
 		call := logext.RandId(8)
-		canCount := s.canCountFunc(req, call)
+		canCount := s.canCountFunc(cmd, req, call)
 		s.Debug("processQueue canCount", "can", canCount, "running", running, "should", shouldCount)
 		if canCount > shouldCount {
 			canCount = shouldCount
@@ -490,69 +512,50 @@ func (s *local) processQueue() error {
 		// start running what we can
 		s.Debug("processQueue runCmdFunc", "count", canCount)
 		reserved := make(chan bool, canCount)
+		s.runMutex.Lock()
 		for i := 0; i < canCount; i++ {
 			s.running[key]++
+			s.Debug("increased running", "cmd", cmd, "now", s.running[key])
 
 			go func() {
 				defer internal.LogPanic(s.Logger, "processQueue runCmd loop", true)
 
 				err := s.runCmdFunc(cmd, req, reserved, call)
+				art := time.Now()
+				s.Debug("after runCmd", "cmd", cmd)
 
-				s.mutex.Lock()
+				s.runMutex.Lock()
+				before := s.running[key]
 				s.running[key]--
+				s.Debug("after runCmd, decremented running", "cmd", cmd, "before", before, "now", s.running[key], "locktime", time.Since(art))
 				if s.running[key] <= 0 {
 					delete(s.running, key)
 				}
+				s.runMutex.Unlock()
 
-				if err == nil {
-					j.Lock()
-					j.count--
-					jCount := j.count
-					j.Unlock()
-					if jCount <= 0 {
-						s.removeKey(key)
-					}
-				} else if err.Error() != standinNotNeeded {
+				// we don't decrement j.count here because we expect our caller
+				// to decrement it via a schedule() call
+
+				if err != nil {
 					// users are notified of relevant errors during runCmd; here
 					// we just debug log everything
 					s.Debug("runCmd error", "err", err)
 				}
-				s.mutex.Unlock()
-				err = s.processQueue()
+
+				err = s.processQueue("after runCmd")
 				if err != nil {
 					s.Error("processQueue recall failed", "err", err)
 				}
 			}()
 		}
+		s.runMutex.Unlock()
 
-		// before allowing this function to be called again, or looping again,
-		// wait for all the above runCmdFuncs to at least get as far as
-		// reserving their resources, so subsequent calls to canCountFunc will
-		// be accurate
-		s.processing = true
-
+		// before looping again, wait for all the above runCmdFuncs to at least
+		// get as far as reserving their resources, so subsequent calls to
+		// canCountFunc will be accurate
 		for i := 0; i < canCount; i++ {
 			<-reserved
 		}
-
-		go func() {
-			defer internal.LogPanic(s.Logger, "processQueue recall setup", true)
-
-			s.mutex.Lock()
-			defer s.mutex.Unlock()
-			s.processing = false
-			recall := s.recall
-			s.recall = false
-			if recall {
-				go func() {
-					defer internal.LogPanic(s.Logger, "processQueue recall", true)
-					errp := s.processQueue()
-					if errp != nil {
-						s.Warn("processQueue recall failed", "err", errp)
-					}
-				}()
-			}
-		}()
 
 		// keep looping, in case any smaller job can also be run
 	}
@@ -560,7 +563,7 @@ func (s *local) processQueue() error {
 
 // canCount tells you how many jobs with the given RAM and core requirements it
 // is possible to run, given remaining resources.
-func (s *local) canCount(req *Requirements, call string) int {
+func (s *local) canCount(cmd string, req *Requirements, call string) int {
 	s.resourceMutex.RLock()
 	defer s.resourceMutex.RUnlock()
 
@@ -638,29 +641,33 @@ func (s *local) runCmd(cmd string, req *Requirements, reservedCh chan bool, call
 	return nil // do not return error running the command
 }
 
-// cancelRun in the local scheduler is a no-op, since our runCmd immediately
-// starts running the cmd and is never eligible for cancellation.
-func (s *local) cancelRun(cmd string, cancelCount int) {}
-
 // stateUpdate in the local scheduler is a no-op, since there currently isn't
 // any state out of our control we worry about.
 func (s *local) stateUpdate() {}
+
+// postProcess in the local scheduler is a no-op, since there currently isn't
+// anything that needs to be done after a postProcess() call.
+func (s *local) postProcess() {}
 
 // startAutoProcessing begins periodic running of processQueue(). Normally
 // processQueue is only called when cmds are added or complete. Calling it
 // periodically as well means we are responsive to external events freeing up
 // resources.
 func (s *local) startAutoProcessing() {
+	if s.cleanedUp() {
+		return
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
-	if s.cleaned || s.autoProcessing {
+	if s.autoProcessing {
 		return
 	}
 
 	go func() {
 		defer internal.LogPanic(s.Logger, "auto processQueue", false)
 
+		s.Debug("starting auto processing", "frequency", s.stateUpdateFreq)
 		ticker := time.NewTicker(s.stateUpdateFreq)
 		for {
 			select {
@@ -670,7 +677,7 @@ func (s *local) startAutoProcessing() {
 				// it until this case completes, so call processQueue in a go
 				// routine to complete the case ~instantly
 				go func() {
-					err := s.processQueue()
+					err := s.processQueue("auto")
 					if err != nil {
 						s.Error("Automated processQueue call failed", "err", err)
 					}
@@ -689,7 +696,10 @@ func (s *local) startAutoProcessing() {
 // stopAutoProcessing turns off the periodic processQueue() calls initiated by
 // startAutoProcessing(). You must hold the lock on s before calling this!
 func (s *local) stopAutoProcessing() {
-	if s.cleaned || !s.autoProcessing {
+	if s.cleanedUp() {
+		return
+	}
+	if !s.autoProcessing {
 		return
 	}
 
@@ -701,9 +711,7 @@ func (s *local) stopAutoProcessing() {
 // busy returns true if there's anything in our queue or we are still running
 // any cmd.
 func (s *local) busy() bool {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	if s.cleaned {
+	if s.cleanedUp() {
 		return false
 	}
 	s.rcMutex.RLock()
@@ -730,6 +738,8 @@ func (s *local) setBadServerCallBack(cb BadServerCallBack) {}
 func (s *local) cleanup() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	s.cleanMutex.Lock()
+	defer s.cleanMutex.Unlock()
 	s.stopAutoProcessing()
 	close(s.stopPidMonitoring)
 	s.cleaned = true
@@ -737,4 +747,11 @@ func (s *local) cleanup() {
 	if err != nil {
 		s.Warn("local scheduler cleanup failed", "err", err)
 	}
+}
+
+// cleanedUp returns true if cleanup() has been called
+func (s *local) cleanedUp() bool {
+	s.cleanMutex.RLock()
+	defer s.cleanMutex.RUnlock()
+	return s.cleaned
 }

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -819,7 +819,7 @@ func (s *opst) spawn(req *Requirements, flavor *cloud.Flavor, requestedOS string
 
 	// spawn
 	failMsg := "server failed spawn"
-	logger.Debug("will spawn", "flavor", flavor.Name)
+	logger.Debug("will spawn new server", "flavor", flavor.Name, "cmd", cmd)
 	tSpawn := time.Now()
 	server, err := s.provider.Spawn(requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime, false, usingQuotaCB)
 	serverID := "failed"
@@ -984,7 +984,7 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call 
 			server.Allocate(req.Cores, req.RAM, req.Disk)
 			reservedCh <- true
 			logger = logger.New("server", sid)
-			logger.Debug("using existing server")
+			logger.Debug("picked server")
 			break
 		}
 	}
@@ -1249,6 +1249,8 @@ func (s *opst) notifyBadServer(server *cloud.Server) {
 func (s *opst) cleanup() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	s.runMutex.Lock()
+	defer s.runMutex.Unlock()
 	s.cleanMutex.Lock()
 	defer s.cleanMutex.Unlock()
 	s.spawnMutex.Lock()

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -22,7 +22,6 @@ package scheduler
 // on servers spawned on demand.
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -35,15 +34,13 @@ import (
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/queue"
-	"github.com/gofrs/uuid"
 	"github.com/inconshreveable/log15"
-	logext "github.com/inconshreveable/log15/ext"
 	"github.com/patrickmn/go-cache"
 )
 
 const (
-	unquotadVal      = 1000000 // a "large" number for use when we don't have quota
-	standinNotNeeded = "standin no longer needed"
+	unquotadVal     = 1000000 // a "large" number for use when we don't have quota
+	cleanedUpErrStr = "cleaned up"
 )
 
 // debugCounter and debugEffect are used by tests to prove some bugs
@@ -67,10 +64,7 @@ type opst struct {
 	reservedRAM       int
 	reservedVolume    int
 	servers           map[string]*cloud.Server
-	standins          map[string]*standin
 	waitingToSpawn    int
-	cmdToStandins     map[string]map[string]bool
-	standinToCmd      map[string]map[string]bool
 	msgCB             MessageCallBack
 	badServerCB       BadServerCallBack
 	recoveredServers  map[string]bool
@@ -81,9 +75,9 @@ type opst struct {
 	cbmutex           sync.RWMutex
 	ffMutex           sync.RWMutex
 	stateMutex        sync.Mutex
-	runMutex          sync.Mutex
 	rsMutex           sync.Mutex
-	spawningNow       bool
+	spawnMutex        sync.Mutex
+	spawningNow       map[string]bool
 	updatingState     bool
 	stopRunning       bool
 }
@@ -246,320 +240,6 @@ func (c *ConfigOpenStack) GetServerKeepTime() time.Duration {
 	return c.ServerKeepTime
 }
 
-// standin describes a server that we're in the middle of spawning (or intend to
-// spawn in the future), allowing us to keep track of command->server
-// allocations while they're still being created.
-type standin struct {
-	script      []byte
-	id          string
-	os          string
-	configFiles string // in cloud.Server.CopyOver() format
-	firstCmd    string
-	failReason  string
-	log15.Logger
-	flavor         *cloud.Flavor
-	disk           int
-	usedRAM        int
-	usedCores      float64
-	usedDisk       int
-	cmds           map[string][]*Requirements // cmd to req lookup of allocations
-	cmdNotNeeded   map[string]chan bool
-	cmdsWaiting    map[string]int
-	nowWaiting     int // for waitForServer()
-	endWait        chan *cloud.Server
-	readyToSpawn   chan bool
-	noLongerNeeded chan bool
-	mutex          sync.RWMutex
-	sharedDisk     bool
-	alreadyFailed  bool
-	waitingToSpawn bool // for isExtraneous()
-}
-
-// newStandin returns a new standin server.
-func newStandin(id string, flavor *cloud.Flavor, disk int, osPrefix string, script []byte, configFiles string, sharedDisk bool, logger log15.Logger) *standin {
-	availableDisk := flavor.Disk
-	if disk > availableDisk {
-		availableDisk = disk
-	}
-	return &standin{
-		id:             id,
-		flavor:         flavor,
-		disk:           availableDisk,
-		os:             osPrefix,
-		script:         script,
-		configFiles:    configFiles,
-		sharedDisk:     sharedDisk,
-		waitingToSpawn: true,
-		endWait:        make(chan *cloud.Server),
-		readyToSpawn:   make(chan bool),
-		noLongerNeeded: make(chan bool),
-		cmds:           make(map[string][]*Requirements),
-		cmdNotNeeded:   make(map[string]chan bool),
-		cmdsWaiting:    make(map[string]int),
-		Logger:         logger.New("standin", id),
-	}
-}
-
-// matches is like cloud.Server.Matches().
-func (s *standin) matches(os string, script []byte, configFiles string, flavor *cloud.Flavor, sharedDisk bool) bool {
-	return s.os == os && bytes.Equal(s.script, script) && s.configFiles == configFiles && (flavor == nil || flavor.ID == s.flavor.ID) && s.sharedDisk == sharedDisk
-}
-
-// allocate is like cloud.Server.Allocate() but also records the cmd these reqs
-// were allocated for, for possible cancellation purposes.
-func (s *standin) allocate(cmd string, req *Requirements) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.usedCores = internal.FloatAdd(s.usedCores, req.Cores)
-	s.usedRAM += req.RAM
-	s.usedDisk += req.Disk
-	s.Debug("allocate", "cores", req.Cores, "RAM", req.RAM, "disk", req.Disk, "usedCores", s.usedCores, "usedRAM", s.usedRAM, "usedDisk", s.usedDisk)
-
-	if s.firstCmd == "" {
-		s.firstCmd = cmd
-	}
-	if _, exists := s.cmds[cmd]; !exists {
-		s.cmds[cmd] = []*Requirements{}
-	}
-	s.cmds[cmd] = append(s.cmds[cmd], req)
-}
-
-// numAllocationsForCmd returns the number of times cmd was sent to allocate()
-// (and not cancel()ed).
-func (s *standin) numAllocationsForCmd(cmd string) int {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	if reqs, exists := s.cmds[cmd]; exists {
-		return len(reqs)
-	}
-	return 0
-}
-
-// cancel is used to change your mind about prior allocate() calls; it will make
-// it as if count of those calls never happened. Returns the number of prior
-// calls successfully cancelled, and a boolean which if true means this standin
-// is now empty.
-func (s *standin) cancel(cmd string, count int) (int, bool) {
-	if count == 0 {
-		return 0, false
-	}
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	notNeededCh := s.cmdNotNeeded[cmd]
-	cancelled := 0
-	if reqs, exists := s.cmds[cmd]; exists {
-		if len(reqs) == 0 {
-			delete(s.cmds, cmd)
-			return 0, len(s.cmds) == 0
-		}
-
-		for {
-			var req *Requirements
-			req, reqs = reqs[len(reqs)-1], reqs[:len(reqs)-1]
-
-			s.usedCores = internal.FloatSubtract(s.usedCores, req.Cores)
-			s.usedRAM -= req.RAM
-			s.usedDisk -= req.Disk
-			s.Debug("cancel", "cores", req.Cores, "RAM", req.RAM, "disk", req.Disk, "usedCores", s.usedCores, "usedRAM", s.usedRAM, "usedDisk", s.usedDisk)
-
-			waiting := s.cmdsWaiting[cmd]
-			if waiting > 0 {
-				notNeededCh <- true
-				s.nowWaiting--
-				s.cmdsWaiting[cmd]--
-			}
-
-			cancelled++
-			if cancelled == count {
-				break
-			}
-		}
-
-		if len(reqs) == 0 {
-			delete(s.cmds, cmd)
-		} else if cancelled > 0 {
-			s.cmds[cmd] = reqs
-		}
-	}
-
-	return cancelled, len(s.cmds) == 0
-}
-
-// hasSpaceFor is like cloud.Server.HasSpaceFor().
-func (s *standin) hasSpaceFor(req *Requirements) int {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	cores := req.Cores
-	if internal.FloatLessThan(float64(s.flavor.Cores)-s.usedCores, cores) || (s.flavor.RAM-s.usedRAM < req.RAM) || (s.disk-s.usedDisk < req.Disk) {
-		return 0
-	}
-	var canDo int
-	if cores > 0 {
-		canDo = int(math.Floor(internal.FloatSubtract(float64(s.flavor.Cores), s.usedCores) / cores))
-	} else {
-		canDo = maxZeroCoreJobs
-	}
-	if canDo > 1 {
-		var n int
-		if req.RAM > 0 {
-			n = (s.flavor.RAM - s.usedRAM) / req.RAM
-			if n < canDo {
-				canDo = n
-			}
-		}
-		if req.Disk > 0 {
-			n = (s.disk - s.usedDisk) / req.Disk
-			if n < canDo {
-				canDo = n
-			}
-		}
-	}
-	return canDo
-}
-
-// willBeUsed tags this standin to note that we're no longer waiting to spawn,
-// and we're about to spawn a real server.
-func (s *standin) willBeUsed() {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.waitingToSpawn = false
-}
-
-// isExtraneous checks if all prior allocate()ions on this standin can fit on
-// the given server. If they can, this standin will get failed() and we return
-// true.
-func (s *standin) isExtraneous(server *cloud.Server) bool {
-	s.mutex.RLock()
-	var failed bool
-	if s.waitingToSpawn {
-		if server.OS == s.os && server.HasSpaceFor(s.usedCores, s.usedRAM, s.usedDisk) > 0 {
-			s.mutex.RUnlock()
-			failed = s.failed(standinNotNeeded)
-			s.Debug("isExtraneous", "failed", failed)
-		} else {
-			s.mutex.RUnlock()
-		}
-	} else {
-		s.mutex.RUnlock()
-	}
-	return failed
-}
-
-// failed is what you call if the server that this is a standin for failed to
-// start up; anything that is waiting on waitForServer() will then receive nil.
-// Returns true if it hadn't already been failed.
-func (s *standin) failed(msg string) bool {
-	s.mutex.Lock()
-	alreadyFailed := s.alreadyFailed
-	waitingToSpawn := s.waitingToSpawn
-	s.failReason = msg
-	if s.nowWaiting > 0 {
-		s.mutex.Unlock()
-		s.endWait <- nil
-	} else {
-		s.mutex.Unlock()
-	}
-	if alreadyFailed || !waitingToSpawn {
-		s.Debug("standin already failed or not waiting to spawn", "msg", msg)
-		return false
-	}
-	s.mutex.Lock()
-	s.alreadyFailed = true
-	s.mutex.Unlock()
-	s.Debug(msg)
-	return true
-}
-
-// worked is what you call once the server that this is a standin for has
-// actually started up successfully. Anything that is waiting on waitForServer()
-// will then receive the server you supply here. The server is allocated all the
-// resources that were allocated to this standin.
-//
-// If no allocation occurred because everything had been cancel()ed, returns
-// false. Also returns false if the first cmd to be allocated has been fully
-// cancel()ed, meaning the same caller that created this standin and the server
-// and is now calling this method no longer needs to run a command on this
-// server (but other users of this standin do).
-func (s *standin) worked(server *cloud.Server) bool {
-	s.mutex.RLock()
-	server.Allocate(s.usedCores, s.usedRAM, s.usedDisk)
-	msg := "standin worked"
-	r := true
-	if s.usedCores == 0 && s.usedRAM == 0 && s.usedDisk == 0 {
-		msg = "standin's server not needed"
-		server.Release(s.usedCores, s.usedRAM, s.usedDisk)
-		r = false
-	}
-	s.Debug(msg, "server", server.ID, "cores", s.usedCores, "ram", s.usedRAM, "disk", s.usedDisk)
-	if s.nowWaiting > 0 {
-		s.mutex.RUnlock()
-		s.endWait <- server
-	} else {
-		s.mutex.RUnlock()
-	}
-
-	if r {
-		if _, exists := s.cmds[s.firstCmd]; !exists {
-			r = false
-		}
-	}
-
-	return r
-}
-
-// waitForServer waits until another goroutine calls failed() or worked(). You
-// would use this after checking hasSpaceFor() and doing allocate().
-func (s *standin) waitForServer(cmd string) (*cloud.Server, error) {
-	s.mutex.Lock()
-	s.nowWaiting++
-	var notNeededCh chan bool
-	var exists bool
-	if notNeededCh, exists = s.cmdNotNeeded[cmd]; !exists {
-		notNeededCh = make(chan bool)
-		s.cmdNotNeeded[cmd] = notNeededCh
-	}
-	s.cmdsWaiting[cmd]++
-	s.Debug("waitForServer", "waiting", s.nowWaiting, "cmd", cmd, "cmdWaiting", s.cmdsWaiting[cmd])
-	s.mutex.Unlock()
-	done := make(chan *cloud.Server)
-	reason := make(chan string)
-	go func() {
-		defer internal.LogPanic(s.Logger, "waitForServer", true)
-		select {
-		case server := <-s.endWait: // sent by failed() or worked()
-			s.mutex.RLock()
-			reasonStr := s.failReason
-			s.mutex.RUnlock()
-			done <- server
-			reason <- reasonStr
-			s.mutex.Lock()
-			s.nowWaiting--
-			s.cmdsWaiting[cmd]--
-			nowWaiting := s.nowWaiting
-			s.mutex.Unlock()
-			s.Debug("waitForServer endWait", "waiting", nowWaiting)
-
-			// multiple goroutines may have called waitForServer(), so we
-			// will repeat for the next one if so
-			if nowWaiting > 0 {
-				s.endWait <- server
-			}
-		case <-notNeededCh: // sent by cancel()
-			done <- nil
-			reason <- standinNotNeeded
-			s.Debug("waitForServer notNeeded")
-			// cancel() will send on the channel as many times as needed
-		}
-	}()
-	server := <-done
-	reasonStr := <-reason
-	if reasonStr != "" {
-		return server, fmt.Errorf(reasonStr)
-	}
-	return server, nil
-}
-
 // initialize sets up an openstack scheduler.
 func (s *opst) initialize(config interface{}, logger log15.Logger) error {
 	s.config = config.(*ConfigOpenStack)
@@ -629,7 +309,7 @@ func (s *opst) initialize(config interface{}, logger log15.Logger) error {
 	}
 
 	// initialize our job queue and other trackers
-	s.queue = queue.New(localPlace)
+	s.queue = queue.New(localPlace, s.Logger)
 	s.running = make(map[string]int)
 
 	// initialise our servers with details of ourself
@@ -656,12 +336,12 @@ func (s *opst) initialize(config interface{}, logger log15.Logger) error {
 	s.maxCPUFunc = s.maxCPU
 	s.canCountFunc = s.canCount
 	s.runCmdFunc = s.runCmd
-	s.cancelRunCmdFunc = s.cancelRun
 	s.stateUpdateFunc = s.stateUpdate
 	s.stateUpdateFreq = s.config.StateUpdateFrequency
 	if s.stateUpdateFreq == 0 {
 		s.stateUpdateFreq = 1 * time.Minute
 	}
+	s.postProcessFunc = s.postProcess
 
 	// pass through our shell config and logger to our local embed, as well as
 	// creating its stopAuto channel
@@ -669,12 +349,9 @@ func (s *opst) initialize(config interface{}, logger log15.Logger) error {
 	s.local.Logger = s.Logger
 	s.local.stopAuto = make(chan bool)
 
-	s.standins = make(map[string]*standin)
-	s.cmdToStandins = make(map[string]map[string]bool)
-	s.standinToCmd = make(map[string]map[string]bool)
-
 	s.recoveredServers = make(map[string]bool)
 	s.stopRSMonitoring = make(chan struct{})
+	s.spawningNow = make(map[string]bool)
 
 	if s.config.FlavorSets != "" {
 		sets := strings.Split(s.config.FlavorSets, ";")
@@ -861,10 +538,21 @@ func (s *opst) serverReqs(req *Requirements) (osPrefix string, osScript []byte, 
 }
 
 // canCount tells you how many jobs with the given RAM and core requirements it
-// is possible to run, given remaining resources.
-func (s *opst) canCount(req *Requirements, call string) int {
-	s.resourceMutex.RLock()
-	defer s.resourceMutex.RUnlock()
+// is possible to run, given remaining resources in existing servers.
+//
+// If the answer is 0, but there is enough quota to spawn a new server, and we
+// are not already in the middle of spawning a server for this req, this is done
+// in the background, and recalling this method later (once the new server has
+// booted up) would return a number greater than 0. It is arranged that this
+// method will be automatically recalled in this cirumcstance.
+//
+// New servers for the same req are created sequentially to avoid overloading
+// OpenStack's sub-systems. Servers for different reqs may be created in
+// parallel, however.
+func (s *opst) canCount(cmd string, req *Requirements, call string) int {
+	if s.cleanedUp() {
+		return 0
+	}
 
 	requestedOS, requestedScript, requestedConfigFiles, requestedFlavor, needsSharedDisk, err := s.serverReqs(req)
 	if err != nil {
@@ -872,27 +560,15 @@ func (s *opst) canCount(req *Requirements, call string) int {
 		return 0
 	}
 
-	reqForSpawn := s.reqForSpawn(req)
-
 	// we don't do any actual checking of current resources on the machines, but
 	// instead rely on our simple tracking based on how many cores and RAM
 	// prior cmds were /supposed/ to use. This could be bad for misbehaving cmds
 	// that use too much memory, but we will end up killing cmds that do this,
 	// so it shouldn't be too much of an issue.
 
-	// first we see how many of these commands will run on existing servers ***
-	// both here and for the similar bit in runCmd, while looping over even
-	// thousands of servers shouldn't be a performance issue, perhaps we could
-	// do something a bit better, eg bin packing:
-	// http://codeincomplete.com/posts/bin-packing/ (implemented in go:
-	// https://github.com/azul3d/engine/blob/master/binpack/binpack.go)
-	// "Analytical and empirical results suggest that ‘first fit decreasing’ is
-	// the best heuristic. Sort the objects in decreasing order of size, so that
-	// the biggest object is first and the smallest last. Insert each object one
-	// by one in to the first bin that has room for it.”
+	// see how many of these commands will run on existing servers
 	var canCount int
 	s.serversMutex.RLock()
-	numServers := len(s.servers)
 	for _, server := range s.servers {
 		if !server.IsBad() && server.Matches(requestedOS, requestedScript, requestedConfigFiles, requestedFlavor, needsSharedDisk) {
 			space := server.HasSpaceFor(req.Cores, req.RAM, req.Disk)
@@ -901,22 +577,69 @@ func (s *opst) canCount(req *Requirements, call string) int {
 	}
 	s.serversMutex.RUnlock()
 
-	// if a specific flavor was not requested, get the smallest server type that
-	// can run our job, so we can subsequently calculate how many we could spawn
-	// before exceeding our quota
+	if canCount == 0 {
+		s.spawnMutex.Lock()
+		defer s.spawnMutex.Unlock()
+		reqStr := req.Stringify()
+		if s.spawningNow[reqStr] {
+			return canCount
+		}
+
+		// spawn a server in the background
+		s.spawningNow[reqStr] = true
+		go func() {
+			defer internal.LogPanic(s.Logger, "canCount", false)
+			defer func() {
+				s.spawnMutex.Lock()
+				delete(s.spawningNow, reqStr)
+				s.spawnMutex.Unlock()
+			}()
+
+			reqForSpawn := s.reqForSpawn(req)
+
+			spawnable, flavor := s.checkQuota(reqForSpawn, requestedFlavor, call)
+			if spawnable == 0 {
+				return
+			}
+
+			s.spawn(reqForSpawn, flavor, requestedOS, requestedScript, requestedConfigFiles, needsSharedDisk, cmd, call)
+
+			errp := s.processQueue("post spawn")
+			if errp != nil {
+				s.Error("processQueue recall failed", "err", errp)
+			}
+		}()
+	}
+
+	return canCount
+}
+
+// checkQuota sees if there's enough quota to spawn a server suitable for the
+// given requirements.
+//
+// If requestedFlavor is nil, the smallest suitable server flavor will be
+// determined.
+//
+// Returns the number of servers that can be spawned, and the flavor that should
+// be spawned (if number greater than 0). Errors are simply Warn()ed.
+func (s *opst) checkQuota(req *Requirements, requestedFlavor *cloud.Flavor, call string) (int, *cloud.Flavor) {
+	s.resourceMutex.RLock()
+	defer s.resourceMutex.RUnlock()
+
 	flavor := requestedFlavor
+	var err error
 	if flavor == nil {
-		flavor, err = s.determineFlavor(reqForSpawn, call)
+		flavor, err = s.determineFlavor(req, call)
 		if err != nil {
 			s.Warn("Failed to determine a server flavor", "err", err)
-			return canCount
+			return 0, nil
 		}
 	}
 
 	quota, err := s.provider.GetQuota() // this includes resources used by currently spawning servers
 	if err != nil {
 		s.Warn("Failed to GetQuota", "err", err)
-		return canCount
+		return 0, nil
 	}
 	remainingInstances := unquotadVal
 	if quota.MaxInstances > 0 {
@@ -928,6 +651,9 @@ func (s *opst) canCount(req *Requirements, call string) int {
 	}
 	if remainingInstances > 0 && s.quotaMaxInstances > -1 && s.quotaMaxInstances < quota.MaxInstances {
 		// also check that the users configured max instances hasn't been breached
+		s.serversMutex.RLock()
+		numServers := len(s.servers)
+		s.serversMutex.RUnlock()
 		used := numServers + s.reservedInstances
 		remaining := s.quotaMaxInstances - used
 		if remaining < remainingInstances {
@@ -963,9 +689,11 @@ func (s *opst) canCount(req *Requirements, call string) int {
 		}
 	}
 	if remainingInstances < 1 || remainingRAM < flavor.RAM || remainingCores < flavor.Cores || remainingVolume < req.Disk {
-		return canCount
+		return 0, nil
 	}
 
+	// (we only care that we can spawn at least 1, but calculate the actual
+	// spawnable number in case we want to spawn multiple at once in the future)
 	spawnable := remainingInstances
 	if spawnable > 1 {
 		n := remainingRAM / flavor.RAM // dividing ints == floor
@@ -983,37 +711,7 @@ func (s *opst) canCount(req *Requirements, call string) int {
 			}
 		}
 	}
-
-	// finally, calculate how many reqs we can get running on that many servers
-	var perServer int
-	if req.Cores > 0 {
-		perServer = int(math.Floor(float64(flavor.Cores) / req.Cores))
-	} else {
-		perServer = maxZeroCoreJobs
-	}
-	if perServer > 1 {
-		var n int
-		if req.RAM > 0 {
-			n = flavor.RAM / req.RAM
-			if n < perServer {
-				perServer = n
-			}
-		}
-		if req.Disk > 0 {
-			if checkVolume {
-				// we'll be creating volumes to exactly match required disk
-				// space
-				n = 1
-			} else {
-				n = flavor.Disk / req.Disk
-			}
-			if n < perServer {
-				perServer = n
-			}
-		}
-	}
-	canCount += spawnable * perServer
-	return canCount
+	return spawnable, flavor
 }
 
 // reqForSpawn checks the input Requirements and if the configured OSRAM (or
@@ -1063,16 +761,199 @@ func (s *opst) reqForSpawn(req *Requirements) *Requirements {
 	return reqForSpawn
 }
 
-// runCmd runs the command on next available server, or creates a new server if
-// none are available. NB: we only return an error if we can't start the cmd,
-// not if the command fails (schedule() only guarantees that the cmds are run
-// count times, not that they are /successful/ that many times). New servers are
-// created sequentially to avoid overloading OpenStack's sub-systems.
-func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call string) error {
+// spawn creates a new instance in OpenStack. Errors are not returned but are
+// logged, and problematic servers are terminated.
+func (s *opst) spawn(req *Requirements, flavor *cloud.Flavor, requestedOS string, requestedScript []byte, requestedConfigFiles string, needsSharedDisk bool, cmd string, call string) {
 	// since we can have many simultaneous calls to this method running at once,
 	// we make a new logger with a unique "call" context key to keep track of
-	// which runCmd call is doing what
-	logger := s.Logger.New("call", logext.RandId(8))
+	// which spawn call is doing what
+	logger := s.Logger.New("call", call)
+
+	volumeAffected := req.Disk > flavor.Disk
+
+	// because spawning can take a while, we record that we're going to use
+	// up some of our quota and unlock so other things can proceed
+	s.resourceMutex.Lock()
+	s.reservedInstances++
+	s.reservedCores += flavor.Cores
+	s.reservedRAM += flavor.RAM
+	if volumeAffected {
+		s.reservedVolume += req.Disk
+	}
+	s.resourceMutex.Unlock()
+
+	// later on, immediately after the spawn request goes through (and so
+	// presumably is using up quota), but before the new server powers up,
+	// drop our reserved values down or we'll end up double-counting
+	// resource usage in checkQuota(), since that takes in to account
+	// resources used by an in-progress spawn.
+	usingQuotaCB := func() {
+		s.resourceMutex.Lock()
+		s.reservedInstances--
+		s.reservedCores -= flavor.Cores
+		s.reservedRAM -= flavor.RAM
+		if volumeAffected {
+			s.reservedVolume -= req.Disk
+		}
+		s.resourceMutex.Unlock()
+	}
+
+	var osUser string
+	if val, defined := req.Other["cloud_user"]; defined {
+		osUser = val
+	} else {
+		osUser = s.config.OSUser
+	}
+
+	// *** we need a better way for our test script to prove the bugs that rely
+	// on debugEffect, that doesn't affect non-testing code. Probably have to
+	// mock OpenStack instead at some point...
+	var thisDebugCount int
+	if debugEffect != "" {
+		debugCounter++
+		thisDebugCount = debugCounter
+	}
+	if debugEffect == "slowSecondSpawn" && thisDebugCount == 3 {
+		<-time.After(10 * time.Second)
+	}
+
+	// spawn
+	failMsg := "server failed spawn"
+	logger.Debug("will spawn", "flavor", flavor.Name)
+	tSpawn := time.Now()
+	server, err := s.provider.Spawn(requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime, false, usingQuotaCB)
+	serverID := "failed"
+	if server != nil {
+		serverID = server.ID
+	}
+	logger = logger.New("server", serverID)
+	logger.Debug("spawned server", "took", time.Since(tSpawn))
+
+	if err == nil && server != nil {
+		// wait until boot is finished, ssh is ready and osScript has
+		// completed
+		logger.Debug("waiting for server ready")
+		failMsg = "server failed ready"
+		tReady := time.Now()
+		err = s.doUnlessCleaned(server, func() error { return server.WaitUntilReady(requestedConfigFiles, requestedScript) })
+		logger.Debug("waited for server to become ready", "took", time.Since(tReady))
+
+		if err == nil && needsSharedDisk {
+			s.serversMutex.RLock()
+			localhostIP := s.servers["localhost"].IP
+			s.serversMutex.RLock()
+			err = s.doUnlessCleaned(server, func() error { return server.MountSharedDisk(localhostIP) })
+		}
+
+		if err == nil {
+			failMsg = "server failed uploads"
+
+			// check that the exe of the cmd we're supposed to run exists on the
+			// new server, and if not, copy it over *** this is just a hack to
+			// get wr working, need to think of a better way of doing this...
+			exe := strings.Split(cmd, " ")[0]
+			var exePath, stdout string
+			if exePath, err = exec.LookPath(exe); err == nil {
+				err = s.doUnlessCleaned(server, func() error {
+					stdout, _, err = server.RunCmd("file "+exePath, false)
+					return err
+				})
+				if stdout != "" {
+					if strings.Contains(stdout, "No such file") {
+						// *** NB this will fail if exePath is in a dir we can't
+						// create on the remote server, eg. if it is in our home
+						// dir, but the remote server has a different user, or
+						// presumably if it is somewhere requiring root
+						// permission
+						err = s.doUnlessCleaned(server, func() error { return server.UploadFile(exePath, exePath) })
+						if err == nil {
+							err = s.doUnlessCleaned(server, func() error {
+								_, _, err = server.RunCmd("chmod u+x "+exePath, false)
+								return err
+							})
+						} else if err.Error() != cleanedUpErrStr {
+							err = fmt.Errorf("could not upload exe [%s]: %s (try putting the exe in /tmp?)", exePath, err)
+						}
+					} else if err != nil && err.Error() != cleanedUpErrStr {
+						err = fmt.Errorf("could not check exe with [file %s]: %s [%s]", exePath, stdout, err)
+					}
+				} else {
+					// checking for exePath with the file command failed for
+					// some reason, and without any stdout... but let's just
+					// try the upload anyway, assuming the exe isn't there
+					err = s.doUnlessCleaned(server, func() error { return server.UploadFile(exePath, exePath) })
+					if err == nil {
+						err = s.doUnlessCleaned(server, func() error {
+							_, _, err = server.RunCmd("chmod u+x "+exePath, false)
+							return err
+						})
+					} else if err.Error() != cleanedUpErrStr {
+						err = fmt.Errorf("could not upload exe [%s]: %s (try putting the exe in /tmp?)", exePath, err)
+					}
+				}
+			} else {
+				err = fmt.Errorf("could not look for exe [%s]: %s", exePath, err)
+			}
+		}
+	}
+
+	if debugEffect == "failFirstSpawn" && thisDebugCount == 1 {
+		err = errors.New("forced fail")
+	}
+
+	if s.cleanedUp() {
+		err = errors.New(cleanedUpErrStr)
+	}
+
+	// handle Spawn() or upload-of-exe errors now, by destroying the server
+	// and noting we failed
+	if err != nil {
+		if err.Error() != cleanedUpErrStr {
+			logger.Warn(failMsg, "err", err)
+		}
+		if server != nil {
+			errd := server.Destroy()
+			if errd != nil && err.Error() != cleanedUpErrStr {
+				logger.Debug("server also failed to destroy", "err", errd)
+			}
+		} else if s.provider.ErrIsNoHardware(err) {
+			s.ffMutex.Lock()
+			s.failedFlavors[flavor.ID] = time.Now()
+			s.ffMutex.Unlock()
+			s.Warn("server failed to spawn due to lack of hardware", "flavor", flavor.Name)
+		}
+		s.notifyMessage(fmt.Sprintf("OpenStack: Failed to create a usable server: %s", err))
+		return
+	}
+
+	logger.Debug("server useable")
+	s.ffMutex.Lock()
+	if _, failed := s.failedFlavors[flavor.ID]; failed {
+		s.Debug("server successfully spawned on previously failed flavor", "flavor", flavor.Name)
+		delete(s.failedFlavors, flavor.ID)
+	}
+	s.ffMutex.Unlock()
+
+	s.serversMutex.Lock()
+	s.servers[server.ID] = server
+	s.serversMutex.Unlock()
+}
+
+// doUnlessCleaned runs the given code unless cleanup() has been called, in
+// which case an error is returned instead.
+func (s *opst) doUnlessCleaned(server *cloud.Server, code func() error) error {
+	if s.cleanedUp() {
+		return errors.New(cleanedUpErrStr)
+	}
+	return code()
+}
+
+// runCmd runs the command on next available server. NB: we only return an error
+// if we can't start the cmd, not if the command fails (schedule() only
+// guarantees that the cmds are run count times, not that they are /successful/
+// that many times).
+func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call string) error {
+	logger := s.Logger.New("call", call)
 
 	// while it doesn't happen in practice with jobqueue.Server, it is
 	// theoretically possible for our caller to change req while we run, but the
@@ -1088,29 +969,14 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call 
 		logger.Debug("using requested flavor", "flavor", requestedFlavor.Name)
 	}
 
-	s.runMutex.Lock()
-
-	if s.stopRunning {
-		s.runMutex.Unlock()
+	if s.cleanedUp() {
 		reservedCh <- false
 		return nil
 	}
 
-	// *** we need a better way for our test script to prove the bugs that rely
-	// on debugEffect, that doesn't affect non-testing code. Probably have to
-	// mock OpenStack instead at some point...
-	var thisDebugCount int
-	if debugEffect != "" {
-		debugCounter++
-		thisDebugCount = debugCounter
-	}
-
-	s.serversMutex.RLock()
-	numServers := len(s.servers)
-	localhost := s.servers["localhost"]
-
 	// look through space on existing servers to see if we can run cmd on one
 	// of them
+	s.serversMutex.RLock()
 	var server *cloud.Server
 	for sid, thisServer := range s.servers {
 		if !thisServer.IsBad() && thisServer.Matches(requestedOS, requestedScript, requestedConfigFiles, requestedFlavor, needsSharedDisk) && thisServer.HasSpaceFor(req.Cores, req.RAM, req.Disk) > 0 {
@@ -1124,341 +990,17 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call 
 	}
 	s.serversMutex.RUnlock()
 
-	// else see if there will be space on a soon-to-be-spawned server
 	if server == nil {
-		for _, standinServer := range s.standins {
-			if standinServer.matches(requestedOS, requestedScript, requestedConfigFiles, requestedFlavor, needsSharedDisk) && standinServer.hasSpaceFor(req) > 0 {
-				s.recordStandin(standinServer, cmd)
-				standinServer.allocate(cmd, req)
-				reservedCh <- true // it doesn't matter if we send true or false or if the follwing waitForServer() call fails
-				s.runMutex.Unlock()
-				logger = logger.New("standin", standinServer.id)
-				logger.Debug("using existing standin")
-				var errw error
-				server, errw = standinServer.waitForServer(cmd)
-				if errw != nil || server == nil {
-					logger.Debug("giving up on standin", "err", errw)
-					return errw
-				}
-				s.runMutex.Lock()
-				logger = logger.New("server", server.ID)
-				logger.Debug("using server from standin")
-				break
-			}
-		}
+		reservedCh <- false
+		return errors.New("no available server")
 	}
-
-	// else spawn the smallest server that can run this cmd, recording our new
-	// quota usage.
-	if server == nil {
-		// *** sometimes, when we're configured to not spawn any servers, we can
-		// still manage to get here without a server due to timing issues? Guard
-		// against proceeding if we'd spawn more servers than configured
-		if s.quotaMaxInstances > -1 {
-			numServersAndStandins := numServers + len(s.standins)
-			if numServersAndStandins >= s.quotaMaxInstances {
-				s.runMutex.Unlock()
-				logger.Debug("over quota", "servers", numServersAndStandins, "max", s.quotaMaxInstances)
-				reservedCh <- false
-				return errors.New("over quota")
-			}
-		}
-
-		flavor := requestedFlavor
-		if flavor == nil {
-			var errd error
-			flavor, errd = s.determineFlavor(s.reqForSpawn(req), call)
-			if errd != nil {
-				s.runMutex.Unlock()
-				s.notifyMessage(fmt.Sprintf("OpenStack: Was unable to determine a server flavor to use for requirements %s: %s", req.Stringify(), errd))
-				reservedCh <- false
-				return errd
-			}
-		}
-		volumeAffected := req.Disk > flavor.Disk
-
-		// because spawning can take a while, we record that we're going to use
-		// up some of our quota and unlock so other things can proceed
-		s.resourceMutex.Lock()
-		s.reservedInstances++
-		s.reservedCores += flavor.Cores
-		s.reservedRAM += flavor.RAM
-		if volumeAffected {
-			s.reservedVolume += req.Disk
-		}
-		reservedCh <- true
-		s.resourceMutex.Unlock()
-
-		// later on, immediately after the spawn request goes through (and so
-		// presumably is using up quota), but before the new server powers up,
-		// drop our reserved values down or we'll end up double-counting
-		// resource usage in canCount(), since that takes in to account
-		// resources used by an in-progress spawn.
-		usingQuotaCB := func() {
-			s.resourceMutex.Lock()
-			s.reservedInstances--
-			s.reservedCores -= flavor.Cores
-			s.reservedRAM -= flavor.RAM
-			if volumeAffected {
-				s.reservedVolume -= req.Disk
-			}
-			s.resourceMutex.Unlock()
-		}
-
-		u, erru := uuid.NewV4()
-		if erru != nil {
-			s.runMutex.Unlock()
-			usingQuotaCB()
-			return erru
-		}
-		standinID := u.String()
-		standinServer := newStandin(standinID, flavor, req.Disk, requestedOS, requestedScript, requestedConfigFiles, needsSharedDisk, s.Logger)
-		standinServer.allocate(cmd, req)
-		s.recordStandin(standinServer, cmd)
-		logger = logger.New("standin", standinID)
-		logger.Debug("using new standin")
-
-		// now spawn, but don't overload the system by trying to spawn too many
-		// at once; wait until we are no longer in the middle of spawning
-		// another
-		doSpawn := true
-		if s.spawningNow || s.waitingToSpawn > 0 {
-			// before waiting to spawn, find out if we've come in here on a
-			// retry of a known failed flavor
-			s.ffMutex.RLock()
-			_, flavorAlreadyFailed := s.failedFlavors[flavor.ID]
-			s.ffMutex.RUnlock()
-
-			s.waitingToSpawn++
-			s.runMutex.Unlock()
-			done := make(chan error)
-			go func() {
-				defer internal.LogPanic(s.Logger, "runCmd", true)
-
-				for {
-					select {
-					case <-standinServer.readyToSpawn:
-						done <- nil
-						return
-					case <-standinServer.noLongerNeeded:
-						done <- errors.New(standinNotNeeded)
-						return
-					}
-				}
-			}()
-			err = <-done
-			if err != nil {
-				usingQuotaCB()
-				return err
-			}
-
-			// now that we've waited and it's our turn to spawn, check if our
-			// flavor is failed. It it wasn't failed before we started to wait,
-			// we won't waste time trying to spawn later
-			if !flavorAlreadyFailed {
-				s.ffMutex.RLock()
-				if _, currentlyFailed := s.failedFlavors[flavor.ID]; currentlyFailed {
-					doSpawn = false
-				}
-				s.ffMutex.RUnlock()
-			}
-
-			s.runMutex.Lock()
-			logger.Debug("using the standin after waiting")
-		} else {
-			s.spawningNow = true
-			standinServer.willBeUsed()
-			logger.Debug("using the standin straightaway")
-		}
-
-		var osUser string
-		if val, defined := req.Other["cloud_user"]; defined {
-			osUser = val
-		} else {
-			osUser = s.config.OSUser
-		}
-
-		if debugEffect == "slowSecondSpawn" && thisDebugCount == 3 {
-			s.runMutex.Unlock()
-			<-time.After(10 * time.Second)
-			s.runMutex.Lock()
-		}
-
-		// unlock before spawning, since we don't want to block here waiting for
-		// that to complete
-		s.runMutex.Unlock()
-
-		// spawn
-		failMsg := "server failed spawn"
-		if doSpawn {
-			logger.Debug("will spawn", "flavor", flavor.Name)
-			tSpawn := time.Now()
-			server, err = s.provider.Spawn(requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime, false, usingQuotaCB)
-			serverID := "failed"
-			if server != nil {
-				serverID = server.ID
-			}
-			logger = logger.New("server", serverID)
-			logger.Debug("spawned server", "took", time.Since(tSpawn))
-		} else {
-			logger.Debug("will not spawn, since while we waited we ran out of hardware for flavor", "flavor", flavor.Name)
-			usingQuotaCB()
-			failMsg = "skipped spawn"
-			err = errors.New("skipped spawn attempt since ran out of hardware suitable for desired flavor")
-		}
-
-		// spawn completed; if we have standins that are waiting to spawn, tell
-		// one of them to go ahead
-		s.runMutex.Lock()
-		s.spawningNow = false
-		if s.waitingToSpawn > 0 {
-			for _, otherStandinServer := range s.standins {
-				//*** we're not locking otherStandinServer to check
-				//    waitingToSpawn... is this going to be a problem?
-				if otherStandinServer.waitingToSpawn {
-					s.waitingToSpawn--
-					s.spawningNow = true
-					otherStandinServer.willBeUsed()
-					otherStandinServer.readyToSpawn <- true
-					break
-				}
-			}
-		}
-		s.eraseStandin(standinID)
-
-		// unlock again prior to waiting until the server is ready and trying to
-		// check and upload our exe, since that could take quite a long time
-		if err == nil && server != nil {
-			s.runMutex.Unlock()
-
-			// wait until boot is finished, ssh is ready and osScript has
-			// completed
-			logger.Debug("waiting for server ready")
-			failMsg = "server failed ready"
-			tReady := time.Now()
-			err = server.WaitUntilReady(requestedConfigFiles, requestedScript)
-			logger.Debug("waited for server to become ready", "took", time.Since(tReady))
-
-			if err == nil && needsSharedDisk {
-				err = server.MountSharedDisk(localhost.IP)
-			}
-
-			if err == nil {
-				failMsg = "server failed uploads"
-
-				// check that the exe of the cmd we're supposed to run exists on the
-				// new server, and if not, copy it over *** this is just a hack to
-				// get wr working, need to think of a better way of doing this...
-				exe := strings.Split(cmd, " ")[0]
-				var exePath, stdout string
-				if exePath, err = exec.LookPath(exe); err == nil {
-					if stdout, _, err = server.RunCmd("file "+exePath, false); stdout != "" {
-						if strings.Contains(stdout, "No such file") {
-							// *** NB this will fail if exePath is in a dir we can't
-							// create on the remote server, eg. if it is in our home
-							// dir, but the remote server has a different user, or
-							// presumably if it is somewhere requiring root
-							// permission
-							err = server.UploadFile(exePath, exePath)
-							if err == nil {
-								_, _, err = server.RunCmd("chmod u+x "+exePath, false)
-							} else {
-								err = fmt.Errorf("could not upload exe [%s]: %s (try putting the exe in /tmp?)", exePath, err)
-							}
-						} else if err != nil {
-							err = fmt.Errorf("could not check exe with [file %s]: %s [%s]", exePath, stdout, err)
-						}
-					} else {
-						// checking for exePath with the file command failed for
-						// some reason, and without any stdout... but let's just
-						// try the upload anyway, assuming the exe isn't there
-						err = server.UploadFile(exePath, exePath)
-						if err == nil {
-							_, _, err = server.RunCmd("chmod u+x "+exePath, false)
-						} else {
-							err = fmt.Errorf("could not upload exe [%s]: %s (try putting the exe in /tmp?)", exePath, err)
-						}
-					}
-				} else {
-					err = fmt.Errorf("could not look for exe [%s]: %s", exePath, err)
-				}
-			}
-
-			s.runMutex.Lock()
-		}
-
-		if debugEffect == "failFirstSpawn" && thisDebugCount == 1 {
-			err = errors.New("forced fail")
-		}
-
-		// handle Spawn() or upload-of-exe errors now, by destroying the server
-		// and noting we failed
-		if err != nil {
-			logger.Warn(failMsg, "err", err)
-			if server != nil {
-				errd := server.Destroy()
-				if errd != nil {
-					logger.Debug("server also failed to destroy", "err", errd)
-				}
-			} else if s.provider.ErrIsNoHardware(err) {
-				s.ffMutex.Lock()
-				s.failedFlavors[flavor.ID] = time.Now()
-				s.ffMutex.Unlock()
-				s.Warn("server failed to spawn due to lack of hardware", "flavor", flavor.Name)
-			}
-			standinServer.failed(fmt.Sprintf("New server failed to spawn correctly: %s", err))
-			s.runMutex.Unlock()
-			if doSpawn {
-				s.notifyMessage(fmt.Sprintf("OpenStack: Failed to create a usable server: %s", err))
-			}
-			return err
-		}
-
-		logger.Debug("server ready")
-		s.ffMutex.Lock()
-		if _, failed := s.failedFlavors[flavor.ID]; failed {
-			s.Debug("server successfully spawned on previously failed flavor", "flavor", flavor.Name)
-			delete(s.failedFlavors, flavor.ID)
-		}
-		s.ffMutex.Unlock()
-
-		s.serversMutex.Lock()
-		s.servers[server.ID] = server
-		s.serversMutex.Unlock()
-		needed := standinServer.worked(server) // calls server.Allocate() for everything allocated to the standin
-
-		if !needed {
-			// the server is up, but our standin is no longer needed and
-			// allocated nothing to the server, so it also called
-			// server.Release(), triggering its scale down. Or just our own cmd
-			// doesn't need to be run anymore, but other commands assigned to
-			// our standin do. In either case, we don't need to run a command
-			// any more
-			s.runMutex.Unlock()
-			return errors.New(standinNotNeeded)
-		}
-	}
-
-	s.runMutex.Unlock()
 
 	// later, after we've run the command, this server will be available for
-	// another; signal a runCmd call that is waiting its turn to spawn a new
-	// server to give up waiting and potentially get scheduled on us instead
+	// another; release resources, and local scheduler will trigger a new
+	// processQueue() call
 	defer func() {
 		if !server.Destroyed() && server.PermanentProblem() == "" {
-			s.runMutex.Lock()
 			server.Release(req.Cores, req.RAM, req.Disk)
-			if s.waitingToSpawn > 0 {
-				for _, otherStandinServer := range s.standins {
-					if otherStandinServer.isExtraneous(server) {
-						s.waitingToSpawn--
-						s.eraseStandin(otherStandinServer.id)
-						otherStandinServer.noLongerNeeded <- true
-						break
-					}
-				}
-			}
-			s.runMutex.Unlock()
 		}
 	}()
 
@@ -1496,39 +1038,6 @@ func (s *opst) runCmd(cmd string, req *Requirements, reservedCh chan bool, call 
 		logger.Warn("failed to run command", "cmd", cmd, "err", err)
 	}
 	return err
-}
-
-// cancelRun fails standins for the given cmd.
-func (s *opst) cancelRun(cmd string, desiredCount int) {
-	s.runMutex.Lock()
-	defer s.runMutex.Unlock()
-
-	currentCount := 0
-	if lookup, existed := s.cmdToStandins[cmd]; existed {
-		for standinID := range lookup {
-			if standinServer, existed := s.standins[standinID]; existed {
-				currentCount += standinServer.numAllocationsForCmd(cmd)
-				cancelCount := currentCount - desiredCount
-				if cancelCount > 0 {
-					cancelledForThisServer, empty := standinServer.cancel(cmd, cancelCount)
-
-					if empty && standinServer.failed(standinNotNeeded) {
-						s.waitingToSpawn--
-						s.eraseStandin(standinServer.id)
-						standinServer.noLongerNeeded <- true
-					}
-
-					currentCount -= cancelledForThisServer
-					if currentCount <= desiredCount {
-						break
-					}
-				}
-			} else {
-				// (this should be impossible)
-				delete(lookup, standinID)
-			}
-		}
-	}
 }
 
 // stateUpdate checks all our servers are really alive.
@@ -1585,6 +1094,20 @@ func (s *opst) stateUpdate() {
 		defer s.stateMutex.Unlock()
 		s.updatingState = false
 	}()
+}
+
+// postProcess checks that all our newly spawned servers have been used, and if
+// not, initiates the countdown to their destruction
+func (s *opst) postProcess() {
+	s.serversMutex.Lock()
+	for _, server := range s.servers {
+		if !server.Used() {
+			s.Debug("placing unused server on deathrow", "server", server.ID)
+			server.Allocate(0, 1, 1)
+			server.Release(0, 1, 1)
+		}
+	}
+	s.serversMutex.Unlock()
 }
 
 // recover achieves the aims of Recover(). Here we find the given host, and
@@ -1661,7 +1184,7 @@ func (s *opst) recover(cmd string, req *Requirements, host *RecoveredHostDetails
 						s.Debug("recovered server was destroyed after going idle")
 					}
 
-					errp := s.processQueue()
+					errp := s.processQueue("openstack recover")
 					if errp != nil {
 						s.Error("processQueue call after recovery failed", "err", errp)
 					}
@@ -1677,41 +1200,6 @@ func (s *opst) recover(cmd string, req *Requirements, host *RecoveredHostDetails
 
 	s.recoveredServers[host.Host] = true
 	return nil
-}
-
-// recordStandin stores some lookups for the given standin. Only call when you
-// have the lock!
-func (s *opst) recordStandin(standinServer *standin, cmd string) {
-	s.standins[standinServer.id] = standinServer
-
-	if lookup, existed := s.cmdToStandins[cmd]; existed {
-		lookup[standinServer.id] = true
-	} else {
-		s.cmdToStandins[cmd] = make(map[string]bool)
-		s.cmdToStandins[cmd][standinServer.id] = true
-	}
-
-	if lookup, existed := s.standinToCmd[standinServer.id]; existed {
-		lookup[cmd] = true
-	} else {
-		s.standinToCmd[standinServer.id] = make(map[string]bool)
-		s.standinToCmd[standinServer.id][cmd] = true
-	}
-}
-
-// eraseStandin deletes the various lookups for the given standin. Only call
-// when you have the lock!
-func (s *opst) eraseStandin(standinID string) {
-	for cmd := range s.standinToCmd[standinID] {
-		if lookup, existed := s.cmdToStandins[cmd]; existed {
-			delete(lookup, standinID)
-			if len(lookup) == 0 {
-				delete(s.cmdToStandins, cmd)
-			}
-		}
-	}
-	delete(s.standinToCmd, standinID)
-	delete(s.standins, standinID)
 }
 
 // hostToID does the necessary lookup to convert hostname to instance id.
@@ -1761,30 +1249,22 @@ func (s *opst) notifyBadServer(server *cloud.Server) {
 func (s *opst) cleanup() {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	s.runMutex.Lock()
-	defer s.runMutex.Unlock()
+	s.cleanMutex.Lock()
+	defer s.cleanMutex.Unlock()
+	s.spawnMutex.Lock()
+	defer s.spawnMutex.Unlock()
 	s.stateMutex.Lock()
 	defer s.stateMutex.Unlock()
+	s.serversMutex.Lock()
+	defer s.serversMutex.Unlock()
 
 	// prevent any further scheduling and queue processing, and destroy the
 	// queue
 	s.cleaned = true
-	s.stopRunning = true
 	err := s.queue.Destroy()
 	if err != nil {
 		s.Warn("cleanup queue destruction failed", "err", err)
 	}
-
-	// cancel all standins
-	for _, standinServer := range s.standins {
-		s.eraseStandin(standinServer.id)
-		if standinServer.failed(standinNotNeeded) {
-			standinServer.noLongerNeeded <- true
-		}
-	}
-	s.waitingToSpawn = 0
-	s.cmdToStandins = make(map[string]map[string]bool)
-	s.standinToCmd = make(map[string]map[string]bool)
 
 	// wait for any ongoing state update to complete
 	for {

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -997,6 +997,7 @@ func TestOpenstack(t *testing.T) {
 					<-time.After(20 * time.Second)
 
 					foundServers = novaCountServers(novaCmd, rName, "")
+					So(foundServers, ShouldEqual, 0)
 
 					// *** not really confirming that the cmds actually ran on
 					// the spawned servers

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -146,26 +146,7 @@ func TestLocal(t *testing.T) {
 				So(numfiles, ShouldEqual, maxCPU+count)
 				So(s.Busy(), ShouldBeFalse)
 			})
-
-			Convey("You can Schedule() again to drop the count", func() {
-				newcount := maxCPU + 1 // (this test only really makes sense if newcount is now less than count, ie. we have more than 1 cpu)
-
-				<-time.After(700 * time.Millisecond)
-
-				numfiles := testDirForFiles(tmpdir, maxCPU+maxCPU)
-				So(numfiles, ShouldEqual, maxCPU+maxCPU)
-
-				err = s.Schedule(cmd, possibleReq, newcount)
-				So(err, ShouldBeNil)
-
-				<-time.After(750*time.Millisecond + overhead)
-
-				numfiles = testDirForFiles(tmpdir, maxCPU+newcount)
-				So(numfiles, ShouldEqual, maxCPU+newcount)
-
-				So(waitToFinish(s, 3, 100), ShouldBeTrue)
-			})
-
+			
 			Convey("Dropping the count below the number currently running doesn't kill those that are running", func() {
 				newcount := maxCPU - 1
 
@@ -205,6 +186,25 @@ func TestLocal(t *testing.T) {
 			})
 
 			if maxCPU > 1 {
+				Convey("You can Schedule() again to drop the count", func() {
+					newcount := maxCPU + 1 // (this test only really makes sense if newcount is now less than count, ie. we have more than 1 cpu)
+	
+					<-time.After(700 * time.Millisecond)
+	
+					numfiles := testDirForFiles(tmpdir, maxCPU+maxCPU)
+					So(numfiles, ShouldEqual, maxCPU+maxCPU)
+	
+					err = s.Schedule(cmd, possibleReq, newcount)
+					So(err, ShouldBeNil)
+	
+					<-time.After(750*time.Millisecond + overhead)
+	
+					numfiles = testDirForFiles(tmpdir, maxCPU+newcount)
+					So(numfiles, ShouldEqual, maxCPU+newcount)
+	
+					So(waitToFinish(s, 3, 100), ShouldBeTrue)
+				})
+
 				Convey("You can Schedule() a new job and have it run while the first is still running", func() {
 					newcount := maxCPU + 1
 
@@ -230,6 +230,9 @@ func TestLocal(t *testing.T) {
 				//*** want a test where the first job fills up all resources
 				// and has more to do, and a second job could slip and complete
 				// before resources for the first become available
+			} else {
+				waitToFinish(s, 3, 100)
+				SkipConvey("Skipping Schedule() tests that need more than 1 cpu", func() {})
 			}
 		})
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1063,7 +1063,7 @@ func (s *Server) uploadFile(source io.Reader, savePath string) (string, error) {
 // createQueue creates and stores a queue.Queue on the Server and sets up its
 // callbacks.
 func (s *Server) createQueue() {
-	q := queue.New("cmds")
+	q := queue.New("cmds", s.Logger)
 	s.q = q
 
 	// we set a callback for things entering this queue's ready sub-queue.
@@ -2032,7 +2032,7 @@ func (s *Server) scheduleRunners(group string) {
 				problem = false
 				s.sgcmutex.Lock()
 				for {
-					item, errr := s.q.Reserve(group)
+					item, errr := s.q.Reserve(group, 0)
 					if errr != nil {
 						if qerr, ok := errr.(queue.Error); !ok || qerr.Err != queue.ErrNothingReady {
 							s.Warn("scheduleRunners failed to reserve an item", "group", group, "err", errr)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -113,13 +113,6 @@ func (e Error) Error() string {
 	return "jobqueue " + e.Op + "(" + e.Item + "): " + e.Err
 }
 
-// itemErr is used internally to implement Reserve(), which needs to send item
-// and err over a channel.
-type itemErr struct {
-	item *queue.Item
-	err  string
-}
-
 // serverResponse is the struct that the server sends to clients over the
 // network in response to their clientRequest.
 type serverResponse struct {


### PR DESCRIPTION
- Job reservations with a timeout no longer poll, but instead return the moment a job becomes available.
- OpenStack scheduler reimplemented by removing the stand-in queue.
- Fix server deathrow/allocate race condition.

New OpenStack scheduler behaviour:
- Avoids a lock-up issue where jobs would stop getting scheduled under certain circumstances.
- Quota warnings no longer appear until quota is physically used up.
- The flavor of server to spawn and the jobs to run on them are reassessed after every spawn, job completion and schedule, allowing bin-packing to do the expected thing as new jobs are scheduled over time.
- Spawned servers that are no longer needed are abandoned right away, even interrupting the ready phase.