### PR TITLE
Increase TCP timeout for ssh

### DIFF
--- a/cloud/server.go
+++ b/cloud/server.go
@@ -43,7 +43,7 @@ import (
 )
 
 const sharePath = "/shared" // mount point for the *SharedDisk methods
-const sshShortTimeOut = 5 * time.Second
+const sshShortTimeOut = 15 * time.Second
 
 // maxSSHSessions is the maximum number of sessions we will try and multiplex on
 // each ssh client we make for a server. It doesn't matter if this is lower than

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -5072,7 +5072,7 @@ func TestJobqueueRunners(t *testing.T) {
 				done = make(chan bool, 1)
 				twoHundredCount := 0
 				go func() {
-					limit := time.After(180 * time.Second)
+					limit := time.After(360 * time.Second)
 					ticker := time.NewTicker(50 * time.Millisecond)
 					for {
 						select {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -6281,7 +6281,7 @@ func TestJobqueueWithMounts(t *testing.T) {
 			So(inserts, ShouldEqual, 1)
 			So(already, ShouldEqual, 0)
 
-			<-time.After(4 * time.Second)
+			<-time.After(8 * time.Second)
 
 			info, err := os.Stat(config.ManagerDbFile)
 			So(err, ShouldBeNil)

--- a/jobqueue/scheduler/scheduler_test.go
+++ b/jobqueue/scheduler/scheduler_test.go
@@ -588,7 +588,7 @@ func TestLSF(t *testing.T) {
 			})
 
 			Convey("You can Schedule() a new job and have it run while the first is still running", func() {
-				<-time.After(3 * time.Second) // *** if the following test fails, it probably just because LSF didn't get any previous jobs running yet; not sure what to do about that
+				<-time.After(6 * time.Second) // *** if the following test fails, it probably just because LSF didn't get any previous jobs running yet; not sure what to do about that
 				numfiles := testDirForFiles(tmpdir, 1)
 				So(numfiles, ShouldBeBetweenOrEqual, 1, count)
 				So(s.Busy(), ShouldBeTrue)
@@ -618,7 +618,7 @@ func TestLSF(t *testing.T) {
 			So(s.Busy(), ShouldBeTrue)
 
 			Convey("It runs some of them and you can Schedule() again to drop the count", func() {
-				So(waitToFinish(s, 3, 1000), ShouldBeFalse)
+				So(waitToFinish(s, 6, 1000), ShouldBeFalse)
 				numfiles := testDirForFiles(tmpdir, 1)
 				So(numfiles, ShouldBeBetween, 1, count-(maxCPU*2)-2)
 


### PR DESCRIPTION
In OpenStack train, instances/network seems slower and servers were timing out on the ssh attempt. This triples the TCP timeout.