### PR TITLE
Fix small add, status time, and websocket issues

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -69,6 +69,7 @@ var (
 	cmdPri                  int
 	cmdRet                  int
 	cmdFile                 string
+	cmdHead                 int
 	cmdCwdMatters           bool
 	cmdChangeHome           bool
 	cmdRepGroup             string
@@ -475,6 +476,10 @@ directory, with ManagerHost, ManagerPort, and ManagerCertDomain set.`,
 			die("--with_docker and --with_singularity are mutually exclusive")
 		}
 
+		if cmdHead < 0 {
+			die("--head can't be negative")
+		}
+
 		timeout := time.Duration(timeoutint) * time.Second
 		jq := connect(timeout)
 		var err error
@@ -532,6 +537,7 @@ func init() {
 
 	// flags specific to this sub-command
 	addCmd.Flags().StringVarP(&cmdFile, "file", "f", "-", "file containing your commands; - means read from STDIN")
+	addCmd.Flags().IntVar(&cmdHead, "head", 0, "only add the first N parsed commands from the command file; 0 means all")
 	addCmd.Flags().StringVarP(&cmdRepGroup, "rep_grp", "i", "manually_added", "reporting group for your commands")
 	addCmd.Flags().StringVarP(&cmdLimitGroups, "limit_grps", "l", "", "comma-separated list of limit groups")
 	addCmd.Flags().StringVar(&cmdModules, "modules", "", "comma-separated list of environment modules to load")
@@ -858,6 +864,9 @@ func parseCmdFile(jq *jobqueue.Client, diskSet bool) ([]*jobqueue.Job, bool, boo
 		checkForRelativePathsInNonCwdMatters(&warnedAboutRelative, cwdContents, job)
 
 		jobs = append(jobs, job)
+		if cmdHead > 0 && len(jobs) >= cmdHead {
+			break
+		}
 	}
 
 	serr := scanner.Err()

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -35,6 +35,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/jobqueue"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -130,6 +131,194 @@ func runSynchronousAddHelper(exitCode int, stdout string, stderr string, exit fu
 		true,
 		exit,
 	)
+}
+
+func TestAddHeadKeepsFirstParsedCommands(t *testing.T) {
+	Convey("wr add --head keeps only the first parsed commands from a command file", t, func() {
+		cmdPath := filepath.Join(t.TempDir(), "cmds.txt")
+		err := os.WriteFile(cmdPath, []byte("\ncmd one\ncmd two\t{\"rep_grp\":\"custom\"}\ncmd three\n"), 0600)
+		So(err, ShouldBeNil)
+
+		configureAddParserTest(t, cmdPath)
+		So(addCmd.Flags().Set("head", "2"), ShouldBeNil)
+
+		jq := &jobqueue.Client{ServerInfo: &jobqueue.ServerInfo{Addr: "remote:1234"}}
+		jobs, _, _ := parseCmdFile(jq, false)
+
+		So(jobs, ShouldHaveLength, 2)
+		So(jobs[0].Cmd, ShouldEqual, "cmd one")
+		So(jobs[1].Cmd, ShouldEqual, "cmd two")
+		So(jobs[1].RepGroup, ShouldEqual, "custom")
+	})
+}
+
+func TestAddHeadZeroKeepsAllParsedCommands(t *testing.T) {
+	Convey("wr add --head 0 keeps all parsed commands from a command file", t, func() {
+		cmdPath := filepath.Join(t.TempDir(), "cmds.txt")
+		err := os.WriteFile(cmdPath, []byte("\ncmd one\ncmd two\ncmd three\n"), 0600)
+		So(err, ShouldBeNil)
+
+		configureAddParserTest(t, cmdPath)
+		So(addCmd.Flags().Set("head", "0"), ShouldBeNil)
+
+		jq := &jobqueue.Client{ServerInfo: &jobqueue.ServerInfo{Addr: "remote:1234"}}
+		jobs, _, _ := parseCmdFile(jq, false)
+
+		So(jobs, ShouldHaveLength, 3)
+		So(jobs[0].Cmd, ShouldEqual, "cmd one")
+		So(jobs[1].Cmd, ShouldEqual, "cmd two")
+		So(jobs[2].Cmd, ShouldEqual, "cmd three")
+	})
+}
+
+func configureAddParserTest(t *testing.T, cmdPath string) {
+	t.Helper()
+
+	oldConfig := config
+	oldCmdFile := cmdFile
+	oldCmdRepGroup := cmdRepGroup
+	oldCmdLimitGroups := cmdLimitGroups
+	oldCmdModules := cmdModules
+	oldCmdDepGroups := cmdDepGroups
+	oldCmdCwd := cmdCwd
+	oldCmdCwdMatters := cmdCwdMatters
+	oldCmdChangeHome := cmdChangeHome
+	oldReqGroup := reqGroup
+	oldCmdMem := cmdMem
+	oldCmdTime := cmdTime
+	oldCmdCPUs := cmdCPUs
+	oldCmdDisk := cmdDisk
+	oldCmdOvr := cmdOvr
+	oldCmdPri := cmdPri
+	oldCmdRet := cmdRet
+	oldCmdNoRetry := cmdNoRetry
+	oldCmdCmdDeps := cmdCmdDeps
+	oldCmdGroupDeps := cmdGroupDeps
+	oldCmdMonitorDocker := cmdMonitorDocker
+	oldCmdWithDocker := cmdWithDocker
+	oldCmdWithSingularity := cmdWithSingularity
+	oldCmdContainerMounts := cmdContainerMounts
+	oldCmdOnFailure := cmdOnFailure
+	oldCmdOnSuccess := cmdOnSuccess
+	oldCmdOnExit := cmdOnExit
+	oldMountJSON := mountJSON
+	oldMountSimple := mountSimple
+	oldCmdOsPrefix := cmdOsPrefix
+	oldCmdOsUsername := cmdOsUsername
+	oldCmdOsRAM := cmdOsRAM
+	oldCmdFlavor := cmdFlavor
+	oldCmdPostCreationScript := cmdPostCreationScript
+	oldCmdCloudConfigs := cmdCloudConfigs
+	oldCmdCloudSharedDisk := cmdCloudSharedDisk
+	oldCmdQueue := cmdQueue
+	oldCmdQueuesAvoidAdd := cmdQueuesAvoidAdd
+	oldCmdMisc := cmdMisc
+	oldCmdEnv := cmdEnv
+	oldCmdReRun := cmdReRun
+	oldCmdBsubMode := cmdBsubMode
+	oldCmdDisableRelativeCheck := cmdDisableRelativeCheck
+	oldCmdGroup := cmdGroup
+	oldRtimeoutint := rtimeoutint
+
+	t.Cleanup(func() {
+		config = oldConfig
+		cmdFile = oldCmdFile
+		cmdRepGroup = oldCmdRepGroup
+		cmdLimitGroups = oldCmdLimitGroups
+		cmdModules = oldCmdModules
+		cmdDepGroups = oldCmdDepGroups
+		cmdCwd = oldCmdCwd
+		cmdCwdMatters = oldCmdCwdMatters
+		cmdChangeHome = oldCmdChangeHome
+		reqGroup = oldReqGroup
+		cmdMem = oldCmdMem
+		cmdTime = oldCmdTime
+		cmdCPUs = oldCmdCPUs
+		cmdDisk = oldCmdDisk
+		cmdOvr = oldCmdOvr
+		cmdPri = oldCmdPri
+		cmdRet = oldCmdRet
+		cmdNoRetry = oldCmdNoRetry
+		cmdCmdDeps = oldCmdCmdDeps
+		cmdGroupDeps = oldCmdGroupDeps
+		cmdMonitorDocker = oldCmdMonitorDocker
+		cmdWithDocker = oldCmdWithDocker
+		cmdWithSingularity = oldCmdWithSingularity
+		cmdContainerMounts = oldCmdContainerMounts
+		cmdOnFailure = oldCmdOnFailure
+		cmdOnSuccess = oldCmdOnSuccess
+		cmdOnExit = oldCmdOnExit
+		mountJSON = oldMountJSON
+		mountSimple = oldMountSimple
+		cmdOsPrefix = oldCmdOsPrefix
+		cmdOsUsername = oldCmdOsUsername
+		cmdOsRAM = oldCmdOsRAM
+		cmdFlavor = oldCmdFlavor
+		cmdPostCreationScript = oldCmdPostCreationScript
+		cmdCloudConfigs = oldCmdCloudConfigs
+		cmdCloudSharedDisk = oldCmdCloudSharedDisk
+		cmdQueue = oldCmdQueue
+		cmdQueuesAvoidAdd = oldCmdQueuesAvoidAdd
+		cmdMisc = oldCmdMisc
+		cmdEnv = oldCmdEnv
+		cmdReRun = oldCmdReRun
+		cmdBsubMode = oldCmdBsubMode
+		cmdDisableRelativeCheck = oldCmdDisableRelativeCheck
+		cmdGroup = oldCmdGroup
+		rtimeoutint = oldRtimeoutint
+
+		if addCmd.Flags().Lookup("head") != nil {
+			if err := addCmd.Flags().Set("head", "0"); err != nil {
+				t.Errorf("reset add --head: %s", err)
+			}
+		}
+	})
+
+	config = &internal.Config{ManagerPort: "4321"}
+	cmdFile = cmdPath
+	cmdRepGroup = "head-test"
+	cmdLimitGroups = ""
+	cmdModules = ""
+	cmdDepGroups = ""
+	cmdCwd = t.TempDir()
+	cmdCwdMatters = true
+	cmdChangeHome = false
+	reqGroup = ""
+	cmdMem = "1G"
+	cmdTime = "1h"
+	cmdCPUs = 1
+	cmdDisk = 0
+	cmdOvr = "no"
+	cmdPri = 0
+	cmdRet = 3
+	cmdNoRetry = ""
+	cmdCmdDeps = ""
+	cmdGroupDeps = ""
+	cmdMonitorDocker = ""
+	cmdWithDocker = ""
+	cmdWithSingularity = ""
+	cmdContainerMounts = ""
+	cmdOnFailure = ""
+	cmdOnSuccess = ""
+	cmdOnExit = `[{"cleanup":true}]`
+	mountJSON = ""
+	mountSimple = ""
+	cmdOsPrefix = ""
+	cmdOsUsername = ""
+	cmdOsRAM = 0
+	cmdFlavor = ""
+	cmdPostCreationScript = ""
+	cmdCloudConfigs = ""
+	cmdCloudSharedDisk = false
+	cmdQueue = ""
+	cmdQueuesAvoidAdd = "interactive"
+	cmdMisc = ""
+	cmdEnv = ""
+	cmdReRun = false
+	cmdBsubMode = false
+	cmdDisableRelativeCheck = true
+	cmdGroup = ""
+	rtimeoutint = 1
 }
 
 func TestSynchronousAddPrintsStdoutAndExitsZero(t *testing.T) {

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -983,12 +983,12 @@ func (j *Job) ToStatus() (JStatus, error) {
 	}
 
 	if !j.StartTime.IsZero() {
-		i := j.StartTime.Unix()
+		i := j.StartTime.UnixNano()
 		js.Started = &i
 	}
 
 	if !j.EndTime.IsZero() {
-		i := j.EndTime.Unix()
+		i := j.EndTime.UnixNano()
 		js.Ended = &i
 	}
 

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -30,7 +30,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -233,5 +235,30 @@ func TestJob(t *testing.T) {
 				So(cmd, ShouldEndWith, fmt.Sprintf(" | singularity shell -B /foo/bar:/bar -B /foo/baz:/baz %s", image))
 			})
 		})
+	})
+
+	Convey("ToStatus() reports start and end times as Unix nanoseconds", t, func() {
+		started := time.Unix(100, 123456789)
+		ended := started.Add(25 * time.Millisecond)
+		job := &Job{
+			Cmd:          "true",
+			Cwd:          "/cwd",
+			Requirements: &scheduler.Requirements{RAM: 1, Time: time.Second, Cores: 1},
+			StartTime:    started,
+			EndTime:      ended,
+		}
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.Started, ShouldNotBeNil)
+		So(status.Ended, ShouldNotBeNil)
+
+		if status.Started == nil || status.Ended == nil {
+			return
+		}
+
+		So(*status.Started, ShouldEqual, started.UnixNano())
+		So(*status.Ended, ShouldEqual, ended.UnixNano())
+		So(*status.Ended, ShouldBeGreaterThan, *status.Started)
 	})
 }

--- a/jobqueue/static/js/wr/websocket-handler.js
+++ b/jobqueue/static/js/wr/websocket-handler.js
@@ -16,43 +16,80 @@ export function setupWebSocket(viewModel) {
 
     const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${wsProtocol}//${location.hostname}:${location.port}/status_ws?token=${viewModel.token}`;
+    const currentRequest = JSON.stringify({ Request: "current" });
+    const reconnectInitialDelay = 1000;
+    const reconnectMaxDelay = 30000;
+    let reconnectDelay = reconnectInitialDelay;
+    let reconnectTimer = null;
+    let reportedClose = false;
 
-    try {
-        viewModel.ws = new WebSocket(wsUrl);
+    const scheduleReconnect = () => {
+        if (reconnectTimer !== null) {
+            return;
+        }
 
-        viewModel.ws.onopen = () => {
-            viewModel.ws.send(JSON.stringify({ Request: "current" }));
-        };
+        const delay = reconnectDelay;
+        reconnectDelay = Math.min(reconnectDelay * 2, reconnectMaxDelay);
 
-        viewModel.ws.onclose = () => {
-            viewModel.statuserror.push("Connection to the manager has been lost!");
-        };
+        reconnectTimer = window.setTimeout(() => {
+            reconnectTimer = null;
+            connect();
+        }, delay);
+    };
 
-        viewModel.ws.onerror = (error) => {
-            viewModel.statuserror.push(`WebSocket error: ${error.message || 'Unknown error'}`);
-        };
+    const connect = () => {
+        try {
+            const ws = new WebSocket(wsUrl);
+            viewModel.ws = ws;
 
-        viewModel.ws.onmessage = (e) => {
-            try {
-                const json = JSON.parse(e.data);
+            ws.onopen = () => {
+                reconnectDelay = reconnectInitialDelay;
+                reportedClose = false;
+                ws.send(currentRequest);
+            };
 
-                if (json.hasOwnProperty('FromState')) {
-                    handleStateChangeMessage(viewModel, json);
-                } else if (json.hasOwnProperty('State')) {
-                    handleJobDetailsMessage(viewModel, json);
-                } else if (json.hasOwnProperty('IP')) {
-                    handleServerMessage(viewModel, json);
-                } else if (json.hasOwnProperty('Msg')) {
-                    handleSchedulerMessage(viewModel, json);
+            ws.onclose = () => {
+                if (viewModel.ws !== ws) {
+                    return;
                 }
-            } catch (error) {
-                console.error("Error processing message:", error);
-                viewModel.statuserror.push(`Error processing message: ${error.message}`);
-            }
-        };
-    } catch (error) {
-        viewModel.statuserror.push(`Failed to connect: ${error.message}`);
-    }
+
+                if (!reportedClose) {
+                    viewModel.statuserror.push("Connection to the manager has been lost!");
+                    reportedClose = true;
+                }
+
+                scheduleReconnect();
+            };
+
+            ws.onerror = (error) => {
+                viewModel.statuserror.push(`WebSocket error: ${error.message || 'Unknown error'}`);
+            };
+
+            ws.onmessage = (e) => {
+                try {
+                    const json = JSON.parse(e.data);
+
+                    if (json.hasOwnProperty('FromState')) {
+                        handleStateChangeMessage(viewModel, json);
+                    } else if (json.hasOwnProperty('State')) {
+                        handleJobDetailsMessage(viewModel, json);
+                    } else if (json.hasOwnProperty('IP')) {
+                        handleServerMessage(viewModel, json);
+                    } else if (json.hasOwnProperty('Msg')) {
+                        handleSchedulerMessage(viewModel, json);
+                    }
+                } catch (error) {
+                    console.error("Error processing message:", error);
+                    viewModel.statuserror.push(`Error processing message: ${error.message}`);
+                }
+            };
+        } catch (error) {
+            viewModel.statuserror.push(`Failed to connect: ${error.message}`);
+            scheduleReconnect();
+        }
+    };
+
+    connect();
 }
 
 /**

--- a/jobqueue/static/js/wr/websocket-handler.js
+++ b/jobqueue/static/js/wr/websocket-handler.js
@@ -4,6 +4,46 @@
 import { removeBadServer, setupLiveWalltime } from '/js/wr/utility.js';
 import { createRepGroupTracker } from '/js/wr/inflight-tracking.js';
 
+const countProperties = ['delayed', 'dependent', 'ready', 'running', 'lost', 'buried', 'deleted', 'complete'];
+const percentProperties = ['delayPct', 'dependentPct', 'readyPct', 'runPct', 'lostPct', 'buryPct', 'deletePct', 'completePct'];
+const unixNanoThreshold = 1000000000000000;
+
+function resetTrackerCounts(tracker) {
+    for (const property of countProperties.concat(percentProperties)) {
+        if (tracker && typeof tracker[property] === 'function') {
+            tracker[property](0);
+        }
+    }
+
+    if (tracker) {
+        tracker.old_total = 0;
+    }
+}
+
+function resetLiveCounts(viewModel) {
+    resetTrackerCounts(viewModel.inflight);
+    viewModel.ignore = {};
+
+    for (const repgroup of viewModel.repGroups) {
+        if (!repgroup.id.startsWith('search:')) {
+            resetTrackerCounts(repgroup);
+        }
+    }
+}
+
+function normalizeStatusTimestamp(timestamp) {
+    if (typeof timestamp !== 'number' || Math.abs(timestamp) < unixNanoThreshold) {
+        return timestamp;
+    }
+
+    return timestamp / 1000000000;
+}
+
+function normalizeJobStatusTimes(job) {
+    job.Started = normalizeStatusTimestamp(job.Started);
+    job.Ended = normalizeStatusTimestamp(job.Ended);
+}
+
 /**
  * Sets up the WebSocket connection and message handling
  * @param {StatusViewModel} viewModel - The main view model
@@ -44,6 +84,9 @@ export function setupWebSocket(viewModel) {
 
             ws.onopen = () => {
                 reconnectDelay = reconnectInitialDelay;
+                if (reportedClose) {
+                    resetLiveCounts(viewModel);
+                }
                 reportedClose = false;
                 ws.send(currentRequest);
             };
@@ -206,6 +249,8 @@ function jobExists(detailsArray, key) {
  * @param {object} json - The JSON message data
  */
 function handleJobDetailsMessage(viewModel, json) {
+    normalizeJobStatusTimes(json);
+
     var rg = json['RepGroup'];
 
     // Handle search mode - add to search results instead of details


### PR DESCRIPTION
## Summary
- add `wr add --head N` for command-file smoke tests
- report job status start/end times as nanoseconds while preserving browser display
- reconnect the status websocket with capped backoff and resync state without double-counting

Solves #507
Solves #324
Solves #310

## Tests
- go test -tags netgo --count 1 ./cmd ./jobqueue -run 'Test(AddHeadKeepsFirstParsedCommands|AddHeadZeroKeepsAllParsedCommands|Job)$'\n- WR_TEST_LANE=37 go test -tags netgo --count 1 ./jobqueue -run 'Test(ServerWebI|REST)$'\n- node --check jobqueue/static/js/wr/websocket-handler.js\n- make lint\n- make test