### PR TITLE
Fix database deadlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - GO111MODULE=on
 go:
-  - "1.14"
+  - "1.14.3"
 go_import_path: github.com/VertebrateResequencing/wr
 install:
   - "go mod verify"

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ compile_k8s_tmp: /tmp/wr
 
 test: export CGO_ENABLED = 0
 test:
-	@go test -p 1 -tags netgo -timeout 20m --count 1 ./
 	@go test -p 1 -tags netgo -timeout 20m --count 1 ${PKG_LIST}
 
 test-e2e: compile_k8s_tmp ## Run E2E tests. E2E tests may be destructive. Requires working Kubernetes cluster and a Kubeconfig file.

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,13 @@ test-k8s-unit: compile_k8s_tmp ## Run the unit and integration tests for the kub
 
 race: export CGO_ENABLED = 1
 race:
-	# *** -gcflags=all=-d=checkptr=0 is temporarily required until bbolt is fixed (<=1.3.3 has unsafe pointer usage)
 	go test -p 1 -tags netgo -race --count 1 ./
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 ./queue
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 -timeout 30m ./jobqueue
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 -timeout 40m ./jobqueue/scheduler
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 -timeout 40m ./cloud
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 ./rp
-	go test -p 1 -tags netgo -race --count 1 -gcflags=all=-d=checkptr=0 ./limiter
+	go test -p 1 -tags netgo -race --count 1 ./queue
+	go test -p 1 -tags netgo -race --count 1 -timeout 30m ./jobqueue
+	go test -p 1 -tags netgo -race --count 1 -timeout 40m ./jobqueue/scheduler
+	go test -p 1 -tags netgo -race --count 1 -timeout 40m ./cloud
+	go test -p 1 -tags netgo -race --count 1 ./rp
+	go test -p 1 -tags netgo -race --count 1 ./limiter
 
 # curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
 lint:

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ you can instead replace `make` above with:
 
 Usage instructions
 ------------------
-The download .zip should contain the wr executable, this README.md, a
-CHANGELOG.md and an example config file called wr_config.yml, which details all
-the config options available. The main things you need to know are:
+The download .zip should contain the wr executable, this README.md, and a
+CHANGELOG.md. Running `wr conf --default` will print an example config file
+which details all the config options available. The main things you need to
+know are:
 
 * You can use the wr executable directly from where you extracted it, or
   move it to where you normally install software to.

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -849,8 +849,10 @@ func (p *Provider) TearDown() error {
 }
 
 // saveResources saves our resources to our savePath, overwriting any existing
-// content. This is not thread safe!
+// content.
 func (p *Provider) saveResources() error {
+	p.Lock()
+	defer p.Unlock()
 	file, err := os.OpenFile(p.savePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
@@ -858,8 +860,6 @@ func (p *Provider) saveResources() error {
 	defer internal.LogClose(p.Logger, file, "resource file", "path", p.savePath)
 
 	encoder := gob.NewEncoder(file)
-	p.RLock()
-	defer p.RUnlock()
 	return encoder.Encode(p.resources)
 }
 

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -1062,7 +1062,6 @@ func (p *openstackp) tearDown(resources *Resources) error {
 
 	// delete servers, except for ourselves
 	var toDestroy []string
-	t := time.Now()
 	pager := servers.List(p.computeClient, servers.ListOpts{})
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		serverList, err := servers.ExtractServers(page)
@@ -1110,7 +1109,7 @@ func (p *openstackp) tearDown(resources *Resources) error {
 				// fully terminated yet
 				tries := 0
 				for {
-					t = time.Now()
+					t := time.Now()
 					_, errr := routers.RemoveInterface(p.networkClient, id, routers.RemoveInterfaceOpts{SubnetID: subnetid}).Extract()
 					p.Debug("remove router interface", "time", time.Since(t), "routerid", id, "subnetid", subnetid, "err", errr)
 					if errr != nil {
@@ -1125,7 +1124,7 @@ func (p *openstackp) tearDown(resources *Resources) error {
 					break
 				}
 			}
-			t = time.Now()
+			t := time.Now()
 			err := routers.Delete(p.networkClient, id).ExtractErr()
 			p.Debug("delete router", "time", time.Since(t), "id", id, "err", err)
 			merr = p.combineError(merr, err)
@@ -1133,7 +1132,7 @@ func (p *openstackp) tearDown(resources *Resources) error {
 
 		// delete network (and its subnet)
 		if id := resources.Details["network"]; id != "" {
-			t = time.Now()
+			t := time.Now()
 			err := networks.Delete(p.networkClient, id).ExtractErr()
 			p.Debug("delete network (auto-deletes subnet)", "time", time.Since(t), "id", id, "err", err)
 			merr = p.combineError(merr, err)
@@ -1141,7 +1140,7 @@ func (p *openstackp) tearDown(resources *Resources) error {
 
 		// delete secgroup
 		if id := resources.Details["secgroup"]; id != "" {
-			t = time.Now()
+			t := time.Now()
 			err := secgroups.Delete(p.computeClient, id).ExtractErr()
 			p.Debug("delete security group", "time", time.Since(t), "id", id, "err", err)
 			merr = p.combineError(merr, err)
@@ -1154,7 +1153,7 @@ func (p *openstackp) tearDown(resources *Resources) error {
 	// we definitely created the key pair this session
 	if id := resources.Details["keypair"]; id != "" {
 		if p.createdKeyPair || p.ownName == "" || (p.securityGroup != "" && p.securityGroup != id) {
-			t = time.Now()
+			t := time.Now()
 			err := keypairs.Delete(p.computeClient, id).ExtractErr()
 			p.Debug("delete keypair", "time", time.Since(t), "id", id, "err", err)
 			merr = p.combineError(merr, err)

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -1072,7 +1072,6 @@ func (p *openstackp) tearDown(resources *Resources) error {
 		for _, server := range serverList {
 			if p.ownName != server.Name && strings.HasPrefix(server.Name, resources.ResourceName) {
 				toDestroy = append(toDestroy, server.ID)
-
 			}
 		}
 

--- a/cmd/conf.go
+++ b/cmd/conf.go
@@ -617,7 +617,7 @@ deployments where wr itself creates compute nodes, a config file will be created
 on new nodes automatically.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if confDefault {
-			fmt.Printf(defaultYML)
+			fmt.Print(defaultYML)
 			os.Exit(0)
 		}
 

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -693,7 +693,7 @@ func startJQ(postCreation []byte) {
 			// work
 			provider, errc := cloud.New(scheduler, cloudResourceName(localUsername), filepath.Join(config.ManagerDir, "cloud_resources."+scheduler), appLogger)
 			if errc != nil {
-				die("cloud not connect to %s: %s", scheduler, errc)
+				die("could not connect to %s: %s", scheduler, errc)
 			}
 			if !provider.InCloud() {
 				die("according to hostname, this is not an instance in %s", scheduler)

--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -712,13 +712,20 @@ func startJQ(postCreation []byte) {
 		runnerCmd += " --debug"
 	}
 
+	var wgDebug strings.Builder
 	deadlockBuf := new(bytes.Buffer)
 	sync.Opts.LogBuf = deadlockBuf
 	sync.Opts.DeadlockTimeout = deadlockTimeout
 	sync.Opts.OnPotentialDeadlock = func() {
+		wgMsg := wgDebug.String()
+		if wgMsg != "" {
+			serverLogger.Warn("waitgroups waiting", "msgs", wgMsg)
+			wgDebug.Reset()
+		}
 		serverLogger.Crit("deadlock", "err", deadlockBuf.String())
 	}
-	waitgroup.Opts.Disable = true
+	waitgroup.Opts.Logger = &wgDebug
+	waitgroup.Opts.Disable = false
 
 	// start the jobqueue server
 	server, msg, token, err := jobqueue.Serve(jobqueue.ServerConfig{
@@ -755,6 +762,12 @@ func startJQ(postCreation []byte) {
 
 	// block forever while the jobqueue does its work
 	err = server.Block()
+
+	wgMsg := wgDebug.String()
+	if wgMsg != "" {
+		serverLogger.Warn("waitgroups waiting", "msgs", wgMsg)
+	}
+
 	if err != nil {
 		saddr := sAddr(server.ServerInfo)
 		jqerr, ok := err.(jobqueue.Error)

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ugorji/go/codec v1.1.7
-	go.etcd.io/bbolt v1.3.3
+	go.etcd.io/bbolt v1.3.4
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.4 h1:hi1bXHMVrlQh6WwxAy+qZCV/SYIlqo+Ushwdpa4tAKg=
+go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -455,6 +457,7 @@ golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=

--- a/internal/config.go
+++ b/internal/config.go
@@ -250,8 +250,8 @@ func ConfigLoad(deployment string, useparentdir bool, logger log15.Logger) Confi
 	// advantage of configor.Load() being able to take all env vars and config
 	// files at once. We do it repeatedly and merge results instead
 	config := &Config{}
-	if err := defaults.Set(config); err != nil {
-		logger.Error(err.Error())
+	if cerr := defaults.Set(config); cerr != nil {
+		logger.Error(cerr.Error())
 		os.Exit(1)
 	}
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -51,6 +51,8 @@ const (
 
 	// ConfigSourceDefault is a config value source
 	ConfigSourceDefault = "default"
+
+	sourcesProperty = "sources"
 )
 
 // Config holds the configuration options for jobqueue server and client
@@ -109,7 +111,7 @@ func (c *Config) merge(new *Config, source string) {
 
 	for i := 0; i < v.NumField(); i++ {
 		property := typeOfC.Field(i).Name
-		if property == "sources" {
+		if property == sourcesProperty {
 			continue
 		}
 
@@ -137,7 +139,7 @@ func (c *Config) clone() *Config {
 	typeOfC := v.Type()
 	for i := 0; i < v.NumField(); i++ {
 		property := typeOfC.Field(i).Name
-		if property == "sources" {
+		if property == sourcesProperty {
 			continue
 		}
 
@@ -183,7 +185,7 @@ func (c Config) String() string {
 
 	for i := 0; i < v.NumField(); i++ {
 		property := typeOfC.Field(i).Name
-		if property == "sources" {
+		if property == sourcesProperty {
 			continue
 		}
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1006,7 +1006,7 @@ func (c *Client) Execute(job *Job, shell string) error {
 			case <-resourceTicker.C:
 				// always see if we've run out of disk space on the machine, in
 				// which case abort
-				if internal.NoDiskSpaceLeft(filepath.Dir(job.Cwd)) {
+				if internal.NoDiskSpaceLeft(job.Cwd) {
 					killErr = killCmd()
 					stateMutex.Lock()
 					ranoutDisk = true

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -984,7 +984,6 @@ func (c *Client) Execute(job *Job, shell string) error {
 			stateMutex.Lock()
 			killCalled = true
 			stateMutex.Unlock()
-			closeReaders()
 		}
 		wkbsMutex.Unlock()
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1088,6 +1088,7 @@ func (c *Client) Execute(job *Job, shell string) error {
 				}
 				stateMutex.Unlock()
 			case <-stopChecking:
+				closeReaders()
 				break CHECKING
 			}
 		}

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -1075,7 +1075,6 @@ func (db *db) updateJobAfterChange(job *Job) {
 	wgk := db.wg.Add(1)
 	go func() {
 		defer internal.LogPanic(db.Logger, "updateJobAfterChange", true)
-		defer db.wg.Done(wgk)
 
 		err := db.bolt.Batch(func(tx *bolt.Tx) error {
 			bjl := tx.Bucket(bucketJobsLive)
@@ -1089,6 +1088,7 @@ func (db *db) updateJobAfterChange(job *Job) {
 			}
 			return bjl.Put(key, encoded)
 		})
+		db.wg.Done(wgk)
 		if err != nil {
 			db.Error("Database operation updateJobAfterChange failed", "err", err)
 			return

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -42,15 +42,17 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/inconshreveable/log15"
+	"github.com/sb10/waitgroup"
 	"github.com/ugorji/go/codec"
 	bolt "go.etcd.io/bbolt"
 )
 
 const (
-	dbDelimiter               = "_::_"
-	jobStatWindowPercent      = float32(5)
-	dbFilePermission          = 0600
-	minimumTimeBetweenBackups = 30 * time.Second
+	dbDelimiter                   = "_::_"
+	jobStatWindowPercent          = float32(5)
+	dbFilePermission              = 0600
+	minimumTimeBetweenBackups     = 30 * time.Second
+	dbRunningTransactionsWaitTime = 1 * time.Minute
 )
 
 var (
@@ -110,7 +112,7 @@ type db struct {
 	bolt                 *bolt.DB
 	envcache             *lru.ARCCache
 	updatingAfterJobExit int
-	wg                   *sync.WaitGroup
+	wg                   *waitgroup.WaitGroup
 	wgMutex              sync.Mutex // protects wg since we want to call Wait() while another goroutine might call Add()
 	sync.RWMutex
 	backingUp      bool
@@ -314,7 +316,7 @@ func initDB(dbFile string, dbBkFile string, deployment string, logger log15.Logg
 		backupNotification: make(chan bool),
 		backupWait:         minimumTimeBetweenBackups,
 		backupStopWait:     make(chan bool),
-		wg:                 &sync.WaitGroup{},
+		wg:                 waitgroup.New(),
 		Logger:             l,
 	}
 	if fs != nil {
@@ -421,48 +423,48 @@ func (db *db) storeNewJobs(jobs []*Job, ignoreAdded bool) (jobsToQueue []*Job, j
 		errors := make(chan error, numStores)
 
 		db.wgMutex.Lock()
-		db.wg.Add(1)
+		wgk := db.wg.Add(1)
 		go func() {
 			defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs rglookups", true)
-			defer db.wg.Done()
+			defer db.wg.Done(wgk)
 			sort.Sort(rgLookups)
 			errors <- db.storeBatched(bucketRTK, rgLookups, db.storeLookups)
 		}()
 
 		if len(rgs) > 0 {
-			db.wg.Add(1)
+			wgk2 := db.wg.Add(1)
 			go func() {
 				defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs repGroups", true)
-				defer db.wg.Done()
+				defer db.wg.Done(wgk2)
 				sort.Sort(rgs)
 				errors <- db.storeBatched(bucketRGs, rgs, db.storeLookups)
 			}()
 		}
 
 		if len(dgLookups) > 0 {
-			db.wg.Add(1)
+			wgk3 := db.wg.Add(1)
 			go func() {
 				defer internal.LogPanic(db.Logger, "jobqueue database dgLookups", true)
-				defer db.wg.Done()
+				defer db.wg.Done(wgk3)
 				sort.Sort(dgLookups)
 				errors <- db.storeBatched(bucketDTK, dgLookups, db.storeLookups)
 			}()
 		}
 
 		if len(rdgLookups) > 0 {
-			db.wg.Add(1)
+			wgk4 := db.wg.Add(1)
 			go func() {
 				defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs rdgLookups", true)
-				defer db.wg.Done()
+				defer db.wg.Done(wgk4)
 				sort.Sort(rdgLookups)
 				errors <- db.storeBatched(bucketRDTK, rdgLookups, db.storeLookups)
 			}()
 		}
 
-		db.wg.Add(1)
+		wgk5 := db.wg.Add(1)
 		go func() {
 			defer internal.LogPanic(db.Logger, "jobqueue database storeNewJobs encodedJobs", true)
-			defer db.wg.Done()
+			defer db.wg.Done(wgk5)
 			sort.Sort(encodedJobs)
 			errors <- db.storeBatched(bucketJobsLive, encodedJobs, db.storeEncodedJobs)
 		}()
@@ -984,10 +986,10 @@ func (db *db) updateJobAfterExit(job *Job, stdo []byte, stde []byte, forceStorag
 
 	db.wgMutex.Lock()
 	defer db.wgMutex.Unlock()
-	db.wg.Add(1)
+	wgk := db.wg.Add(1)
 	go func() {
 		defer internal.LogPanic(db.Logger, "updateJobAfterExit", true)
-		defer db.wg.Done()
+		defer db.wg.Done(wgk)
 
 		db.Lock()
 		db.updatingAfterJobExit++
@@ -1070,10 +1072,10 @@ func (db *db) updateJobAfterChange(job *Job) {
 
 	db.wgMutex.Lock()
 	defer db.wgMutex.Unlock()
-	db.wg.Add(1)
+	wgk := db.wg.Add(1)
 	go func() {
 		defer internal.LogPanic(db.Logger, "updateJobAfterChange", true)
-		defer db.wg.Done()
+		defer db.wg.Done(wgk)
 
 		err := db.bolt.Batch(func(tx *bolt.Tx) error {
 			bjl := tx.Bucket(bucketJobsLive)
@@ -1400,10 +1402,10 @@ func (db *db) retrieve(bucket []byte, key string) []byte {
 func (db *db) remove(bucket []byte, key string) {
 	db.wgMutex.Lock()
 	defer db.wgMutex.Unlock()
-	db.wg.Add(1)
+	wgk := db.wg.Add(1)
 	go func() {
 		defer internal.LogPanic(db.Logger, "jobqueue database remove", true)
-		defer db.wg.Done()
+		defer db.wg.Done(wgk)
 		err := db.bolt.Batch(func(tx *bolt.Tx) error {
 			b := tx.Bucket(bucket)
 			return b.Delete([]byte(key))
@@ -1515,13 +1517,13 @@ func (db *db) close() error {
 			db.Unlock()
 			<-db.backupNotification
 			db.wgMutex.Lock()
-			db.wg.Wait()
+			db.wg.Wait(dbRunningTransactionsWaitTime)
 			db.wgMutex.Unlock()
 			db.Lock()
 		} else {
 			db.Unlock()
 			db.wgMutex.Lock()
-			db.wg.Wait()
+			db.wg.Wait(dbRunningTransactionsWaitTime)
 			db.wgMutex.Unlock()
 			db.Lock()
 		}
@@ -1627,11 +1629,11 @@ func (db *db) backupToBackupFile(slowBackups bool) {
 	// that alters (the important parts of) the database; wait for those
 	// transactions to actually complete before backing up
 	db.wgMutex.Lock()
-	db.wg.Wait()
+	db.wg.Wait(dbRunningTransactionsWaitTime)
 
-	db.wg.Add(1)
+	wgk := db.wg.Add(1)
 	db.wgMutex.Unlock()
-	defer db.wg.Done()
+	defer db.wg.Done(wgk)
 
 	// create the new backup file with temp name
 	tmpBackupPath := db.backupPath + ".tmp"

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -289,14 +289,6 @@ type Job struct {
 	// the Jobs they're allowed to ReserveFiltered().
 	schedulerGroup string
 
-	// the server uses this to track if it already scheduled a runner for this
-	// job.
-	scheduledRunner bool
-
-	// the server uses this to track if it already ignored this job during
-	// scheduling, due to hitting a limit.
-	schedulerIgnored bool
-
 	// we store the MuxFys that we mount during Mount() so we can Unmount() them
 	// later; this is purely client side.
 	mountedFS []*muxfys.MuxFys
@@ -738,38 +730,6 @@ func (j *Job) Key() string {
 		return byteKey([]byte(fmt.Sprintf("%s.%s.%s", j.Cwd, j.Cmd, j.MountConfigs.Key())))
 	}
 	return byteKey([]byte(fmt.Sprintf("%s.%s", j.Cmd, j.MountConfigs.Key())))
-}
-
-// getScheduledRunner provides a thread-safe way of getting the scheduledRunner
-// property of a Job.
-func (j *Job) getScheduledRunner() bool {
-	j.RLock()
-	defer j.RUnlock()
-	return j.scheduledRunner
-}
-
-// setScheduledRunner provides a thread-safe way of setting the scheduledRunner
-// property of a Job.
-func (j *Job) setScheduledRunner(newval bool) {
-	j.Lock()
-	defer j.Unlock()
-	j.scheduledRunner = newval
-}
-
-// setSchedulerIgnored provides a thread-safe way of setting the
-// schedulerIgnored property of a Job.
-func (j *Job) setSchedulerIgnored(newval bool) {
-	j.Lock()
-	defer j.Unlock()
-	j.schedulerIgnored = newval
-}
-
-// getSchedulerIgnored provides a thread-safe way of getting the
-// schedulerIgnored property of a Job.
-func (j *Job) getSchedulerIgnored() bool {
-	j.RLock()
-	defer j.RUnlock()
-	return j.schedulerIgnored
 }
 
 // generateSchedulerGroup returns a stringified form of the given requirements,

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -71,7 +71,7 @@ func init() {
 	h := l15h.CallerInfoHandler(log15.StderrHandler)
 	testLogger.SetHandler(log15.LvlFilterHandler(log15.LvlWarn, h))
 
-	sync.Opts.DeadlockTimeout = 2 * time.Minute
+	sync.Opts.DeadlockTimeout = 5 * time.Minute // some openstack behaviour needs a pretty long timeout
 
 	flag.BoolVar(&runnermode, "runnermode", false, "enable to disable tests and act as a 'runner' client")
 	flag.BoolVar(&runnerfail, "runnerfail", false, "make the runner client fail")
@@ -5246,9 +5246,6 @@ func TestJobqueueWithOpenStack(t *testing.T) {
 		return
 	}
 
-	// because OpenStack can be slow, increase the deadlock timeout
-	sync.Opts.DeadlockTimeout = 5 * time.Minute
-
 	ServerInterruptTime = 10 * time.Millisecond
 	ServerReserveTicker = 10 * time.Millisecond
 	ClientReleaseDelay = 100 * time.Millisecond
@@ -6114,8 +6111,6 @@ func TestJobqueueWithMounts(t *testing.T) {
 	if runnermode || servermode {
 		return
 	}
-
-	sync.Opts.DeadlockTimeout = 2 * time.Minute
 
 	if runtime.NumCPU() == 1 {
 		// we lock up with only 1 proc

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -4621,8 +4621,8 @@ func TestJobqueueRunners(t *testing.T) {
 							continue
 						case <-limit:
 							ticker.Stop()
-							jobs, errj := jq.GetByRepGroup("manually_added", false, 0, "", true, false)
-							timelimitDebug(jobs, errj)
+							gjobs, errj := jq.GetByRepGroup("manually_added", false, 0, "", true, false)
+							timelimitDebug(gjobs, errj)
 							done <- false
 							return
 						}

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -5594,7 +5594,7 @@ sudo usermod -aG docker ` + osUser
 			So(len(got), ShouldEqual, 1)
 			stdout, err := got[0].StdOut()
 			So(err, ShouldBeNil)
-			So(stdout, ShouldEqual, "1")
+			So(stdout, ShouldEqual, fmt.Sprintf("%d", cores))
 
 			jm := NewJobModifer()
 			other = make(map[string]string)
@@ -5645,7 +5645,7 @@ sudo usermod -aG docker ` + osUser
 			So(len(got), ShouldEqual, 1)
 			stdout, err = got[0].StdOut()
 			So(err, ShouldBeNil)
-			So(stdout, ShouldEqual, "1")
+			So(stdout, ShouldEqual, fmt.Sprintf("%d", cores))
 		})
 
 		Convey("You can modify MonitorDocker of a job", func() {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -5959,10 +5959,13 @@ sudo usermod -aG docker ` + osUser
 			So(err, ShouldBeNil)
 
 			destroyedBadServer := 0
+			var dbsMutex sync.Mutex
 			badServerCB := func(server *cloud.Server) {
 				errf := server.Destroy()
 				if errf == nil {
+					dbsMutex.Lock()
 					destroyedBadServer++
+					dbsMutex.Unlock()
 				}
 			}
 
@@ -6101,7 +6104,9 @@ sudo usermod -aG docker ` + osUser
 			So(<-started, ShouldBeTrue)
 			stopChecking <- true
 			So(<-moreThan2, ShouldBeFalse)
+			dbsMutex.Lock()
 			So(destroyedBadServer, ShouldEqual, 1)
+			dbsMutex.Unlock()
 		})
 
 		Reset(func() {

--- a/jobqueue/scheduler/local.go
+++ b/jobqueue/scheduler/local.go
@@ -306,7 +306,7 @@ func (s *local) schedule(cmd string, req *Requirements, priority uint8, count in
 			if j.priority != priority {
 				err = s.queue.Update(key, "", j, priority, 0*time.Second, 30*time.Second)
 				if err != nil {
-					s.Error("failed to update priority for cmd", "cmd")
+					s.Error("failed to update priority", "cmd", cmd, "err", err)
 				} else {
 					s.Debug("schedule changed priority", "cmd", cmd, "before", j.priority, "now", priority)
 					j.priority = priority

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -1,4 +1,4 @@
-// Copyright © 2016-2018 Genome Research Limited
+// Copyright © 2016-2020 Genome Research Limited
 // Author: Sendu Bala <sb10@sanger.ac.uk>.
 //
 //  This file is part of wr.
@@ -533,6 +533,11 @@ func (s *lsf) schedule(cmd string, req *Requirements, priority uint8, count int)
 	}
 
 	return err
+}
+
+// scheduled achieves the aims of Scheduled().
+func (s *lsf) scheduled(cmd string) (int, error) {
+	return s.checkCmd(cmd, -1)
 }
 
 // generateBsubArgs generates the appropriate bsub args for the given req and

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -114,7 +114,7 @@ func (s *lsf) initialize(config interface{}, logger log15.Logger) error {
 		}
 	}
 
-	bmgroups := make(map[string]int)
+	bmgroups := make(map[string]map[string]bool)
 	parsedBmgroups := false
 
 	// parse bqueues -l to figure out what usable queues we have
@@ -261,7 +261,7 @@ func (s *lsf) initialize(config interface{}, logger log15.Logger) error {
 					queue = ""
 				}
 			} else if matches[2] != "all" {
-				hosts := 0
+				hosts := make(map[string]bool)
 				for _, val := range vals {
 					if strings.HasSuffix(val, "/") {
 						// this is a group name, look it up in bmgroup
@@ -273,17 +273,19 @@ func (s *lsf) initialize(config interface{}, logger log15.Logger) error {
 							parsedBmgroups = true
 						}
 						val = strings.TrimSuffix(val, "/")
-						if n, exists := bmgroups[val]; exists {
-							hosts += n
+						if servers, exists := bmgroups[val]; exists {
+							for server := range servers {
+								hosts[server] = true
+							}
 						} else {
-							hosts++
+							hosts[val] = true
 						}
 					} else {
-						hosts++
+						hosts[val] = true
 					}
 				}
-				s.queues[queue][kind] = hosts
-				updateHighest(kind, hosts)
+				s.queues[queue][kind] = len(hosts)
+				updateHighest(kind, len(hosts))
 			}
 		}
 
@@ -412,8 +414,8 @@ func (s *lsf) initialize(config interface{}, logger log15.Logger) error {
 }
 
 // parseBmgroups parses the output of `bmgroup`, storing group name as a key in
-// the supplied map, with number of hosts in that group as the value.
-func (s *lsf) parseBmgroups(groups map[string]int) error {
+// the supplied map, with a map of hosts in that group as the value.
+func (s *lsf) parseBmgroups(groups map[string]map[string]bool) error {
 	bmgcmd := exec.Command(s.config.Shell, "-c", "bmgroup") // #nosec
 	bmgout, err := bmgcmd.StdoutPipe()
 	if err != nil {
@@ -429,7 +431,22 @@ func (s *lsf) parseBmgroups(groups map[string]int) error {
 		if len(fields) < 2 {
 			continue
 		}
-		groups[fields[0]] = len(fields) - 1
+		for i, field := range fields {
+			if i == 0 {
+				continue
+			}
+			if groups[fields[0]] == nil {
+				groups[fields[0]] = make(map[string]bool)
+			}
+			if strings.HasSuffix(field, "/") {
+				lookup := strings.TrimSuffix(field, "/")
+				for server := range groups[lookup] {
+					groups[fields[0]][server] = true
+				}
+			} else {
+				groups[fields[0]][field] = true
+			}
+		}
 	}
 	return nil
 }

--- a/jobqueue/scheduler/scheduler.go
+++ b/jobqueue/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright © 2016-2019 Genome Research Limited
+// Copyright © 2016-2020 Genome Research Limited
 // Author: Sendu Bala <sb10@sanger.ac.uk>.
 //
 //  This file is part of wr.
@@ -177,6 +177,7 @@ type RecoveredHostDetails struct {
 type scheduleri interface {
 	initialize(config interface{}, logger log15.Logger) error                // do any initial set up to be able to use the job scheduler
 	schedule(cmd string, req *Requirements, priority uint8, count int) error // achieve the aims of Schedule()
+	scheduled(cmd string) (int, error)                                       // achieve the aims of Scheduled()
 	recover(cmd string, req *Requirements, host *RecoveredHostDetails) error // achieve the aims of Recover()
 	busy() bool                                                              // achieve the aims of Busy()
 	reserveTimeout(req *Requirements) int                                    // achieve the aims of ReserveTimeout()
@@ -319,6 +320,12 @@ func (s *Scheduler) Schedule(cmd string, req *Requirements, priority uint8, coun
 	s.Unlock()
 
 	return err
+}
+
+// Scheduled tells you how many of the given cmd are currently scheduled in the
+// scheduler.
+func (s *Scheduler) Scheduled(cmd string) (int, error) {
+	return s.impl.scheduled(cmd)
 }
 
 // Recover is used if you had Scheduled some cmds, then you crashed, and now

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -130,11 +130,11 @@ func TestLocal(t *testing.T) {
 
 			count := maxCPU * 2
 			sched := func() {
-				err = s.Schedule(cmd, possibleReq, 0, count)
-				So(err, ShouldBeNil)
+				serr := s.Schedule(cmd, possibleReq, 0, count)
+				So(serr, ShouldBeNil)
 				So(s.Busy(), ShouldBeTrue)
-				scheduled, err := s.Scheduled(cmd)
-				So(err, ShouldBeNil)
+				scheduled, serr := s.Scheduled(cmd)
+				So(serr, ShouldBeNil)
 				So(scheduled, ShouldEqual, count)
 			}
 

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -133,6 +133,9 @@ func TestLocal(t *testing.T) {
 				err = s.Schedule(cmd, possibleReq, 0, count)
 				So(err, ShouldBeNil)
 				So(s.Busy(), ShouldBeTrue)
+				scheduled, err := s.Scheduled(cmd)
+				So(err, ShouldBeNil)
+				So(scheduled, ShouldEqual, count)
 			}
 
 			Convey("It eventually runs them all", func() {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1437,7 +1437,6 @@ func (s *Server) createQueue() {
 				delete(s.previouslyScheduledGroups, name)
 				s.Debug("rac deleted previous unneeded group", "group", name)
 			}
-			s.psgmutex.Unlock()
 
 			// schedule runners for each group in the job scheduler
 			for name, group := range groups {
@@ -1458,6 +1457,7 @@ func (s *Server) createQueue() {
 
 				s.previouslyScheduledGroups[name] = group
 			}
+			s.psgmutex.Unlock()
 
 			// in the event that the runners we spawn can't reach us temporarily
 			// and just die (or they manage to run and exit due to a limit), we

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -212,6 +212,8 @@ type sgroup struct {
 
 // clone creates a new copy of the sgroup with the given count
 func (s *sgroup) clone(count int) *sgroup {
+	s.RLock()
+	defer s.RUnlock()
 	return &sgroup{
 		name:     s.name,
 		count:    count,
@@ -2315,7 +2317,9 @@ func (s *Server) scheduleRunners(group *sgroup) {
 					return
 				}
 
+				group.Lock()
 				s.scheduleRunners(group)
+				group.Unlock()
 			}()
 			return
 		}
@@ -2349,7 +2353,9 @@ func (s *Server) decrementGroupCount(schedulerGroup string, optionalDrop ...int)
 
 	count := group.decrement(drop)
 	if count >= 0 {
+		group.Lock()
 		s.scheduleRunners(group)
+		group.Unlock()
 	}
 }
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -223,6 +223,13 @@ func (s *sgroup) clone(count int) *sgroup {
 	}
 }
 
+// getCount is a thread-safe way of getting the current count
+func (s *sgroup) getCount() int {
+	s.RLock()
+	defer s.RUnlock()
+	return s.count
+}
+
 // decrement is a thread-safe way of dropping the count of the group by the
 // given amount.
 //
@@ -2251,7 +2258,7 @@ func (s *Server) schedulerGroupDetails() []string {
 	result := make([]string, len(s.previouslyScheduledGroups))
 	i := 0
 	for name, group := range s.previouslyScheduledGroups {
-		result[i] = fmt.Sprintf("%s (%d jobs)", name, group.count)
+		result[i] = fmt.Sprintf("%s (%d jobs)", name, group.getCount())
 		i++
 	}
 	return result

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -381,7 +381,7 @@ func (s *Server) handleRequest(m *mangos.Message) error {
 							}
 							s.rpl.Unlock()
 							s.Debug("completed job", "cmd", job.Cmd, "schedGrp", sgroup)
-							s.q.TriggerReadyAddedCallback()
+							s.decrementGroupCount(sgroup, 1)
 						}
 					}
 				}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -214,7 +214,7 @@ func (s *Server) handleRequest(m *mangos.Message) error {
 					// nothing was ready. Likewise if in drain mode.
 					if cr.FirstReserve && s.rc != "" {
 						s.psgmutex.RLock()
-						if group, existed := s.previouslyScheduledGroups[cr.SchedulerGroup]; !existed || group.count == 0 {
+						if group, existed := s.previouslyScheduledGroups[cr.SchedulerGroup]; !existed || group.getCount() == 0 {
 							skip = true
 						}
 						s.psgmutex.RUnlock()

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -327,7 +327,7 @@ func webInterfaceStatusWS(s *Server) http.HandlerFunc {
 							s.Debug("removed job", "cmd", job.Cmd)
 							toDelete = append(toDelete, key)
 							if job.State == JobStateReady {
-								s.decrementGroupCount(job.schedulerGroup)
+								s.q.TriggerReadyAddedCallback()
 							}
 						}
 						s.rpl.Lock()

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -327,7 +327,7 @@ func webInterfaceStatusWS(s *Server) http.HandlerFunc {
 							s.Debug("removed job", "cmd", job.Cmd)
 							toDelete = append(toDelete, key)
 							if job.State == JobStateReady {
-								s.q.TriggerReadyAddedCallback()
+								s.decrementGroupCount(job.getSchedulerGroup(), 1)
 							}
 						}
 						s.rpl.Lock()

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,7 @@ func TestConfig(t *testing.T) {
 		So(config.ManagerSetDomainIP, ShouldBeFalse)
 		So(config.Source("ManagerSetDomainIP"), ShouldEqual, internal.ConfigSourceDefault)
 
-		Convey("These can be overriden with Env Vars", func() {
+		Convey("These can be overridden with Env Vars", func() {
 			os.Setenv("WR_MANAGERPORT", "1234")
 			os.Setenv("WR_MANAGERUMASK", "077")
 			os.Setenv("WR_MANAGERSETDOMAINIP", "true")
@@ -105,7 +105,7 @@ func TestConfig(t *testing.T) {
 			So(config.Source("ManagerSetDomainIP"), ShouldEqual, internal.ConfigSourceEnvVar)
 		})
 
-		Convey("These can be overriden with config files in WR_CONFIG_DIR", func() {
+		Convey("These can be overridden with config files in WR_CONFIG_DIR", func() {
 			dir, err := ioutil.TempDir("", "wr_conf_test")
 			So(err, ShouldBeNil)
 			defer os.RemoveAll(dir)
@@ -152,7 +152,7 @@ func TestConfig(t *testing.T) {
 				So(config.ManagerWeb, ShouldEqual, mweb2)
 				So(config.Source("ManagerWeb"), ShouldEqual, path4)
 
-				Convey("These can be overriden with config files in current dir", func() {
+				Convey("These can be overridden with config files in current dir", func() {
 					pwd, err := os.Getwd()
 					So(err, ShouldBeNil)
 					mport = "1434"

--- a/main_test.go
+++ b/main_test.go
@@ -115,6 +115,7 @@ func TestConfig(t *testing.T) {
 			mweb2 := "1236"
 			path, path2, err := fileTestSetup(dir, mport, mweb1, mweb2)
 			defer fileTestTeardown(path, path2)
+			So(err, ShouldBeNil)
 
 			os.Setenv("WR_CONFIG_DIR", dir)
 			defer func() {
@@ -145,6 +146,7 @@ func TestConfig(t *testing.T) {
 				mweb2 = "1336"
 				path3, path4, err := fileTestSetup(home, mport, mweb1, mweb2)
 				defer fileTestTeardown(path3, path4)
+				So(err, ShouldBeNil)
 
 				config = internal.ConfigLoad("development", false, testLogger)
 				So(config.ManagerPort, ShouldEqual, mport)
@@ -160,6 +162,7 @@ func TestConfig(t *testing.T) {
 					mweb2 = "1436"
 					path5, path6, err := fileTestSetup(pwd, mport, mweb1, mweb2)
 					defer fileTestTeardown(path5, path6)
+					So(err, ShouldBeNil)
 
 					config = internal.ConfigLoad("development", false, testLogger)
 					So(config.ManagerPort, ShouldEqual, mport)

--- a/main_test.go
+++ b/main_test.go
@@ -127,7 +127,7 @@ func TestConfig(t *testing.T) {
 			So(config.ManagerWeb, ShouldEqual, mweb2)
 			So(config.Source("ManagerWeb"), ShouldEqual, path2)
 
-			Convey("These can be overriden with config files in home dir", func() {
+			Convey("These can be overridden with config files in home dir", func() {
 				realHome, err := os.UserHomeDir()
 				So(err, ShouldBeNil)
 				newHome, err := ioutil.TempDir(dir, "home")

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -288,8 +288,9 @@ func (queue *Queue) readyAdded() {
 				}
 			}
 			queue.mutex.RUnlock()
-			queue.Debug("new ready items, triggering callback")
+			queue.Debug("new ready items, triggering callback", "items", len(data))
 			queue.readyAddedCb(queue.Name, data)
+			queue.Debug("finished triggering callback for new ready items", "items", len(data))
 
 			queue.readyAddedCbMutex.Lock()
 			if queue.readyAddedCbRecall {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1546,7 +1546,7 @@ func TestQueue(t *testing.T) {
 		So(added[0], ShouldEqual, 1)
 		callBackLock.RUnlock()
 
-		<-time.After(100 * time.Millisecond)
+		<-time.After(650 * time.Millisecond)
 
 		callBackLock.RLock()
 		So(len(added), ShouldEqual, 2)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1616,23 +1616,37 @@ func TestQueue(t *testing.T) {
 		// queue takes ~15ms instead of ~0.1ms, so the times here allow for that
 		// kind of leeway
 
+		willReserve := make(map[int]chan bool)
+		willReserve[1] = make(chan bool)
+		willReserve[2] = make(chan bool)
+		addTimes := make(map[int]chan time.Time)
+		addTimes[1] = make(chan time.Time)
+		addTimes[2] = make(chan time.Time)
 		rCh := make(chan bool)
-		for i := 0; i < 2; i++ {
-			go func() {
+		for i := 1; i <= 2; i++ {
+			go func(i int) {
+				willReserve[i] <- true
 				t := time.Now()
 				item, err := queue.Reserve("foo", 3000*time.Millisecond)
-				rCh <- item != nil && err == nil && time.Since(t) < 2500*time.Millisecond
-			}()
+				addT := <-addTimes[i]
+				ok := item != nil && err == nil && time.Since(t) < 2500*time.Millisecond && time.Since(t) > 2000*time.Millisecond && time.Since(addT) < 10*time.Millisecond
+				if !ok {
+					fmt.Printf("\nitem: %v, err: [%s], time passed: %s, since add: %s\n", item != nil, err, time.Since(t), time.Since(addT))
+				}
+				rCh <- ok
+			}(i)
 		}
 
 		addErrCh := make(chan error)
-		go func() {
-			<-time.After(2000 * time.Millisecond)
-			_, err1 := queue.Add("key1", "foo", "data", 0, 0*time.Millisecond, 10*time.Millisecond, "")
-			_, err2 := queue.Add("key2", "foo", "data", 0, 0*time.Millisecond, 10*time.Millisecond, "")
-			addErrCh <- err1
-			addErrCh <- err2
-		}()
+		for i := 1; i <= 2; i++ {
+			go func(i int) {
+				<-willReserve[i]
+				<-time.After(2000 * time.Millisecond)
+				_, err := queue.Add(fmt.Sprintf("key%d", i), "foo", "data", 0, 0*time.Millisecond, 10*time.Millisecond, "")
+				addTimes[i] <- time.Now()
+				addErrCh <- err
+			}(i)
+		}
 
 		So(<-addErrCh, ShouldBeNil)
 		So(<-addErrCh, ShouldBeNil)


### PR DESCRIPTION
This is a critical fix for the database becoming deadlocked during database backups.

Logging added to debug the cause of the deadlock: waiting on the database waitgroup.

Unfortunately it wasn't possible to replicate the deadlock or develop a test to prove the fix works, but it seems to have been fixed based on actual usage.

Also fixes jobs failing when they detect `/` has run out disk space: they check the correct volume now instead.