### PR TITLE
Resolve #294: only half-hour-round time for calculating scheduler group.

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -363,13 +363,18 @@ down will be lost.`,
 			die("even though I was able to connect to the manager, it failed to enter drain mode: %s", err)
 		}
 
+		completeMsg := "have already completed"
+		if etc > 0 {
+			completeMsg = fmt.Sprintf("complete in less than %s", etc)
+		}
+
 		if numLeft == 0 {
 			info("wr manager running on port %s is drained: there were no jobs still running, so the manger should stop right away.", config.ManagerPort)
 			deleteToken()
 		} else if numLeft == 1 {
-			info("wr manager running on port %s is now draining; there is a job still running, and it should complete in less than %s", config.ManagerPort, etc)
+			info("wr manager running on port %s is now draining; there is a job still running, and it should %s", config.ManagerPort, completeMsg)
 		} else {
-			info("wr manager running on port %s is now draining; there are %d jobs still running, and they should complete in less than %s", config.ManagerPort, numLeft, etc)
+			info("wr manager running on port %s is now draining; there are %d jobs still running, and they should %s", config.ManagerPort, numLeft, completeMsg)
 		}
 
 		err = jq.Disconnect()

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -76,8 +76,8 @@ var (
 // Rec* variables are only exported for testing purposes (*** though they should
 // probably be user configurable somewhere...).
 var (
-	RecMBRound  = 100  // when we recommend amount of memory to reserve for a job, we round up to the nearest RecMBRound MBs
-	RecSecRound = 1800 // when we recommend time to reserve for a job, we round up to the nearest RecSecRound seconds
+	RecMBRound  = 100 // when we recommend amount of memory to reserve for a job, we round up to the nearest RecMBRound MBs
+	RecSecRound = 1   // when we recommend time to reserve for a job, we round up to the nearest RecSecRound seconds
 )
 
 // sobsd ('slice of byte slice doublets') implements sort interface so we can
@@ -1297,8 +1297,8 @@ func (db *db) recommendedReqGroupDisk(reqGroup string) (int, error) {
 // that previously ran with the given reqGroup. If there are too few prior
 // values to calculate a 95th percentile, or if the 95th percentile is very
 // close to the maximum value, returns the maximum value instead. In either
-// case, the true value is rounded up to the nearest 30mins (but returned in
-// seconds). Returns 0 if there are no prior values.
+// case, the true value is rounded up to the nearest second. Returns 0 if there
+// are no prior values.
 func (db *db) recommendedReqGroupTime(reqGroup string) (int, error) {
 	return db.recommendedReqGroupStat(bucketJobSecs, reqGroup, RecSecRound)
 }

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -3460,6 +3460,15 @@ func TestJobqueueModify(t *testing.T) {
 
 			job = kick("a", learnedRgroup, cmd, "a")
 			So(job.Requirements.Time, ShouldEqual, 1*time.Second)
+			stats := server.GetServerStats()
+			So(stats.ETC, ShouldEqual, 0*time.Second)
+
+			_, err := jq.Kick(jobsToJobEssenses([]*Job{job}))
+			So(err, ShouldBeNil)
+			job = reserve(learnedRgroup, cmd)
+			jq.Started(job, 1)
+			stats = server.GetServerStats()
+			So(stats.ETC, ShouldEqual, 1*time.Second)
 		})
 
 		Convey("You can modify the retries of a job", func() {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1067,7 +1067,8 @@ func (s *Server) Resume() (bool, error) {
 // server's queue.
 func (s *Server) GetServerStats() *ServerStats {
 	var delayed, ready, running, buried int
-	var etc time.Time
+	now := time.Now()
+	etc := now
 
 	stats := s.q.Stats()
 	delayed += stats.Delayed
@@ -1089,7 +1090,7 @@ func (s *Server) GetServerStats() *ServerStats {
 		job.RUnlock()
 	}
 
-	return &ServerStats{Delayed: delayed, Ready: ready, Running: running, Buried: buried, ETC: etc.Truncate(time.Second).Sub(time.Now().Truncate(time.Second))}
+	return &ServerStats{Delayed: delayed, Ready: ready, Running: running, Buried: buried, ETC: etc.Truncate(time.Second).Sub(now.Truncate(time.Second))}
 }
 
 // BackupDB lets you do a manual live backup of the server's database to a given

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1089,7 +1089,7 @@ func (s *Server) GetServerStats() *ServerStats {
 		job.RUnlock()
 	}
 
-	return &ServerStats{Delayed: delayed, Ready: ready, Running: running, Buried: buried, ETC: etc.Truncate(time.Minute).Sub(time.Now().Truncate(time.Minute))}
+	return &ServerStats{Delayed: delayed, Ready: ready, Running: running, Buried: buried, ETC: etc.Truncate(time.Second).Sub(time.Now().Truncate(time.Second))}
 }
 
 // BackupDB lets you do a manual live backup of the server's database to a given


### PR DESCRIPTION
Fix drain to not report negative eta.