### PR TITLE
Deadlock fixes and improved debugging

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,5 +91,5 @@ issues:
         - gosec
   max-issues-per-linter: 0
   max-same-issues: 0
-  new-from-rev: HEAD~
+  new-from-rev: master
 

--- a/.golangci_extra.yml
+++ b/.golangci_extra.yml
@@ -41,5 +41,5 @@ issues:
         - gochecknoglobals
         - gochecknoinits
 
-  new-from-rev: HEAD~
+  new-from-rev: master
 

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -80,8 +80,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/gofrs/uuid"

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -31,8 +31,9 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VividCortex/ewma"

--- a/cloud/server.go
+++ b/cloud/server.go
@@ -32,8 +32,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/inconshreveable/log15"

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -22,7 +22,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	sync "github.com/sasha-s/go-deadlock"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,6 +30,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
@@ -713,7 +714,6 @@ func startJQ(postCreation []byte) {
 	sync.Opts.LogBuf = deadlockBuf
 	sync.Opts.OnPotentialDeadlock = func() {
 		serverLogger.Crit("deadlock", "err", deadlockBuf.String())
-		os.Exit(2)
 	}
 
 	// start the jobqueue server

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -712,6 +712,7 @@ func startJQ(postCreation []byte) {
 
 	deadlockBuf := new(bytes.Buffer)
 	sync.Opts.LogBuf = deadlockBuf
+	sync.Opts.DeadlockTimeout = 5 * time.Minute
 	sync.Opts.OnPotentialDeadlock = func() {
 		serverLogger.Crit("deadlock", "err", deadlockBuf.String())
 	}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/sftp v1.10.1
 	github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f
+	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa
 	github.com/sb10/l15h v0.0.0-20170510122137-64c488bf8e22
 	github.com/sevlyar/go-daemon v0.1.5
 	github.com/shirou/gopsutil v2.19.9+incompatible
@@ -77,5 +78,7 @@ replace k8s.io/client-go => k8s.io/client-go v7.0.0+incompatible
 replace github.com/grafov/bcast => github.com/grafov/bcast v0.0.0-20161019100130-e9affb593f6c
 
 replace github.com/sevlyar/go-daemon => github.com/sevlyar/go-daemon v0.1.1-0.20160925164401-01bb5caedcc4
+
+replace sync => github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // doesn't work?
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/opencontainers/image-spec v0.0.0-20180411145040-e562b0440392/go.mod h
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1 h1:VasscCm72135zRysgrJDKsntdmPN+OuU3+nnHYA9wyc=
@@ -210,6 +212,10 @@ github.com/ricochet2200/go-disk-usage v0.0.0-20150921141558-f0d1b743428f/go.mod 
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sasha-s/go-deadlock v0.2.0 h1:lMqc+fUb7RrFS3gQLtoQsJ7/6TV/pAIFvBsqX73DK8Y=
+github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
+github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa h1:0U2s5loxrTy6/VgfVoLuVLFJcURKLH49ie0zSch7gh4=
+github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/sb10/l15h v0.0.0-20170510122137-64c488bf8e22 h1:1ECjRVBhG3NLRKTbvZ07fIQ5BiLnZFc3qLxqM6H6Rn8=
 github.com/sb10/l15h v0.0.0-20170510122137-64c488bf8e22/go.mod h1:s4RlXXC/L+BTwtp3zv5UREYJOftKFBWLsUCILdaMYeU=
 github.com/sevlyar/go-daemon v0.1.1-0.20160925164401-01bb5caedcc4 h1:H+i94rakdHPRJP3BbJNOarQOn3fl9VQyRDirwQlSBN4=

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -34,7 +34,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"time"
 
 	"github.com/VertebrateResequencing/muxfys/v4"

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -34,8 +34,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/muxfys/v4"
 	"github.com/VertebrateResequencing/wr/internal"

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -26,7 +26,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"sync/atomic"
 	"syscall"
 	"time"

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -26,10 +26,11 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/muxfys/v4"
 	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -32,10 +32,11 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	muxfys "github.com/VertebrateResequencing/muxfys/v4"
 	"github.com/VertebrateResequencing/wr/cloud"

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3061,6 +3061,7 @@ func TestJobqueueModify(t *testing.T) {
 		}
 
 		reserve := func(schedStr, expected string) *Job {
+			_, _, line, _ := runtime.Caller(1)
 			job, errr := jq.ReserveScheduled(rtime, schedStr)
 			So(errr, ShouldBeNil)
 			if job == nil && schedStr == learnedRgroup {
@@ -3073,16 +3074,18 @@ func TestJobqueueModify(t *testing.T) {
 					job, errr = jq.ReserveScheduled(rtime, "400:30:1:0")
 					So(errr, ShouldBeNil)
 				}
-
-				if job == nil {
-					schedDetails := server.schedulerGroupDetails()
-					if len(schedDetails) > 0 {
-						fmt.Printf("\nschedgrp %s not found, we have:\n", schedStr)
-						for _, val := range schedDetails {
-							fmt.Printf(" - %s\n", val)
-						}
+			}
+			if job == nil {
+				schedDetails := server.schedulerGroupDetails()
+				if len(schedDetails) > 0 {
+					fmt.Printf("\nschedgrp %s not found, we have:\n", schedStr)
+					for _, val := range schedDetails {
+						fmt.Printf(" - %s\n", val)
 					}
+				} else {
+					fmt.Printf("\nschedgrp %s not found, and nothing in the scheduler.\n", schedStr)
 				}
+				fmt.Printf(" *** test from line %d failed\n", line)
 			}
 			So(job, ShouldNotBeNil)
 			So(job.Cmd, ShouldEqual, expected)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -71,6 +71,8 @@ func init() {
 	h := l15h.CallerInfoHandler(log15.StderrHandler)
 	testLogger.SetHandler(log15.LvlFilterHandler(log15.LvlWarn, h))
 
+	sync.Opts.DeadlockTimeout = 2 * time.Minute
+
 	flag.BoolVar(&runnermode, "runnermode", false, "enable to disable tests and act as a 'runner' client")
 	flag.BoolVar(&runnerfail, "runnerfail", false, "make the runner client fail")
 	flag.BoolVar(&runnerdebug, "runnerdebug", false, "make the runner create debug files")

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -23,13 +23,13 @@ package scheduler
 // may not be very efficient with the machine's resources.
 
 import (
+	sync "github.com/sasha-s/go-deadlock"
 	"math"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -23,7 +23,6 @@ package scheduler
 // may not be very efficient with the machine's resources.
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
 	"math"
 	"os"
 	"os/exec"
@@ -32,6 +31,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/queue"

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -29,8 +29,9 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"

--- a/jobqueue/scheduler/scheduler.go
+++ b/jobqueue/scheduler/scheduler.go
@@ -44,8 +44,9 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -31,9 +31,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/inconshreveable/log15"
 	. "github.com/smartystreets/goconvey/convey"

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -36,10 +36,11 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	sync "github.com/sasha-s/go-deadlock"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
@@ -1122,8 +1123,6 @@ func (s *Server) createQueue() {
 	q.SetReadyAddedCallback(func(queuename string, allitemdata []interface{}) {
 		defer internal.LogPanic(s.Logger, "jobqueue ready added callback", true)
 
-		s.Debug("SetReadyAddedCallback called", "items", len(allitemdata))
-
 		s.ssmutex.RLock()
 		if s.drain || !s.up {
 			s.ssmutex.RUnlock()
@@ -1412,7 +1411,6 @@ func (s *Server) createQueue() {
 				go func(group string) {
 					defer internal.LogPanic(s.Logger, "jobqueue schedule runners", true)
 					defer s.wg.Done()
-					s.Debug("calling scheduleRunners", "group", group, "count", countIncRunning)
 					s.scheduleRunners(group)
 				}(group)
 			}
@@ -1450,7 +1448,6 @@ func (s *Server) createQueue() {
 
 					if stats.Ready > 0 {
 						s.racmutex.Unlock()
-						s.Debug("forcing a TriggerReadyAddedCallback just in case")
 						q.TriggerReadyAddedCallback()
 					} else {
 						s.racmutex.Unlock()
@@ -2150,7 +2147,6 @@ func (s *Server) scheduleRunners(group string) {
 	s.sgcmutex.Unlock()
 
 	if !doClear {
-		s.Debug("scheduleRunners will Schedule", "group", group, "count", groupCount)
 		err := s.scheduler.Schedule(fmt.Sprintf(rc, group, s.ServerInfo.Deployment, s.ServerInfo.Addr, s.ServerInfo.Host, s.scheduler.ReserveTimeout(req), int(s.scheduler.MaxQueueTime(req).Minutes())), req, priority, groupCount)
 		if err != nil {
 			problem := true

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -189,7 +189,7 @@ func (s *Server) handleRequest(m *mangos.Message) error {
 				// don't proceed when we're expecting new/changed items
 				s.rpmutex.Lock()
 				var wch chan struct{}
-				if s.racPending {
+				if s.racPending || s.racRunning {
 					wch = make(chan struct{})
 					s.waitingReserves = append(s.waitingReserves, wch)
 				}

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -23,7 +23,7 @@ package jobqueue
 import (
 	"net/http"
 	"strings"
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/queue"

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -23,6 +23,7 @@ package jobqueue
 import (
 	"net/http"
 	"strings"
+
 	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/VertebrateResequencing/wr/internal"

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -22,7 +22,7 @@ package limiter
 // package, the Limiter.
 
 import (
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"time"
 )
 

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -22,8 +22,9 @@ package limiter
 // package, the Limiter.
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 // SetLimitCallback is provided to New(). Your function should take the name of

--- a/limiter/limiter_test.go
+++ b/limiter/limiter_test.go
@@ -19,10 +19,11 @@
 package limiter
 
 import (
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/queue/bury_queue.go
+++ b/queue/bury_queue.go
@@ -22,7 +22,7 @@ package queue
 // removing items
 
 import (
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 type buryQueue struct {

--- a/queue/dependency_queue.go
+++ b/queue/dependency_queue.go
@@ -26,7 +26,7 @@ package queue
 // duplication...
 
 import (
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 type depQueue struct {

--- a/queue/item.go
+++ b/queue/item.go
@@ -23,8 +23,9 @@ package queue
 // This file implements the items that are added to queues.
 
 import (
-	sync "github.com/sasha-s/go-deadlock"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 // ItemState is how we describe the possible item states.

--- a/queue/item.go
+++ b/queue/item.go
@@ -23,7 +23,7 @@ package queue
 // This file implements the items that are added to queues.
 
 import (
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"time"
 )
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -86,7 +86,7 @@ package queue
 
 import (
 	"errors"
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -287,6 +287,7 @@ func (queue *Queue) readyAdded() {
 				}
 			}
 			queue.mutex.RUnlock()
+			queue.Debug("new ready items, triggering callback")
 			queue.readyAddedCb(queue.Name, data)
 
 			queue.readyAddedCbMutex.Lock()

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -86,8 +86,9 @@ package queue
 
 import (
 	"errors"
-	sync "github.com/sasha-s/go-deadlock"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/inconshreveable/log15"
 )

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"sync"
 	"testing"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/queue/subqueue.go
+++ b/queue/subqueue.go
@@ -23,7 +23,7 @@ package queue
 
 import (
 	"container/heap"
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 	"time"
 
 	"github.com/inconshreveable/log15"

--- a/queue/subqueue.go
+++ b/queue/subqueue.go
@@ -23,8 +23,9 @@ package queue
 
 import (
 	"container/heap"
-	sync "github.com/sasha-s/go-deadlock"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"

--- a/queue/subqueue.go
+++ b/queue/subqueue.go
@@ -270,13 +270,21 @@ func (q *subQueue) Swap(i, j int) {
 	} else {
 		itemList = q.items
 	}
+
 	itemList[i], itemList[j] = itemList[j], itemList[i]
-	itemList[i].mutex.Lock()
-	defer itemList[i].mutex.Unlock()
-	if i != j {
-		itemList[j].mutex.Lock()
-		defer itemList[j].mutex.Unlock()
+	lockFirst := i
+	lockSecond := j
+	if itemList[i].iid > itemList[j].iid {
+		lockFirst = j
+		lockSecond = i
 	}
+	itemList[lockFirst].mutex.Lock()
+	defer itemList[lockFirst].mutex.Unlock()
+	if i != j {
+		itemList[lockSecond].mutex.Lock()
+		defer itemList[lockSecond].mutex.Unlock()
+	}
+
 	itemList[i].queueIndexes[q.sqIndex] = i
 	itemList[j].queueIndexes[q.sqIndex] = j
 }

--- a/rp/protector.go
+++ b/rp/protector.go
@@ -22,8 +22,9 @@ package rp
 // the Protector.
 
 import (
-	"sync"
 	"time"
+
+	sync "github.com/sasha-s/go-deadlock"
 
 	"github.com/gofrs/uuid"
 )

--- a/rp/request.go
+++ b/rp/request.go
@@ -21,7 +21,7 @@ package rp
 // This file contains the implementation of request and Receipt.
 
 import (
-	"sync"
+	sync "github.com/sasha-s/go-deadlock"
 )
 
 // Receipt is the unique id of a request


### PR DESCRIPTION
Switch to using `github.com/sasha-s/go-deadlock` in place of `sync`, to be able to debug deadlocks in production.

Various fixes to actual and possible deadlock issues found as a result of using `go-deadlock` during tests.