### PR TITLE
LSF queue fix

### DIFF
--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -629,7 +629,7 @@ func (s *lsf) determineQueue(req *Requirements, globalMax int) (string, error) {
 		return queue, nil
 	}
 
-	seconds := req.Time.Seconds() + float64(minimumQueueTime)
+	seconds := req.Time.Seconds() + minimumQueueTime.Seconds()
 	mb := req.RAM
 	sortedQueue := 0
 	if globalMax > 0 {

--- a/jobqueue/scheduler/lsf.go
+++ b/jobqueue/scheduler/lsf.go
@@ -629,7 +629,7 @@ func (s *lsf) determineQueue(req *Requirements, globalMax int) (string, error) {
 		return queue, nil
 	}
 
-	seconds := req.Time.Seconds()
+	seconds := req.Time.Seconds() + float64(minimumQueueTime)
 	mb := req.RAM
 	sortedQueue := 0
 	if globalMax > 0 {


### PR DESCRIPTION
LSF scheduler could pick a queue with a time limit exactly matching the job's requirement, which means the runner would think there wasn't enough time to run the job, never running anything.

Now we add a minute to stop this happening.