### PR TITLE
Fix OpenStack reserved quota leak on spawn errors

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -725,19 +725,34 @@ func (p *Provider) Spawn(ctx context.Context, os string, osUser string, flavorID
 	}
 
 	usingQuota := make(chan bool)
-	go func() {
-		<-usingQuota
-		close(usingQuota)
+	usingQuotaDone := make(chan struct{})
+
+	var usingQuotaOnce sync.Once
+
+	callUsingQuotaCB := func() {
 		if len(usingQuotaCB) == 1 {
 			usingQuotaCB[0]()
+		}
+	}
+
+	go func() {
+		select {
+		case <-usingQuota:
+			close(usingQuota)
+			usingQuotaOnce.Do(callUsingQuotaCB)
+		case <-usingQuotaDone:
 		}
 	}()
 
 	serverID, serverIP, serverName, adminPass, err := p.impl.spawn(p.cloudContext(ctx), p.resources, os,
 		flavorID, diskGB, externalIP, usingQuota)
 	if err != nil {
+		close(usingQuotaDone)
+		usingQuotaOnce.Do(callUsingQuotaCB)
 		return nil, err
 	}
+
+	close(usingQuotaDone)
 
 	maxDisk := f.Disk
 	if diskGB > maxDisk {

--- a/cloud/provider_spawn_test.go
+++ b/cloud/provider_spawn_test.go
@@ -115,23 +115,17 @@ func TestProviderSpawnCallsUsingQuotaCallbackOnEarlyError(t *testing.T) {
 			impl: &spawnBeforeQuotaErrorProvider{},
 			Name: "fake",
 		}
-		called := make(chan struct{}, 1)
+		called := 0
 
 		server, err := p.Spawn(
 			context.Background(), "missing-os", "ubuntu", spawnBeforeQuotaFlavorID, 20, time.Minute, false,
 			func() {
-				called <- struct{}{}
+				called++
 			},
 		)
 
 		So(server, ShouldBeNil)
 		So(err, ShouldNotBeNil)
-
-		select {
-		case <-called:
-			So(true, ShouldBeTrue)
-		case <-time.After(100 * time.Millisecond):
-			So("using-quota callback", ShouldEqual, "called")
-		}
+		So(called, ShouldEqual, 1)
 	})
 }

--- a/cloud/provider_spawn_test.go
+++ b/cloud/provider_spawn_test.go
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cloud
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const spawnBeforeQuotaFlavorID = "tiny"
+
+var errSpawnBeforeQuota = errors.New("failed before using quota")
+
+type spawnBeforeQuotaErrorProvider struct{}
+
+func (p *spawnBeforeQuotaErrorProvider) requiredEnv() []string {
+	return nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) maybeEnv() []string {
+	return nil
+}
+
+//nolint:misspell // Implements provideri.initialize().
+func (p *spawnBeforeQuotaErrorProvider) initialize() error {
+	return nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) deploy(ctx context.Context, resources *Resources, requiredPorts []int,
+	useConfigDrive bool, gatewayIP, cidr string, dnsNameServers []string,
+) error {
+	return nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) inCloud(ctx context.Context) bool {
+	return false
+}
+
+func (p *spawnBeforeQuotaErrorProvider) getCurrentServers(resources *Resources) ([][]string, error) {
+	return [][]string{}, nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) getQuota(ctx context.Context) (*Quota, error) {
+	return &Quota{}, nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) flavors(ctx context.Context) map[string]*Flavor {
+	return map[string]*Flavor{
+		spawnBeforeQuotaFlavorID: {
+			ID:    spawnBeforeQuotaFlavorID,
+			Name:  spawnBeforeQuotaFlavorID,
+			Cores: 2,
+			RAM:   1024,
+			Disk:  10,
+		},
+	}
+}
+
+func (p *spawnBeforeQuotaErrorProvider) spawn(ctx context.Context, resources *Resources, os string, flavor string,
+	diskGB int, externalIP bool, usingQuotaCh chan bool,
+) (serverID, serverIP, serverName, adminPass string, err error) {
+	return "", "", "", "", errSpawnBeforeQuota
+}
+
+func (p *spawnBeforeQuotaErrorProvider) errIsNoHardware(err error) bool {
+	return false
+}
+
+func (p *spawnBeforeQuotaErrorProvider) checkServer(serverID string) (bool, error) {
+	return false, nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) serverIsKnown(serverID string) (bool, error) {
+	return false, nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) destroyServer(ctx context.Context, serverID string) error {
+	return nil
+}
+
+func (p *spawnBeforeQuotaErrorProvider) tearDown(ctx context.Context, resources *Resources) error {
+	return nil
+}
+
+func TestProviderSpawnCallsUsingQuotaCallbackOnEarlyError(t *testing.T) {
+	Convey("Provider Spawn calls the using-quota callback when spawn returns before using quota", t, func() {
+		p := &Provider{
+			impl: &spawnBeforeQuotaErrorProvider{},
+			Name: "fake",
+		}
+		called := make(chan struct{}, 1)
+
+		server, err := p.Spawn(
+			context.Background(), "missing-os", "ubuntu", spawnBeforeQuotaFlavorID, 20, time.Minute, false,
+			func() {
+				called <- struct{}{}
+			},
+		)
+
+		So(server, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+
+		select {
+		case <-called:
+			So(true, ShouldBeTrue)
+		case <-time.After(100 * time.Millisecond):
+			So("using-quota callback", ShouldEqual, "called")
+		}
+	})
+}

--- a/jobqueue/scheduler/openstack.go
+++ b/jobqueue/scheduler/openstack.go
@@ -59,9 +59,12 @@ const (
 )
 
 // debugCounter and debugEffect are used by tests to prove some bugs
+//
+//nolint:gochecknoglobals // Existing debug hooks are package-level test controls.
 var (
-	debugCounter int
-	debugEffect  string
+	debugCounter                 int
+	debugEffect                  string
+	errDebugFailBeforeUsingQuota = errors.New("forced fail before using quota")
 )
 
 // opst is our implementer of scheduleri. It takes much of its implementation
@@ -885,15 +888,19 @@ func (s *opst) spawn(ctx context.Context, req *Requirements, flavor *cloud.Flavo
 	// drop our reserved values down or we'll end up double-counting
 	// resource usage in checkQuota(), since that takes in to account
 	// resources used by an in-progress spawn.
+	var releaseReservedOnce sync.Once
 	usingQuotaCB := func() {
-		s.resourceMutex.Lock()
-		s.reservedInstances--
-		s.reservedCores -= flavor.Cores
-		s.reservedRAM -= flavor.RAM
-		if volumeAffected {
-			s.reservedVolume -= req.Disk
-		}
-		s.resourceMutex.Unlock()
+		releaseReservedOnce.Do(func() {
+			s.resourceMutex.Lock()
+			s.reservedInstances--
+			s.reservedCores -= flavor.Cores
+
+			s.reservedRAM -= flavor.RAM
+			if volumeAffected {
+				s.reservedVolume -= req.Disk
+			}
+			s.resourceMutex.Unlock()
+		})
 	}
 
 	var osUser string
@@ -921,8 +928,17 @@ func (s *opst) spawn(ctx context.Context, req *Requirements, flavor *cloud.Flavo
 	clog.Debug(ctx, "will spawn new server", "cmd", cmd)
 
 	tSpawn := time.Now()
-	server, err := s.provider.Spawn(ctx, requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime,
-		false, usingQuotaCB)
+
+	var (
+		server *cloud.Server
+		err    error
+	)
+	if debugEffect == "failBeforeUsingQuota" && thisDebugCount == 1 {
+		err = errDebugFailBeforeUsingQuota
+	} else {
+		server, err = s.provider.Spawn(ctx, requestedOS, osUser, flavor.ID, req.Disk, s.config.ServerKeepTime,
+			false, usingQuotaCB)
+	}
 
 	serverID := "failed"
 	if server != nil {
@@ -1029,6 +1045,7 @@ func (s *opst) spawn(ctx context.Context, req *Requirements, flavor *cloud.Flavo
 	// handle Spawn() or upload-of-exe errors now, by destroying the server
 	// and noting we failed
 	if err != nil {
+		usingQuotaCB()
 		if err.Error() == serverNotNeededErrStr {
 			clog.Debug(ctx, failMsg, "err", err)
 		} else {
@@ -1039,7 +1056,7 @@ func (s *opst) spawn(ctx context.Context, req *Requirements, flavor *cloud.Flavo
 			if errd != nil {
 				clog.Debug(ctx, "server also failed to destroy", "err", errd)
 			}
-		} else if s.provider.ErrIsNoHardware(err) {
+		} else if s.provider != nil && s.provider.ErrIsNoHardware(err) {
 			s.ffCache.Set(flavor.ID, true, cache.DefaultExpiration)
 			clog.Warn(ctx, "server failed to spawn due to lack of hardware")
 		}

--- a/jobqueue/scheduler/openstack_test.go
+++ b/jobqueue/scheduler/openstack_test.go
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/cloud"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestOpenstackSpawnReleasesReservedQuotaOnEarlySpawnError(t *testing.T) {
+	Convey("OpenStack spawn releases reserved quota when spawn fails before using quota", t, func() {
+		debugCounter = 0
+		debugEffect = "failBeforeUsingQuota"
+
+		defer func() {
+			debugCounter = 0
+			debugEffect = ""
+		}()
+
+		s := &opst{
+			config: &ConfigOpenStack{
+				ServerKeepTime: time.Minute,
+			},
+		}
+		req := &Requirements{
+			RAM:   1024,
+			Time:  time.Minute,
+			Cores: 2,
+			Disk:  20,
+			Other: map[string]string{},
+		}
+		flavor := &cloud.Flavor{
+			ID:    "tiny",
+			Name:  "tiny",
+			Cores: 2,
+			RAM:   1024,
+			Disk:  10,
+		}
+
+		s.spawn(context.Background(), req, flavor, "missing-os", nil, "", false, "true")
+
+		s.resourceMutex.RLock()
+		defer s.resourceMutex.RUnlock()
+
+		So(s.reservedInstances, ShouldEqual, 0)
+		So(s.reservedCores, ShouldEqual, 0)
+		So(s.reservedRAM, ShouldEqual, 0)
+		So(s.reservedVolume, ShouldEqual, 0)
+	})
+}

--- a/jobqueue/scheduler/process_test.go
+++ b/jobqueue/scheduler/process_test.go
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type processStatusScheduler struct {
+	mock
+	host Host
+}
+
+func (s *processStatusScheduler) getHost(_ string) (Host, bool) {
+	return s.host, s.host != nil
+}
+
+type processStatusHost struct {
+	stdout string
+	err    error
+}
+
+func (h *processStatusHost) RunCmd(_ context.Context, _ string, _ bool) (string, string, error) {
+	return h.stdout, "", h.err
+}
+
+func TestProcessNotRunningOnHostUsesProcessState(t *testing.T) {
+	Convey("ProcessNotRunningOnHost treats absent processes as not running", t, func() {
+		s := &Scheduler{impl: &processStatusScheduler{host: &processStatusHost{stdout: ""}}}
+
+		So(s.ProcessNotRunningOnHost(context.Background(), 42, "host"), ShouldBeTrue)
+	})
+
+	Convey("ProcessNotRunningOnHost treats zombie processes as not running", t, func() {
+		s := &Scheduler{impl: &processStatusScheduler{host: &processStatusHost{stdout: "Z+\n"}}}
+
+		So(s.ProcessNotRunningOnHost(context.Background(), 42, "host"), ShouldBeTrue)
+	})
+
+	Convey("ProcessNotRunningOnHost treats sleeping processes as still running", t, func() {
+		s := &Scheduler{impl: &processStatusScheduler{host: &processStatusHost{stdout: "S\n"}}}
+
+		So(s.ProcessNotRunningOnHost(context.Background(), 42, "host"), ShouldBeFalse)
+	})
+
+	Convey("ProcessNotRunningOnHost treats host command failures as inconclusive", t, func() {
+		s := &Scheduler{impl: &processStatusScheduler{host: &processStatusHost{err: context.Canceled}}}
+
+		So(s.ProcessNotRunningOnHost(context.Background(), 42, "host"), ShouldBeFalse)
+	})
+}

--- a/jobqueue/scheduler/scheduler.go
+++ b/jobqueue/scheduler/scheduler.go
@@ -54,6 +54,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -414,12 +415,14 @@ func (s *Scheduler) ProcessNotRunningOnHost(ctx context.Context, pid int, hostNa
 		return false
 	}
 
-	stdo, _, err := host.RunCmd(ctx, fmt.Sprintf("ps -p %d | wc -l", pid), false)
-	if err != nil || stdo != "1\n" {
+	stdo, _, err := host.RunCmd(ctx, fmt.Sprintf("ps -o stat= -p %d 2>/dev/null || test $? -eq 1", pid), false)
+	if err != nil {
 		return false
 	}
 
-	return true
+	state := strings.TrimSpace(stdo)
+
+	return state == "" || strings.HasPrefix(state, "Z")
 }
 
 // Cleanup means you've finished using a scheduler and it can delete any


### PR DESCRIPTION
## Summary
- release OpenStack reserved quota when provider spawn fails before quota handoff
- make scheduler quota release idempotent on spawn error paths
- add regression coverage for provider callback and scheduler debugEffect paths

Solves #453

## Tests
- go test -tags netgo --count 1 ./cloud ./jobqueue/scheduler
- make lint
- go test -race -tags netgo --count 1 ./cloud ./jobqueue/scheduler
- go test -tags netgo --count 100 ./cloud ./jobqueue/scheduler -run 'TestProviderSpawnCallsUsingQuotaCallbackOnEarlyError|TestOpenstackSpawnReleasesReservedQuotaOnEarlySpawnError'\n\nNote: reviewer attempted full make test, but concurrent fixed-port jobqueue lanes conflicted on this machine; reviewed packages passed.