### PR TITLE
Improve server creation and deletion behaviour

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -133,10 +133,12 @@ var pcsTimeOut = 15 * time.Minute
 // command, resulting in you waiting on a timeout instead of knowing if the
 // command completed successfully.
 // 'sync' on any modern system should wait for writes to complete, and ought to
-// be all we really need. Using /proc/sysrq-trigger is just to be extra sure,
-// *** though we don't wait and confirm dmesg actaully reports "Emergency Sync
-// complete", because I don't know of a distrubution and shell agnostic way of
-// doing that wait.
+// be all we really need. Some client/server filesystems may benefit from an
+// explicit umount as well, but `umount -a` will tend to just fail because the
+// filesystems are busy. We can't generically only umount a particular fs that
+// was used for writing job output. Using /proc/sysrq-trigger lets us at least
+// request a ro remount (should be equivalent of umount as far as letting fs
+// servers know we're done), even if we don't know if it succeeds.
 const cleanShutDownCmd = `sync && echo 's' | sudo tee -a /proc/sysrq-trigger > /dev/null && echo 'u' | sudo tee -a /proc/sysrq-trigger > /dev/null`
 
 // defaultDNSNameServers holds some public (google) dns name server addresses

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -769,7 +769,9 @@ func (p *openstackp) spawn(resources *Resources, osPrefix string, flavorID strin
 	sf := p.spawnFailed
 	p.spMutex.RUnlock()
 	if sf {
-		time.Sleep(p.errorBackoff.Duration())
+		wait := p.errorBackoff.Duration()
+		p.Warn("server spawn waiting due to prior failures", "wait", wait)
+		time.Sleep(wait)
 	}
 
 	// we'll use the security group we created, and the "default" one if it

--- a/cloud/server.go
+++ b/cloud/server.go
@@ -505,6 +505,12 @@ func (s *Server) SSHClient(ctx context.Context) (*ssh.Client, int, error) {
 	hostAndPort := s.IP + ":22"
 	client, err := sshDial(ctx, hostAndPort, s.sshClientConfig, s.logger)
 	if err != nil {
+		// if we're trying to destroy this server, just give up straight away
+		if s.destroyed {
+			return nil, index, err
+		}
+
+		// otherwise, keep trying
 		limit := time.After(sshTimeOut)
 		ticker := time.NewTicker(1 * time.Second)
 		ticks := 0


### PR DESCRIPTION
1. We now only wait up to 1min before retrying server creation after errors.
2. We log the wait time.
3. We attempt to sync the filesystem before deletion.