### PR TITLE
LSF Fixes

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -212,10 +212,9 @@ requirements of the job.
 
 "misc" will be used as-is to form the command line used to submit jobs to
 external job schedulers (eg. LSF). For example, --misc '-R avx' might result
-in a command line containing: bsub -R avx. If possible, avoid including single
-or double quotes within the value passed to --misc, as these cause quoting
-issues and will be ignored. The exception to this is when using the LSF
-scheduler you can say --misc '-R "multiple things"' and it will work.
+in a command line containing: bsub -R avx. To avoid quoting issues, surround
+the --misc value in single quotes and if necessary use double quotes within the
+value; do NOT use single quotes within the value. Eg. --misc '-R "foo bar"'.
 
 "priority" defines how urgent a particular command is; those with higher
 priorities will start running before those with lower priorities. The range of

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3586,7 +3586,7 @@ func TestJobqueueHighMem(t *testing.T) {
 			defer disconnect(jq2)
 
 			var jobs []*Job
-			cmd := "perl -e '@a; for (1..1000) { push(@a, q[a] x 8000000000) }'"
+			cmd := "perl -e '@a; for (1..1000) { push(@a, q[a] x 800000000) }'"
 			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: standardReqs, Retries: uint8(0), RepGroup: "run_out_of_mem"})
 			RecMBRound = 1
 			defer func() {

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -504,8 +504,9 @@ func (s *lsf) generateBsubArgs(queue string, req *Requirements, cmd string, need
 		switch {
 		case len(parts) == 2:
 			bsubArgs = append(bsubArgs, "-R", parts[1])
-		case !strings.Contains(val, `"`):
-			bsubArgs = append(bsubArgs, val)
+		case !strings.Contains(val, `"`) && !strings.Contains(val, `'`):
+			parts = strings.Fields(val)
+			bsubArgs = append(bsubArgs, parts...)
 		default:
 			// *** not sure how to handle any arbitrary value supplied, since
 			// we'd have to split flag from value in to separate list elements

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -728,7 +728,7 @@ func (s *lsf) parseBjobs(jobPrefix string, callback bjobsCB) error {
 		fields := strings.Fields(line)
 
 		if len(fields) > 7 {
-			if fields[2] == "EXIT" || fields[2] == "DONE" {
+			if fields[2] == "EXIT" || fields[2] == "DONE" || !strings.HasPrefix(fields[6], jobPrefix) {
 				continue
 			}
 			callback(fields[0], fields[2], fields[6])

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -691,9 +691,9 @@ func (s *lsf) checkCmd(cmd string, max int) (count int, err error) {
 
 		if len(toKill) > 1 {
 			killcmd := exec.Command(s.bkillExe, toKill...) // #nosec
-			errk := killcmd.Run()
-			if errk != nil {
-				s.Warn("checkCmd bkill failed", "err", errk)
+			out, errk := killcmd.CombinedOutput()
+			if errk != nil && !strings.HasPrefix(string(out), "Job has already finished") {
+				s.Warn("checkCmd bkill failed", "cmd", s.bkillExe, "toKill", toKill, "err", errk, "out", string(out))
 			}
 		}
 	} else {


### PR DESCRIPTION
* Fixes `bjobs` parsing for compatibility with LSF 10.1.0.0
* Fixes queue analysis for compatibility with bmgroups
* Allows anything but single quotes to be passed through as `bsub` args via the `--misc` option