### PR TITLE
Resolve #212: enable a mount on spawned servers.

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -899,7 +899,6 @@ func bootstrapOnRemote(provider *cloud.Provider, server *cloud.Server, exe strin
 
 	// mount remote filesystem
 	if mountJSON != "" {
-		warn("will mount...")
 		_, stde, errf := server.RunCmd(ctx, fmt.Sprintf("%s mount -j '%s'", remoteExe, mountJSON), false)
 		if errf != nil {
 			warn("failed to mount: %s\nstderr: %s\n", errf, stde)

--- a/internal/config.go
+++ b/internal/config.go
@@ -202,7 +202,12 @@ func (c Config) ToEnv() {
 			continue
 		}
 
-		os.Setenv("WR_"+strings.ToUpper(property), fmt.Sprintf("%v", vals.Field(i).Interface()))
+		value := fmt.Sprintf("%v", vals.Field(i).Interface())
+		if property == "ManagerDir" {
+			value = strings.TrimSuffix(value, "_"+c.Deployment)
+		}
+
+		os.Setenv("WR_"+strings.ToUpper(property), value)
 	}
 }
 

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -782,7 +782,10 @@ func TestConfig(t *testing.T) {
 			Convey("config values can be exported as env vars", func() {
 				config.ToEnv()
 				So(os.Getenv("WR_MANAGERWEB"), ShouldEqual, config.ManagerWeb)
-				So(os.Getenv("WR_MANAGERDIR"), ShouldEqual, config.ManagerDir)
+				So(os.Getenv("WR_RUNNEREXECSHELL"), ShouldEqual, config.RunnerExecShell)
+				So(os.Getenv("WR_MANAGERDIR"), ShouldEqual, TildaToHome("~/.wr"))
+				So(os.Getenv("WR_MANAGERDIR"), ShouldNotEqual, config.ManagerDir)
+				So(os.Getenv("WR_MANAGERLOGFILE"), ShouldEqual, filepath.Join(config.ManagerDir, "log"))
 
 				if config.ManagerSetDomainIP {
 					So(os.Getenv("WR_MANAGERSETDOMAINIP"), ShouldEqual, "true")

--- a/script
+++ b/script
@@ -1,0 +1,1 @@
+echo foo > /tmp/bar

--- a/script
+++ b/script
@@ -1,1 +1,0 @@
-echo foo > /tmp/bar


### PR DESCRIPTION
This adds `--mount_json` to `wr cloud deploy`, which lets you mount an S3 bucket on all spawned servers.

It also fixes a previously introduced bug that prevented servers being spawned in OpenStack.