### PR TITLE
OpenStack: no longer require OS_PROJECT_ID if OS_PROJECT_NAME set

### DIFF
--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -96,6 +96,21 @@ func TestOpenStack(t *testing.T) {
 			So(vars, ShouldResemble, []string{"OS_AUTH_URL", "OS_USERNAME", "OS_PASSWORD", "OS_REGION_NAME", "OS_USERID", "OS_TENANT_ID", "OS_TENANT_NAME", "OS_DOMAIN_ID", "OS_PROJECT_DOMAIN_ID", "OS_DOMAIN_NAME", "OS_USER_DOMAIN_NAME", "OS_PROJECT_ID", "OS_PROJECT_NAME", "OS_POOL_NAME"})
 		})
 
+		if os.Getenv("OS_PROJECT_NAME") != "" && os.Getenv("OS_PROJECT_ID") != "" {
+			Convey("You can get a new OpenStack Provider with both OS_PROJECT_NAME and OS_PROJECT_ID set", t, func() {
+				p, err := New("openstack", resourceName, crfileprefix, testLogger)
+				So(err, ShouldBeNil)
+				So(p, ShouldNotBeNil)
+			})
+
+			Convey("You can get a new OpenStack Provider with just OS_PROJECT_NAME set", t, func() {
+				os.Unsetenv("OS_PROJECT_ID")
+				p, err := New("openstack", resourceName, crfileprefix, testLogger)
+				So(err, ShouldBeNil)
+				So(p, ShouldNotBeNil)
+			})
+		}
+
 		Convey("You can get a new OpenStack Provider", t, func() {
 			p, err := New("openstack", resourceName, crfileprefix, testLogger)
 			So(err, ShouldBeNil)

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -158,6 +158,9 @@ func (p *openstackp) initialize(logger log15.Logger) error {
 	// we use a non-standard env var to find the default network from which to
 	// get floating IPs from, which defaults depending on age of OpenStack
 	// installation
+	// *** A Nova "pool" can be thought of as a Neutron public subnet. It should
+	// be possible to query/search for a subnet using the Neutron API without
+	// having to provide a project ID and pool name.
 	p.poolName = os.Getenv("OS_POOL_NAME")
 	if p.poolName == "" {
 		if os.Getenv("OS_TENANT_ID") != "" {

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -191,10 +191,10 @@ You will need additional environment variables, but these depend on the version
 of OpenStack you're using. Older installs may need:
 OS_TENANT_ID, OS_TENANT_NAME
 Newer installs may need:
-OS_PROJECT_ID, OS_PROJECT_NAME, and one of OS_DOMAIN_ID (aka
+OS_PROJECT_ID or OS_PROJECT_NAME, and one of OS_DOMAIN_ID (aka
 OS_PROJECT_DOMAIN_ID) or OS_DOMAIN_NAME (aka OS_USER_DOMAIN_NAME)
-Depending on the install, one of OS_TENANT_ID and OS_PROJECT_ID is required. You
-might also need OS_USERID.
+Depending on the install, one of OS_TENANT_ID and OS_PROJECT_ID may be required.
+You might also need OS_USERID.
 You can get the necessary values by logging in to your OpenStack dashboard web
 interface and looking for the 'Download Openstack RC File' button. For older
 installs this is in the Compute -> Access & Security, 'API Access' tab. For


### PR DESCRIPTION
We used to require both OS_PROJECT_NAME and ID, when just NAME should be fine.
This has now been fixed.

We're still guessing at the pool name, and perhaps that can be fixed in the future if it's a problem for anyone.