### PR TITLE
Simple outputs for add and status to ease working with other tools

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -84,7 +84,10 @@ name to just the first letter, eg. -o c):
     (and you are told how many are not being displayed). A limit of 0 turns off
     grouping and shows all your desired commands individually, but you could hit
     a timeout if retrieving the details of very many (tens of thousands+)
-    commands.
+	commands.
+  "plain" outputs 2 tab separated columns: internal job id and current state of
+	that job. Possible states are: delayed, ready, reserved, running, lost,
+	buried, complete. If any jobs are buried, exits non-0 as well.
   "json" simply dumps the complete details of every job out as an array of
     JSON objects. The properties of the JSON objects are described in the
     documentation for wr's REST API.`,
@@ -138,6 +141,18 @@ name to just the first letter, eg. -o c):
 				}
 			}
 			fmt.Printf("complete: %d\nrunning: %d\nready: %d\ndependent: %d\nlost contact: %d\ndelayed: %d\nburied: %d\n", c, ru, re, dep, l, d, b)
+		case "plain", "p":
+			buried := false
+			for _, job := range jobs {
+				fmt.Printf("%s\t%s\n", job.Key(), job.State)
+				if job.State == jobqueue.JobStateBuried {
+					buried = true
+				}
+			}
+			if buried {
+				os.Exit(1)
+			}
+			os.Exit(0)
 		case "summary", "s":
 			counts := make(map[string]map[jobqueue.JobState]int)
 			buried := make(map[string]map[string][]string)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -808,6 +808,22 @@ func TestJobqueueBasics(t *testing.T) {
 
 		server.rc = serverRC // ReserveScheduled() only works if we have an rc
 
+		Convey("You can connect to the server and add jobs and get back their IDs", func() {
+			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+			So(err, ShouldBeNil)
+			defer disconnect(jq)
+
+			var jobs []*Job
+			req := &jqs.Requirements{RAM: 10, Time: 1 * time.Second, Cores: 1}
+			jobs = append(jobs, &Job{Cmd: "echo 1", Cwd: "/tmp", ReqGroup: "fake_group", Requirements: req, Retries: uint8(0), RepGroup: "test"})
+			jobs = append(jobs, &Job{Cmd: "echo 2", Cwd: "/tmp", ReqGroup: "fake_group", Requirements: req, Retries: uint8(0), RepGroup: "test"})
+			ids, err := jq.AddAndReturnIDs(jobs, envVars, true)
+			So(err, ShouldBeNil)
+			So(len(ids), ShouldEqual, 2)
+			So(ids[0], ShouldEqual, "9a456dee1e351f82e3d562769c27d803")
+			So(ids[1], ShouldEqual, "2bb7055e49e21ea85066899a5ba38d8e")
+		})
+
 		Convey("You can connect to the server and add jobs to the queue", func() {
 			jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 			So(err, ShouldBeNil)

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -173,7 +173,16 @@ func (s *Server) handleRequest(m *mangos.Message) error {
 						qerr = err.Error()
 					} else {
 						s.Debug("added jobs", "new", added, "dups", dups, "complete", alreadyComplete)
-						sr = &serverResponse{Added: added, Existed: dups + alreadyComplete}
+						if cr.ReturnIDs {
+							jobs := s.inputToQueuedJobs(cr.Jobs)
+							var ids []string
+							for _, job := range jobs {
+								ids = append(ids, job.Key())
+							}
+							sr = &serverResponse{Added: added, Existed: dups + alreadyComplete, AddedIDs: ids}
+						} else {
+							sr = &serverResponse{Added: added, Existed: dups + alreadyComplete}
+						}
 					}
 				}
 			}

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -786,20 +786,7 @@ func restJobsAdd(r *http.Request, s *Server) ([]*Job, int, error) {
 	}
 
 	// see which of the inputJobs are now actually in the queue
-	// *** queue.AddMany doesn't currently return which jobs were added and
-	// which were dups, and server.createJobs doesn't know which were ignored
-	// due to being incomplete, so we do this loop even though it's probably
-	// slow and wasteful?...
-	var jobs []*Job
-	for _, job := range inputJobs {
-		item, qerr := s.q.Get(job.Key())
-		if qerr == nil && item != nil {
-			// append the q's version of the job, not the input job, since the
-			// job may have been a duplicate and we want to return its current
-			// state
-			jobs = append(jobs, s.itemToJob(item, false, false))
-		}
-	}
+	jobs := s.inputToQueuedJobs(inputJobs)
 
 	return jobs, http.StatusCreated, err
 }


### PR DESCRIPTION
Things like Cromwell can interact with wr more easily if `wr add` returns an internal id, and `wr status` just returns a state for a given id.

These things are now implemented like:

```
wr add [...] -s
1289fe328e92de37f37acdccac4f33ec

wr status -i 1289fe328e92de37f37acdccac4f33ec -y -o p
1289fe328e92de37f37acdccac4f33ec	running
```