### PR TITLE
Resolve #312: better check for if cloud server belongs to us.

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -221,6 +221,8 @@ type provideri interface {
 	errIsNoHardware(err error) bool
 	// achieve the aims of CheckServer()
 	checkServer(serverID string) (bool, error)
+	// achieve the aims of serverIsKnown()
+	serverIsKnown(serverID string) (bool, error)
 	// achieve the aims of DestroyServer()
 	destroyServer(serverID string) error
 	// achieve the aims of TearDown()
@@ -745,6 +747,16 @@ func (p *Provider) CheckServer(serverID string) (working bool, err error) {
 	}
 
 	return working, err
+}
+
+// ServerIsKnown asks the provider if the given server (id retrieved via Spawn()
+// or Servers()) is known about by this provider. If this returns false, it
+// doesn't necessarily mean the server doesn't exist; it could mean you supplied
+// the wrong credentials for the resources file you passed to New(). For that
+// reason, the resources file is not updated if this returns false, and
+// Servers() will continue to return a server with the given serverID.
+func (p *Provider) ServerIsKnown(serverID string) (known bool, err error) {
+	return p.impl.serverIsKnown(serverID)
 }
 
 // DestroyServer destroys a server given its id, that you would have gotten from

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -158,6 +158,22 @@ func TestOpenStack(t *testing.T) {
 					So(flavors[2], ShouldBeNil)
 				}
 
+				Convey("TearDown deletes all the resources that deploy made", func() {
+					err := p.TearDown()
+
+					if p.InCloud() {
+						// the deploy didn't actually create anything that
+						// teardown would delete, so it complains
+						So(err, ShouldNotBeNil)
+						So(err.Error(), ShouldContainSubstring, "nothing to tear down")
+					} else {
+						So(err, ShouldBeNil)
+					}
+
+					// *** should really use openstack API to confirm everything is
+					// really deleted...
+				})
+
 				Convey("Once deployed you can Spawn a server with an external ip", func() {
 					server, err := p.Spawn("osPrefix", osUser, flavor.ID, 1, 0*time.Second, true)
 					So(err, ShouldNotBeNil)
@@ -521,14 +537,6 @@ func TestOpenStack(t *testing.T) {
 					stdout, _, err := server.RunCmd(context.Background(), "df -h .", false)
 					So(err, ShouldBeNil)
 					So(stdout, ShouldContainSubstring, fmt.Sprintf("%dG", flavor.Disk+10))
-				})
-
-				Convey("TearDown deletes all the resources that deploy made", func() {
-					err := p.TearDown()
-					So(err, ShouldBeNil)
-
-					// *** should really use openstack API to confirm everything is
-					// really deleted...
 				})
 
 				Reset(func() {

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -172,7 +172,12 @@ func TestOpenStack(t *testing.T) {
 					So(p.resources.Servers[server.ID], ShouldNotBeNil)
 					So(p.resources.Servers[server.ID].IP, ShouldEqual, server.IP)
 
-					ok, err := p.CheckServer(server.ID)
+					ok, err := p.ServerIsKnown(server.ID)
+					So(err, ShouldBeNil)
+					So(ok, ShouldBeTrue)
+					// *** negative tests of ServerIsKnown are not possible without mocks, since with the real system we need an alternate set of working credentials
+
+					ok, err = p.CheckServer(server.ID)
 					So(err, ShouldBeNil)
 					So(ok, ShouldBeTrue)
 
@@ -528,7 +533,7 @@ func TestOpenStack(t *testing.T) {
 
 				Reset(func() {
 					errd := p.TearDown()
-					if errd != nil {
+					if errd != nil && !strings.Contains(errd.Error(), "nothing to tear down") {
 						fmt.Printf("reset p.Teardown failed: %s", errd)
 					}
 				})
@@ -537,7 +542,7 @@ func TestOpenStack(t *testing.T) {
 			// *** we need all the tests for negative and failure cases
 
 			errd := p.TearDown()
-			if errd != nil {
+			if errd != nil && !strings.Contains(errd.Error(), "nothing to tear down") {
 				fmt.Printf("ending p.Teardown failed: %s", errd)
 			}
 		})

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -1006,7 +1006,7 @@ func (p *openstackp) getServerIP(serverID string) (string, error) {
 	return "", nil
 }
 
-// checkServer achieves the aims of CheckServer()
+// checkServer achieves the aims of CheckServer().
 func (p *openstackp) checkServer(serverID string) (bool, error) {
 	server, err := servers.Get(p.computeClient, serverID).Extract()
 	if err != nil {
@@ -1019,7 +1019,20 @@ func (p *openstackp) checkServer(serverID string) (bool, error) {
 	return server.Status == "ACTIVE", nil
 }
 
-// destroyServer achieves the aims of DestroyServer()
+// checkServer achieves the aims of ServerIsKnown().
+func (p *openstackp) serverIsKnown(serverID string) (bool, error) {
+	server, err := servers.Get(p.computeClient, serverID).Extract()
+	if err != nil {
+		if err.Error() == "Resource not found" {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return server != nil, nil
+}
+
+// destroyServer achieves the aims of DestroyServer().
 func (p *openstackp) destroyServer(serverID string) error {
 	err := servers.Delete(p.computeClient, serverID).ExtractErr()
 	if err != nil {
@@ -1101,7 +1114,9 @@ func (p *openstackp) tearDown(resources *Resources) error {
 	})
 	merr = p.combineError(merr, err)
 
+	var didSomething bool
 	if len(toDestroy) > 0 {
+		didSomething = true
 		wg := waitgroup.New()
 		wgk := wg.Add(len(toDestroy))
 		for _, sid := range toDestroy {
@@ -1148,6 +1163,9 @@ func (p *openstackp) tearDown(resources *Resources) error {
 			t := time.Now()
 			err := routers.Delete(p.networkClient, id).ExtractErr()
 			p.Debug("delete router", "time", time.Since(t), "id", id, "err", err)
+			if err == nil {
+				didSomething = true
+			}
 			merr = p.combineError(merr, err)
 		}
 
@@ -1156,6 +1174,9 @@ func (p *openstackp) tearDown(resources *Resources) error {
 			t := time.Now()
 			err := networks.Delete(p.networkClient, id).ExtractErr()
 			p.Debug("delete network (auto-deletes subnet)", "time", time.Since(t), "id", id, "err", err)
+			if err == nil {
+				didSomething = true
+			}
 			merr = p.combineError(merr, err)
 		}
 
@@ -1164,6 +1185,9 @@ func (p *openstackp) tearDown(resources *Resources) error {
 			t := time.Now()
 			err := secgroups.Delete(p.computeClient, id).ExtractErr()
 			p.Debug("delete security group", "time", time.Since(t), "id", id, "err", err)
+			if err == nil {
+				didSomething = true
+			}
 			merr = p.combineError(merr, err)
 		}
 	}
@@ -1177,12 +1201,18 @@ func (p *openstackp) tearDown(resources *Resources) error {
 			t := time.Now()
 			err := keypairs.Delete(p.computeClient, id).ExtractErr()
 			p.Debug("delete keypair", "time", time.Since(t), "id", id, "err", err)
+			// keypairs are not credential-specific enough, so we don't consider
+			// deleting one as didSomething
 			merr = p.combineError(merr, err)
 			resources.PrivateKey = ""
 		}
 	}
 
-	return merr.ErrorOrNil()
+	rerr := merr.ErrorOrNil()
+	if rerr == nil && !didSomething {
+		return fmt.Errorf("nothing to tear down; did you deploy with the current credentials?")
+	}
+	return rerr
 }
 
 // combineError Append()s the given err on merr, but ignores err if it is

--- a/cloud/server.go
+++ b/cloud/server.go
@@ -1284,7 +1284,8 @@ func (s *Server) Destroyed() bool {
 
 // Alive tells you if a server is usable. It first does the same check as
 // Destroyed() before calling out to the provider. Supplying an optional boolean
-// will double check the server to make sure it can be ssh'd to.
+// will double check the server to make sure it can be ssh'd to. If the server
+// doesn't exist, it will be removed from the provider's resources file.
 func (s *Server) Alive(checkSSH ...bool) bool {
 	s.mutex.Lock()
 	if s.destroyed || s.toBeDestroyed {
@@ -1309,4 +1310,18 @@ func (s *Server) Alive(checkSSH ...bool) bool {
 	}
 
 	return true
+}
+
+// Known tells you if a server exists according to the provider. This can
+// return false even if the server exists, because the credentials you used for
+// the provider are different to the ones used to create this server. If the
+// server isn't known about, the provider's resource file is NOT updated,
+// because this indicates you're using the wrong resource file for these
+// credentials.
+func (s *Server) Known() bool {
+	known, err := s.provider.ServerIsKnown(s.ID)
+	if err != nil {
+		s.logger.Warn("could not check if the server is known about", "err", err)
+	}
+	return known
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -468,6 +468,11 @@ and accessible.`,
 		if err != nil {
 			die("failed to connect to %s: %s", providerName, err)
 		}
+		headNode := provider.HeadNode()
+		var headNodeKnown bool
+		if headNode != nil {
+			headNodeKnown = headNode.Known()
+		}
 
 		// now check if the ssh forwarding is up
 		fmPidFile := filepath.Join(config.ManagerDir, "cloud_resources."+providerName+".fm.pid")
@@ -480,6 +485,10 @@ and accessible.`,
 		if fmRunning {
 			jq := connect(1*time.Second, true)
 			if jq != nil {
+				if !headNodeKnown {
+					die("was able to connect to the manager, but the deployed node is reported as non-existent; are you using the same credentials you deployed this manager with?")
+				}
+
 				var syncMsg string
 				if internal.IsRemote(config.ManagerDbBkFile) {
 					if _, errf := os.Stat(config.ManagerDbFile); !os.IsNotExist(errf) {
@@ -544,8 +553,7 @@ and accessible.`,
 		// copy over any manager logs that got created locally (ignore errors,
 		// and overwrite any existing file) *** currently missing the final
 		// shutdown message doing things this way, but ok?...
-		headNode := provider.HeadNode()
-		if headNode != nil && headNode.Alive() {
+		if headNodeKnown && headNode.Alive() {
 			cloudLogFilePath := config.ManagerLogFile + "." + providerName
 			errf := headNode.DownloadFile(context.Background(), filepath.Join("./.wr_"+config.Deployment, "log"), cloudLogFilePath)
 

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -1447,7 +1447,7 @@ func (s *opst) cleanup() {
 
 	// teardown any cloud resources created
 	err = s.provider.TearDown()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "nothing to tear down") {
 		s.Warn("cleanup teardown failed", "err", err)
 	}
 }


### PR DESCRIPTION
New cloud.ServerIsKnown() method, implemented in osp. Corresponding cloud
Server.Known() method.

tearDown() now returns an error if it did nothing.