### PR TITLE
Fix manager start not reading config file in PWD.

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -201,6 +201,7 @@ fully.`,
 			syscall.Umask(config.ManagerUmask)
 			startJQ(postCreation)
 		} else {
+			config.ToEnv()
 			child, context := daemonize(config.ManagerPidFile, config.ManagerUmask, extraArgs...)
 			if child != nil {
 				// parent; wait a while for our child to bring up the manager

--- a/internal/config.go
+++ b/internal/config.go
@@ -191,6 +191,21 @@ func (c Config) String() string {
 	return tableString.String()
 }
 
+// ToEnv sets all config values as environment variables.
+func (c Config) ToEnv() {
+	vals := reflect.ValueOf(c)
+	typeOfC := vals.Type()
+
+	for i := 0; i < vals.NumField(); i++ {
+		property := typeOfC.Field(i).Name
+		if property == sourcesProperty {
+			continue
+		}
+
+		os.Setenv("WR_"+strings.ToUpper(property), fmt.Sprintf("%v", vals.Field(i).Interface()))
+	}
+}
+
 // ConfigLoadFromCurrentDir loads and returns the config from current directory.
 func ConfigLoadFromCurrentDir(ctx context.Context, deployment string) *Config {
 	pwd, uid := getPWDAndUID(ctx)

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -778,6 +778,18 @@ func TestConfig(t *testing.T) {
 			config := ConfigLoadFromCurrentDir(ctx, "testing")
 			So(config, ShouldNotBeNil)
 			So(config.IsProduction(), ShouldBeTrue)
+
+			Convey("config values can be exported as env vars", func() {
+				config.ToEnv()
+				So(os.Getenv("WR_MANAGERWEB"), ShouldEqual, config.ManagerWeb)
+				So(os.Getenv("WR_MANAGERDIR"), ShouldEqual, config.ManagerDir)
+
+				if config.ManagerSetDomainIP {
+					So(os.Getenv("WR_MANAGERSETDOMAINIP"), ShouldEqual, "true")
+				} else {
+					So(os.Getenv("WR_MANAGERSETDOMAINIP"), ShouldEqual, "false")
+				}
+			})
 		})
 
 		Convey("It can get the default config", func() {


### PR DESCRIPTION
New config.ToEnv() method.

The manager daemon changes directory to `/` as per good daemon behaviour to allow file systems to be unmounted.
However, this means that the daemon doesn't see any config files that were in the original PWD the user started the manager in.

The solution here is to set all config values as env vars so that the daemon can read and use those values.