### PR TITLE
Limit the number of zero cores jobs run

### DIFF
--- a/cloud/server.go
+++ b/cloud/server.go
@@ -43,7 +43,6 @@ import (
 
 const sharePath = "/shared" // mount point for the *SharedDisk methods
 const sshShortTimeOut = 5 * time.Second
-const maxZeroCoreJobs = 1000000 // the maxmimum number of jobs a server has space for when cores request is 0
 
 // maxSSHSessions is the maximum number of sessions we will try and multiplex on
 // each ssh client we make for a server. It doesn't matter if this is lower than
@@ -327,7 +326,10 @@ func (s *Server) HasSpaceFor(cores float64, ramMB, diskGB int) int {
 	if cores > 0 {
 		canDo = int(math.Floor(internal.FloatSubtract(float64(s.Flavor.Cores), s.usedCores) / cores))
 	} else {
-		canDo = maxZeroCoreJobs
+		// rather than an infinite or very large value, we say double the
+		// core count because there are still real limits on the number of
+		// processes we can run at once before things start falling over
+		canDo = s.Flavor.Cores * 2
 	}
 	if canDo > 1 {
 		var n int


### PR DESCRIPTION
When running too many zero core jobs, strange things with being unable to fork can occur.

Limit the number of zero core jobs to 2x physical cores in the machine. This is on top of the normal limit for non-zero core jobs, so we can still run lots of zero core jobs when running a job that uses all cpus.

Also try and avoid locking up when sending on the reserved channel during scheduling.