### PR TITLE
Always show STDOUT/ERR in status

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -108,10 +108,11 @@ future.
 You can also supply just a single command and the --sync option (for
 "synchronous add"), which will result in this command not exiting until the
 manager has finished executing the command. This command will then exit with
-your command's exit code and output the top and tail of its STDOUT and STDERR if
-it had failed. You might use synchronous mode within a simple script that runs
-other commands but needs one of them executed by wr in your cluster environment,
-and if your script can't easily cope with wr's normally asynchonous behaviour.
+your command's exit code and output the head and tail of its STDOUT and STDERR
+if it had failed. You might use synchronous mode within a simple script that
+runs other commands but needs one of them executed by wr in your cluster
+environment, and if your script can't easily cope with wr's normally asynchonous
+behaviour.
 
 You can supply your commands by putting them in a text file (1 per line), or
 by piping them in. In addition to the command itself, you can specify command-

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -89,14 +89,14 @@ name to just the first letter, eg. -o c):
     (and you are told how many are not being displayed). A limit of 0 turns off
     grouping and shows all your desired commands individually, but you could hit
     a timeout if retrieving the details of very many (tens of thousands+)
-	commands. If more than 1000 buried job get displayed, their STDOUT and
+	commands. If more than 1000 buried jobs get displayed, their STDOUT and
 	STDERR are not shown.
   "plain" outputs 2 tab separated columns: internal job id and current state of
 	that job. Possible states are: delayed, ready, reserved, running, lost,
 	buried, complete. If any jobs are buried, exits non-0 as well.
   "json" simply dumps the complete details of every job out as an array of
     JSON objects. The properties of the JSON objects are described in the
-    documentation for wr's REST API. If more than 1000 buried job get
+    documentation for wr's REST API. If more than 1000 buried jobs get
 	returned, their STDOUT and STDERR are excluded.
 
 Note that when jobs run, wr only stores the head and tail of STDOUT and STDERR,

--- a/internal/cert_test.go
+++ b/internal/cert_test.go
@@ -66,13 +66,6 @@ func TestCert(t *testing.T) {
 			So(certTmplt, ShouldNotBeNil)
 
 			Convey("it can create a certificate from it", func() {
-				Convey("not when an empty template is used", func() {
-					testTmpl := x509.Certificate{}
-					certByte, err := createCertFromTemplate(&testTmpl, certTmplt, &rsaKey.PublicKey, rsaKey, crand.Reader)
-					So(err, ShouldNotBeNil)
-					So(certByte, ShouldBeNil)
-				})
-
 				Convey("when a non-empty template is used", func() {
 					certByte, err := createCertFromTemplate(certTmplt, certTmplt, &rsaKey.PublicKey, rsaKey, crand.Reader)
 					So(err, ShouldBeNil)
@@ -123,13 +116,7 @@ func TestCert(t *testing.T) {
 					So(rootCert, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 
-					Convey("not with an empty template", func() {
-						empRootCert, err := generateRootCert(caFile, &x509.Certificate{}, rsaKey, crand.Reader, certFileFlags)
-						So(empRootCert, ShouldBeNil)
-						So(err, ShouldNotBeNil)
-					})
-
-					Convey("and not when file cannot be written", func() {
+					Convey("not when file cannot be written", func() {
 						empRootCert, err := generateRootCert(caFile, certTmplt, rsaKey, crand.Reader, blockFileWrite)
 						So(empRootCert, ShouldBeNil)
 						So(err, ShouldNotBeNil)
@@ -139,12 +126,7 @@ func TestCert(t *testing.T) {
 						err := generateServerCert(certFile, rootCert, certTmplt, rsaKey, rsaKey, crand.Reader, certFileFlags)
 						So(err, ShouldBeNil)
 
-						Convey("not with an empty template", func() {
-							err = generateServerCert(certFile, rootCert, &x509.Certificate{}, rsaKey, rsaKey, crand.Reader, certFileFlags)
-							So(err, ShouldNotBeNil)
-						})
-
-						Convey("and not when file cannot be written", func() {
+						Convey("not when file cannot be written", func() {
 							err = generateServerCert(certFile, rootCert, certTmplt, rsaKey, rsaKey, crand.Reader, blockFileWrite)
 							So(err, ShouldNotBeNil)
 						})

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -2414,6 +2414,9 @@ func (s *Server) limitJobs(ctx context.Context, jobs []*Job, limit int, state Jo
 	return limited
 }
 
+// shouldPopulateStd only returns true if the given getStd is true and if the
+// number of jobs that could potentially have std is less than or equal to the
+// maxJobsForStd.
 func shouldPopulateStd(jobs []*Job, getStd bool) bool {
 	if !getStd {
 		return false

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -87,6 +87,8 @@ const (
 	ServerModeDrain     = "draining"
 )
 
+const maxJobsForStd = 1000
+
 // ServerVersion gets set during build:
 // go build -ldflags "-X github.com/VertebrateResequencing/wr/jobqueue.ServerVersion=`git describe --tags --always --long --dirty`"
 var ServerVersion string
@@ -2196,13 +2198,21 @@ func (s *Server) getJobsByKeys(ctx context.Context, keys []string, getStd bool, 
 		item, err := s.q.Get(jobkey)
 		var job *Job
 		if err == nil && item != nil {
-			job = s.itemToJob(ctx, item, getStd, getEnv)
+			job = s.itemToJob(ctx, item, false, false)
 		} else {
 			notfound = append(notfound, jobkey)
 		}
 
 		if job != nil {
 			jobs = append(jobs, job)
+		}
+	}
+
+	getStd = shouldPopulateStd(jobs, getStd)
+
+	if getStd || getEnv {
+		for _, job := range jobs {
+			s.jobPopulateStdEnv(ctx, job, getStd, getEnv)
 		}
 	}
 
@@ -2393,6 +2403,8 @@ func (s *Server) limitJobs(ctx context.Context, jobs []*Job, limit int, state Jo
 		}
 	}
 
+	getStd = shouldPopulateStd(limited, getStd)
+
 	if getEnv || getStd {
 		for _, job := range limited {
 			s.jobPopulateStdEnv(ctx, job, getStd, getEnv)
@@ -2400,6 +2412,22 @@ func (s *Server) limitJobs(ctx context.Context, jobs []*Job, limit int, state Jo
 	}
 
 	return limited
+}
+
+func shouldPopulateStd(jobs []*Job, getStd bool) bool {
+	if !getStd {
+		return false
+	}
+
+	hasStd := 0
+
+	for _, job := range jobs {
+		if jobCouldHaveStd(job) {
+			hasStd++
+		}
+	}
+
+	return hasStd <= maxJobsForStd
 }
 
 // schedulerGroupDetails is used for debugging purposes to see how many jobs are

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -839,9 +839,11 @@ func (s *Server) jobPopulateStdEnv(ctx context.Context, job *Job, getStd bool, g
 
 	job.Lock()
 	defer job.Unlock()
+
 	if getStd && jobCouldHaveStd(job) {
 		job.StdOutC, job.StdErrC = s.db.retrieveJobStd(ctx, job.Key())
 	}
+
 	if getEnv {
 		job.EnvC = s.db.retrieveEnv(ctx, job.EnvKey)
 		job.EnvCRetrieved = true

--- a/limiter/group.go
+++ b/limiter/group.go
@@ -135,7 +135,7 @@ func beforeDateTimeLimitParse(name string) (string, *GroupData) {
 		return "", nil
 	}
 
-	t, err := time.Parse(time.DateTime, matches[1])
+	t, err := time.ParseInLocation(time.DateTime, matches[1], time.Local) //nolint:gosmopolitan
 	if err != nil {
 		return "", nil
 	}
@@ -149,7 +149,7 @@ func afterDateTimeLimitParse(name string) (string, *GroupData) {
 		return "", nil
 	}
 
-	t, err := time.Parse(time.DateTime, matches[1])
+	t, err := time.ParseInLocation(time.DateTime, matches[1], time.Local) //nolint:gosmopolitan
 	if err != nil {
 		return "", nil
 	}
@@ -163,12 +163,12 @@ func betweenDateTimesLimitParse(name string) (string, *GroupData) {
 		return "", nil
 	}
 
-	t, err := time.Parse(time.DateTime, matches[1])
+	t, err := time.ParseInLocation(time.DateTime, matches[1], time.Local) //nolint:gosmopolitan
 	if err != nil {
 		return "", nil
 	}
 
-	u, err := time.Parse(time.DateTime, matches[2])
+	u, err := time.ParseInLocation(time.DateTime, matches[2], time.Local) //nolint:gosmopolitan
 	if err != nil {
 		return "", nil
 	}


### PR DESCRIPTION
(except if more than 1000 buried jobs are retrieved)

This is a breaking change for the status command, since --std option is being removed, but shouldn't be the end of the world for people.

Also fixes minor other things that came up, to get all tests to pass again.