### PR TITLE
Fix and improve limit handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,5 +90,5 @@ issues:
         - gosec
   max-issues-per-linter: 0
   max-same-issues: 0
-  new: true
+  new-from-rev: HEAD~
 

--- a/.golangci_extra.yml
+++ b/.golangci_extra.yml
@@ -41,5 +41,5 @@ issues:
         - gochecknoglobals
         - gochecknoinits
 
-  new: true
+  new-from-rev: HEAD~
 

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -292,6 +292,10 @@ type Job struct {
 	// job.
 	scheduledRunner bool
 
+	// the server uses this to track if it already ignored this job during
+	// scheduling, due to hitting a limit.
+	schedulerIgnored bool
+
 	// we store the MuxFys that we mount during Mount() so we can Unmount() them
 	// later; this is purely client side.
 	mountedFS []*muxfys.MuxFys
@@ -742,6 +746,22 @@ func (j *Job) setScheduledRunner(newval bool) {
 	j.Lock()
 	defer j.Unlock()
 	j.scheduledRunner = newval
+}
+
+// setSchedulerIgnored provides a thread-safe way of setting the
+// schedulerIgnored property of a Job.
+func (j *Job) setSchedulerIgnored(newval bool) {
+	j.Lock()
+	defer j.Unlock()
+	j.schedulerIgnored = newval
+}
+
+// getSchedulerIgnored provides a thread-safe way of getting the
+// schedulerIgnored property of a Job.
+func (j *Job) getSchedulerIgnored() bool {
+	j.RLock()
+	defer j.RUnlock()
+	return j.schedulerIgnored
 }
 
 // generateSchedulerGroup returns a stringified form of the given requirements,

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -689,10 +689,14 @@ func (j *Job) noteIncrementedLimitGroups(groups []string) {
 // updateAfterExit sets some properties on the job, only if the supplied
 // JobEndState indicates the job exited. It also calls decrementLimitGroups().
 func (j *Job) updateAfterExit(jes *JobEndState, lim *limiter.Limiter) {
+	j.decrementLimitGroups(lim)
+
 	if jes == nil || !jes.Exited {
 		return
 	}
+
 	j.Lock()
+	defer j.Unlock()
 	j.Exited = true
 	j.Exitcode = jes.Exitcode
 	j.PeakRAM = jes.PeakRAM
@@ -702,8 +706,6 @@ func (j *Job) updateAfterExit(jes *JobEndState, lim *limiter.Limiter) {
 	if jes.Cwd != "" {
 		j.ActualCwd = jes.Cwd
 	}
-	j.Unlock()
-	j.decrementLimitGroups(lim)
 }
 
 // decrementLimitGroups decrements any limit groups of this job that had been

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2962,6 +2962,18 @@ func TestJobqueueLimitGroups(t *testing.T) {
 				jobs = reserveJobs()
 				So(len(jobs), ShouldEqual, 2)
 			})
+
+			Convey("Burying jobs after reserving them does not use up the limit", func() {
+				jobs := reserveJobs()
+				So(len(jobs), ShouldEqual, 2)
+
+				jq.Bury(jobs[0], nil, "foo")
+				jq.Bury(jobs[1], nil, "foo")
+
+				<-time.After(2 * time.Second)
+				jobs = reserveJobs()
+				So(len(jobs), ShouldEqual, 2)
+			})
 		})
 
 		Reset(func() {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 	"time"
 
+	muxfys "github.com/VertebrateResequencing/muxfys/v4"
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -36,7 +36,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/VertebrateResequencing/muxfys/v4"
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
@@ -2958,7 +2957,7 @@ func TestJobqueueLimitGroups(t *testing.T) {
 				jobs := reserveJobs()
 				So(len(jobs), ShouldEqual, 2)
 
-				<-time.After(2*time.Second)
+				<-time.After(2 * time.Second)
 				jobs = reserveJobs()
 				So(len(jobs), ShouldEqual, 2)
 			})

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2843,7 +2843,7 @@ func TestJobqueueLimitGroups(t *testing.T) {
 	defer os.RemoveAll(filepath.Join(os.TempDir(), AppName+"_cwd"))
 
 	Convey("Once a new jobqueue server is up", t, func() {
-		ServerItemTTR = 5 * time.Second
+		ServerItemTTR = 1 * time.Second
 		ClientTouchInterval = 2500 * time.Millisecond
 		server, _, token, errs := serve(serverConfig)
 		So(errs, ShouldBeNil)
@@ -2952,6 +2952,15 @@ func TestJobqueueLimitGroups(t *testing.T) {
 				serr, ok := err.(Error)
 				So(ok, ShouldBeTrue)
 				So(serr.Err, ShouldEqual, ErrBadLimitGroup)
+			})
+
+			Convey("Failing to start a job after reserving it does not use up the limit", func() {
+				jobs := reserveJobs()
+				So(len(jobs), ShouldEqual, 2)
+
+				<-time.After(2*time.Second)
+				jobs = reserveJobs()
+				So(len(jobs), ShouldEqual, 2)
 			})
 		})
 

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -295,7 +295,7 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 			}
 			if count == 0 {
 				s.removeKey(key)
-				s.Debug("schedule removed job", "cmd", cmd)
+				s.Debug("schedule removed cmd", "cmd", cmd)
 			}
 			if !s.checkNeeded(cmd, key, count, running) {
 				// bypass a pointless processQueue call
@@ -307,7 +307,7 @@ func (s *local) schedule(cmd string, req *Requirements, count int) error {
 			return err
 		}
 	} else {
-		s.Debug("schedule added new job", "cmd", cmd, "needs", count)
+		s.Debug("schedule added new cmd", "cmd", cmd, "needs", count)
 	}
 	s.mutex.Unlock()
 
@@ -581,7 +581,9 @@ func (s *local) processQueue(reason string) error {
 			go func() {
 				defer internal.LogPanic(s.Logger, "processQueue runCmd loop", true)
 
+				s.Debug("will run cmd", "cmd", cmd, "call", call)
 				err := s.runCmdFunc(cmd, req, reserved, call)
+				s.Debug("ran cmd", "cmd", cmd, "call", call)
 
 				s.mutex.Lock()
 				j.Lock()
@@ -743,7 +745,6 @@ func (s *local) startAutoProcessing() {
 	go func() {
 		defer internal.LogPanic(s.Logger, "auto processQueue", false)
 
-		s.Debug("starting auto processing", "frequency", s.stateUpdateFreq)
 		ticker := time.NewTicker(s.stateUpdateFreq)
 		for {
 			select {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1514,6 +1514,7 @@ func (s *Server) createQueue() {
 		}
 
 		job.Unlock()
+		job.decrementLimitGroups(s.limiter)
 		return queue.SubQueueDelay
 	})
 }

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func BenchmarkLimiter(b *testing.B) {
+func BenchmarkLimiterIncDec(b *testing.B) {
 	limits := make(map[string]int)
 	limits["l1"] = 5
 	limits["l2"] = 6
@@ -37,43 +37,76 @@ func BenchmarkLimiter(b *testing.B) {
 		}
 		return -1
 	}
+	both := []string{"l1", "l2"}
+	first := []string{"l1"}
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
 		l := New(cb)
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Increment([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
-		l.Decrement([]string{"l1", "l2"})
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Increment(both)
+		l.Decrement(both)
+		l.Decrement(both)
+		l.Decrement(both)
+		l.Decrement(both)
+		l.Decrement(both)
+		l.Decrement(both)
 
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Increment([]string{"l1"})
-		l.Decrement([]string{"l1"})
-		l.Decrement([]string{"l1"})
-		l.Decrement([]string{"l1"})
-		l.Decrement([]string{"l1"})
-		l.Decrement([]string{"l1"})
-		l.Decrement([]string{"l1"})
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Increment(first)
+		l.Decrement(first)
+		l.Decrement(first)
+		l.Decrement(first)
+		l.Decrement(first)
+		l.Decrement(first)
+		l.Decrement(first)
+	}
+}
+func BenchmarkLimiterCapacity(b *testing.B) {
+	limits := make(map[string]int)
+	limits["l1"] = 5
+	limits["l2"] = 6
+	cb := func(name string) int {
+		if limit, exists := limits[name]; exists {
+			return limit
+		}
+		return -1
+	}
+	both := []string{"l1", "l2"}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		l := New(cb)
+		for {
+			l.Increment(both)
+			cap := l.GetRemainingCapacity(both)
+			if cap == 0 {
+				break
+			}
+		}
+		for {
+			l.Decrement(both)
+			cap := l.GetRemainingCapacity(both)
+			if cap == 5 {
+				break
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Fix edge cases where limits could be reached and never drop, stalling workflows
- Have runners wait for limits to drop before exiting
- Avoid scheduling jobs if the limit has been reached
- Fix delay in scheduling jobs with different scheduler groups which are at the same limit
- General fix to ensure scheduling is always triggered after a while of doing nothing