### PR TITLE
Modernize jobqueue error handling

### DIFF
--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -301,7 +301,7 @@ func (b *Behaviour) run(j *Job) error {
 	cmd.Dir = actualCwd
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("run behaviour failed: %s\n%s", err, string(out))
+		return fmt.Errorf("run behaviour failed: %w\n%s", err, string(out))
 	}
 	return err
 }

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -307,7 +307,9 @@ func Connect(addr, caFile, certDomain string, token []byte, timeout time.Duratio
 			return c, errc
 		}
 		msg := ErrNoServer
-		if jqerr, ok := err.(Error); ok && jqerr.Err == ErrPermissionDenied {
+
+		var jqerr Error
+		if errors.As(err, &jqerr) && jqerr.Err == ErrPermissionDenied {
 			msg = ErrPermissionDenied
 		}
 		return nil, Error{"Connect", "", msg}
@@ -431,7 +433,7 @@ func (c *Client) BackupDB(path string) error {
 	if err != nil {
 		rerr := os.Remove(tmpPath)
 		if rerr != nil {
-			err = fmt.Errorf("%s\n%s", err.Error(), rerr.Error())
+			err = fmt.Errorf("%w\n%w", err, rerr)
 		}
 		return err
 	}
@@ -677,7 +679,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			buryErr := fmt.Errorf("could not create working directory: %w", err)
 			errb := c.Bury(job, nil, FailReasonCwd, buryErr)
 			if errb != nil {
-				buryErr = fmt.Errorf("%v (and burying the job failed: %w)", buryErr, errb)
+				buryErr = fmt.Errorf("%w (and burying the job failed: %w)", buryErr, errb)
 			}
 			return buryErr
 		}
@@ -742,7 +744,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			buryErr := fmt.Errorf("could not create lsf emulation directory: %w", err)
 			errb := c.Bury(job, nil, FailReasonCwd, buryErr)
 			if errb != nil {
-				buryErr = fmt.Errorf("%v (and burying the job failed: %w)", buryErr, errb)
+				buryErr = fmt.Errorf("%w (and burying the job failed: %w)", buryErr, errb)
 			}
 			return buryErr
 		}
@@ -752,7 +754,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if myerr == nil {
 					myerr = errr
 				} else {
-					myerr = fmt.Errorf("%v (and removing the lsf emulation dir failed: %w)", myerr, errr)
+					myerr = fmt.Errorf("%w (and removing the lsf emulation dir failed: %w)", myerr, errr)
 				}
 			}
 		}()
@@ -796,7 +798,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			buryErr := fmt.Errorf("failed to mount remote file system(s): %w (%s)", err, os.Environ())
 			errb := c.Bury(job, nil, FailReasonMount, buryErr)
 			if errb != nil {
-				buryErr = fmt.Errorf("%v (and burying the job failed: %w)", buryErr, errb)
+				buryErr = fmt.Errorf("%w (and burying the job failed: %w)", buryErr, errb)
 			}
 			return buryErr
 		}
@@ -821,7 +823,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 						if myerr == nil {
 							myerr = errc
 						} else {
-							myerr = fmt.Errorf("%v (and closing dir failed: %w)", myerr, errc)
+							myerr = fmt.Errorf("%w (and closing dir failed: %w)", myerr, errc)
 						}
 					}
 					if (errr == nil || errr == io.EOF) && len(files) == 0 {
@@ -873,7 +875,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if myerr == nil {
 					myerr = errr
 				} else {
-					myerr = fmt.Errorf("%v (and removing the tmpdir failed: %w)", myerr, errr)
+					myerr = fmt.Errorf("%w (and removing the tmpdir failed: %w)", myerr, errr)
 				}
 			}
 		}()
@@ -945,7 +947,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			buryErr := fmt.Errorf("failed to create docker client: %w", err)
 			errb := c.Bury(job, nil, FailReasonDocker, buryErr)
 			if errb != nil {
-				buryErr = fmt.Errorf("%v (and burying the job failed: %w)", buryErr, errb)
+				buryErr = fmt.Errorf("%w (and burying the job failed: %w)", buryErr, errb)
 			}
 			return buryErr
 		}
@@ -963,7 +965,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				buryErr := fmt.Errorf("failed to get docker containers: %w", errc)
 				errb := c.Bury(job, nil, FailReasonDocker, buryErr)
 				if errb != nil {
-					buryErr = fmt.Errorf("%v (and burying the job failed: %w)", buryErr, errb)
+					buryErr = fmt.Errorf("%w (and burying the job failed: %w)", buryErr, errb)
 				}
 				return buryErr
 			}
@@ -1067,7 +1069,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					errk = errc
 				} else {
 					clog.Warn(ctx, "failed to kill cmd", "cmd", job.Cmd, "pid", cmd.Process.Pid, "err", errk)
-					errk = fmt.Errorf("%v, and getting child processes failed: %w", errk, errc)
+					errk = fmt.Errorf("%w, and getting child processes failed: %w", errk, errc)
 				}
 			}
 
@@ -1077,7 +1079,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if errk == nil {
 					errk = errd
 				} else {
-					errk = fmt.Errorf("%v, and killing the docker container failed: %w", errk, errd)
+					errk = fmt.Errorf("%w, and killing the docker container failed: %w", errk, errd)
 				}
 			}
 
@@ -1094,7 +1096,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					errk = errc
 				} else {
 					clog.Warn(ctx, "failed to kill child of cmd", "cmd", job.Cmd, "pid", child.Pid)
-					errk = fmt.Errorf("%v, and killing its child process failed: %w", errk, errc)
+
+					errk = fmt.Errorf("%w, and killing its child process failed: %w", errk, errc)
 				}
 
 				go func(child *process.Process) {
@@ -1197,7 +1200,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 							if myerr == nil {
 								myerr = errg
 							} else {
-								myerr = fmt.Errorf("%v (and finding the docker container had issues: %w)", myerr, errg)
+								myerr = fmt.Errorf("%w (and finding the docker container had issues: %w)", myerr, errg)
 							}
 						}
 					}
@@ -1323,7 +1326,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	if killErr != nil {
 		if myerr != nil {
-			myerr = fmt.Errorf("%v; killing the cmd also failed: %w", myerr, killErr)
+			myerr = fmt.Errorf("%w; killing the cmd also failed: %w", myerr, killErr)
 		} else {
 			myerr = killErr
 		}
@@ -1331,7 +1334,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	if closeErr != nil && !strings.Contains(closeErr.Error(), "file already closed") {
 		if myerr != nil {
-			myerr = fmt.Errorf("%v; closing stderr/out of the cmd also failed: %w", myerr, closeErr)
+			myerr = fmt.Errorf("%w; closing stderr/out of the cmd also failed: %w", myerr, closeErr)
 		} else {
 			myerr = closeErr
 		}
@@ -1341,7 +1344,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	berr := job.TriggerBehaviours(err == nil && myerr == nil)
 	if berr != nil {
 		if myerr != nil {
-			myerr = fmt.Errorf("%v; behaviour(s) also had problem(s): %w", myerr, berr)
+			myerr = fmt.Errorf("%w; behaviour(s) also had problem(s): %w", myerr, berr)
 		} else {
 			myerr = berr
 		}
@@ -1365,7 +1368,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		}
 
 		if myerr != nil {
-			myerr = fmt.Errorf("%v; unmounting also caused problem(s): %w", myerr, unmountErr)
+			myerr = fmt.Errorf("%w; unmounting also caused problem(s): %w", myerr, unmountErr)
 		} else {
 			myerr = unmountErr
 		}
@@ -1409,7 +1412,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			cmdOut = fmt.Sprintf(" [sterr: %s]", string(finalStdErr))
 		}
 
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			exitcode = exitError.Sys().(syscall.WaitStatus).ExitStatus()
 			switch exitcode {
 			case 126:
@@ -1588,11 +1592,11 @@ func (c *Client) createLSFSymlinks(prependPath string, job *Job) error {
 	wr, erre := os.Executable()
 	if erre != nil {
 		errb := c.Bury(job, nil, FailReasonCwd)
-		extra := ""
 		if errb != nil {
-			extra = fmt.Sprintf(" (and burying the job failed: %s)", errb)
+			return fmt.Errorf("could not get path to wr: %w (and burying the job failed: %w)", erre, errb)
 		}
-		return fmt.Errorf("could not get path to wr: %s%s", erre, extra)
+
+		return fmt.Errorf("could not get path to wr: %w", erre)
 	}
 
 	bsub := filepath.Join(prependPath, "bsub")
@@ -1601,29 +1605,29 @@ func (c *Client) createLSFSymlinks(prependPath string, job *Job) error {
 	err := os.Symlink(wr, bsub)
 	if err != nil {
 		errb := c.Bury(job, nil, FailReasonCwd)
-		extra := ""
 		if errb != nil {
-			extra = fmt.Sprintf(" (and burying the job failed: %s)", errb)
+			return fmt.Errorf("could not create bsub symlink: %w (and burying the job failed: %w)", err, errb)
 		}
-		return fmt.Errorf("could not create bsub symlink: %s%s", err, extra)
+
+		return fmt.Errorf("could not create bsub symlink: %w", err)
 	}
 	err = os.Symlink(wr, bjobs)
 	if err != nil {
 		errb := c.Bury(job, nil, FailReasonCwd)
-		extra := ""
 		if errb != nil {
-			extra = fmt.Sprintf(" (and burying the job failed: %s)", errb)
+			return fmt.Errorf("could not create bjobs symlink: %w (and burying the job failed: %w)", err, errb)
 		}
-		return fmt.Errorf("could not create bjobs symlink: %s%s", err, extra)
+
+		return fmt.Errorf("could not create bjobs symlink: %w", err)
 	}
 	err = os.Symlink(wr, bkill)
 	if err != nil {
 		errb := c.Bury(job, nil, FailReasonCwd)
-		extra := ""
 		if errb != nil {
-			extra = fmt.Sprintf(" (and burying the job failed: %s)", errb)
+			return fmt.Errorf("could not create bkill symlink: %w (and burying the job failed: %w)", err, errb)
 		}
-		return fmt.Errorf("could not create bkill symlink: %s%s", err, extra)
+
+		return fmt.Errorf("could not create bkill symlink: %w", err)
 	}
 
 	return nil

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -290,55 +290,55 @@ func initDB(ctx context.Context, dbFile, dbBkFile, deployment string, wipeDevDB,
 	err = boltdb.Update(func(tx *bolt.Tx) error {
 		_, errf := tx.CreateBucketIfNotExists(bucketJobsLive)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketJobsLive, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketJobsLive, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketJobsComplete)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketJobsComplete, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketJobsComplete, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketRTK)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketRTK, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketRTK, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketRGs)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketRGs, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketRGs, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketLGs)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketLGs, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketLGs, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketDTK)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketDTK, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketDTK, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketRDTK)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketRDTK, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketRDTK, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketEnvs)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketEnvs, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketEnvs, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketStdO)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketStdO, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketStdO, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketStdE)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketStdE, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketStdE, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketJobRAM)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketJobRAM, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketJobRAM, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketJobDisk)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketJobDisk, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketJobDisk, errf)
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketJobSecs)
 		if errf != nil {
-			return fmt.Errorf("create bucket %s: %s", bucketJobSecs, errf)
+			return fmt.Errorf("create bucket %s: %w", bucketJobSecs, errf)
 		}
 
 		_, errf = tx.CreateBucketIfNotExists(bucketRGEndTime)
@@ -1637,7 +1637,7 @@ func (db *db) close(ctx context.Context) error {
 				if err == nil {
 					err = erru
 				} else {
-					err = fmt.Errorf("%s (and unmounting backup failed: %s)", err.Error(), erru)
+					err = fmt.Errorf("%w (and unmounting backup failed: %w)", err, erru)
 				}
 			}
 		}

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -625,7 +625,7 @@ func (j *Job) Mount(onCwd ...bool) ([]string, []string, error) {
 			if err != nil {
 				_, erru := j.Unmount()
 				if erru != nil {
-					err = fmt.Errorf("%s (and the unmount failed: %s)", err.Error(), erru)
+					err = fmt.Errorf("%w (and the unmount failed: %w)", err, erru)
 				}
 				return uniqueCacheDirs, uniqueMountedDirs, err
 			}
@@ -633,7 +633,7 @@ func (j *Job) Mount(onCwd ...bool) ([]string, []string, error) {
 			if err != nil {
 				_, erru := j.Unmount()
 				if erru != nil {
-					err = fmt.Errorf("%s (and the unmount failed: %s)", err.Error(), erru)
+					err = fmt.Errorf("%w (and the unmount failed: %w)", err, erru)
 				}
 				return uniqueCacheDirs, uniqueMountedDirs, err
 			}
@@ -660,7 +660,7 @@ func (j *Job) Mount(onCwd ...bool) ([]string, []string, error) {
 			err := fmt.Errorf("no Targets specified")
 			_, erru := j.Unmount()
 			if erru != nil {
-				err = fmt.Errorf("%s (and the unmount failed: %s)", err.Error(), erru)
+				err = fmt.Errorf("%w (and the unmount failed: %w)", err, erru)
 			}
 			return uniqueCacheDirs, uniqueMountedDirs, err
 		}
@@ -699,7 +699,7 @@ func (j *Job) Mount(onCwd ...bool) ([]string, []string, error) {
 		if err != nil {
 			_, erru := j.Unmount()
 			if erru != nil {
-				err = fmt.Errorf("%s (and the unmount failed: %s)", err.Error(), erru)
+				err = fmt.Errorf("%w (and the unmount failed: %w)", err, erru)
 			}
 			return uniqueCacheDirs, uniqueMountedDirs, err
 		}
@@ -708,7 +708,7 @@ func (j *Job) Mount(onCwd ...bool) ([]string, []string, error) {
 		if err != nil {
 			_, erru := j.Unmount()
 			if erru != nil {
-				err = fmt.Errorf("%s (and the unmount failed: %s)", err.Error(), erru)
+				err = fmt.Errorf("%w (and the unmount failed: %w)", err, erru)
 			}
 			return uniqueCacheDirs, uniqueMountedDirs, err
 		}
@@ -780,7 +780,7 @@ func (j *Job) Unmount(stopUploads ...bool) (logs string, err error) {
 
 	err = merr.ErrorOrNil()
 	if err != nil {
-		return logs, fmt.Errorf("Unmount failure(s): %s", err.Error())
+		return logs, fmt.Errorf("Unmount failure(s): %w", err)
 	}
 
 	// delete any empty dirs

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -1324,7 +1324,12 @@ func TestJobqueueSignal(t *testing.T) {
 				go func() {
 					err := jq.Execute(ctx, job, config.RunnerExecShell)
 					if err != nil {
-						if jqerr, ok := err.(Error); ok && jqerr.Err == FailReasonSignal && job.State == JobStateBuried && job.Exited && job.Exitcode == -1 && job.FailReason == FailReasonSignal {
+						var jqerr Error
+
+						gotSignalFailure := errors.As(err, &jqerr) && jqerr.Err == FailReasonSignal &&
+							job.State == JobStateBuried && job.Exited && job.Exitcode == -1 &&
+							job.FailReason == FailReasonSignal
+						if gotSignalFailure {
 							j1worked <- true
 						}
 					}
@@ -1335,7 +1340,12 @@ func TestJobqueueSignal(t *testing.T) {
 				go func() {
 					err := jq.Execute(ctx, job2, config.RunnerExecShell)
 					if err != nil {
-						if jqerr, ok := err.(Error); ok && jqerr.Err == FailReasonTime && job2.State == JobStateBuried && job2.Exited && job2.Exitcode == -1 && job2.FailReason == FailReasonTime {
+						var jqerr Error
+
+						gotTimeFailure := errors.As(err, &jqerr) && jqerr.Err == FailReasonTime &&
+							job2.State == JobStateBuried && job2.Exited && job2.Exitcode == -1 &&
+							job2.FailReason == FailReasonTime
+						if gotTimeFailure {
 							j2worked <- true
 						}
 					}
@@ -1442,8 +1452,8 @@ func TestJobqueueSignal(t *testing.T) {
 						// the server, then reconnected to the new server and
 						// therefore got ErrStopReserving, but otherwise
 						// everything was fine
-						jqerr, ok := erre.(Error)
-						if !ok || jqerr.Err != ErrStopReserving {
+						var jqerr Error
+						if !errors.As(erre, &jqerr) || jqerr.Err != ErrStopReserving {
 							fmt.Printf("\nexecute had err: %s\n", erre)
 							j1worked <- false
 							return
@@ -1717,7 +1727,10 @@ func TestJobqueueBasics(t *testing.T) {
 
 		_, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 		So(err, ShouldNotBeNil)
-		jqerr, ok := err.(Error)
+
+		var jqerr Error
+
+		ok := errors.As(err, &jqerr)
 		So(ok, ShouldBeTrue)
 		So(jqerr.Err, ShouldEqual, ErrNoServer)
 
@@ -2186,7 +2199,10 @@ func TestJobqueueBasics(t *testing.T) {
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
-				jqerr, ok := err.(Error)
+
+				var jqerr Error
+
+				ok := errors.As(err, &jqerr)
 				So(ok, ShouldBeTrue)
 				So(jqerr.Err, ShouldEqual, ErrNoServer)
 
@@ -2206,7 +2222,7 @@ func TestJobqueueBasics(t *testing.T) {
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
-				jqerr, ok = err.(Error)
+				ok = errors.As(err, &jqerr)
 				So(ok, ShouldBeTrue)
 				So(jqerr.Err, ShouldEqual, ErrNoServer)
 			})
@@ -2214,7 +2230,10 @@ func TestJobqueueBasics(t *testing.T) {
 			Convey("You get a nice error if you send the server junk", func() {
 				_, err := jq.request(&clientRequest{Method: "junk"})
 				So(err, ShouldNotBeNil)
-				jqerr, ok := err.(Error)
+
+				var jqerr Error
+
+				ok := errors.As(err, &jqerr)
 				So(ok, ShouldBeTrue)
 				So(jqerr.Err, ShouldEqual, ErrUnknownCommand)
 				disconnect(jq)
@@ -2273,7 +2292,10 @@ func TestJobqueueMedium(t *testing.T) {
 			Convey("You can't execute a job without reserving it", func() {
 				err := jq.Execute(ctx, jobs[0], config.RunnerExecShell)
 				So(err, ShouldNotBeNil)
-				jqerr, ok := err.(Error)
+
+				var jqerr Error
+
+				ok := errors.As(err, &jqerr)
 				So(ok, ShouldBeTrue)
 				So(jqerr.Err, ShouldEqual, ErrMustReserve)
 				disconnect(jq)
@@ -5044,7 +5066,10 @@ func TestJobqueueHighMem(t *testing.T) {
 			err = jq.Execute(ctx, job, config.RunnerExecShell)
 			jq.percentMemoryKill = 90
 			So(err, ShouldNotBeNil)
-			jqerr, ok := err.(Error)
+
+			var jqerr Error
+
+			ok := errors.As(err, &jqerr)
 			So(ok, ShouldBeTrue)
 			So(jqerr.Err, ShouldEqual, FailReasonRAM)
 			So(job.State, ShouldEqual, JobStateBuried)
@@ -7988,7 +8013,8 @@ func runner(ctx context.Context) {
 		// actually run the cmd
 		err = jq.Execute(ctx, job, config.RunnerExecShell)
 		if err != nil {
-			if jqerr, ok := err.(Error); ok && jqerr.Err == FailReasonSignal {
+			var jqerr Error
+			if errors.As(err, &jqerr) && jqerr.Err == FailReasonSignal {
 				break
 			} else {
 				log.Printf("execute err: %s\n", err) // make this a Fatalf if you want to see these in the test output

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2518,16 +2518,67 @@ func TestJobqueueMedium(t *testing.T) {
 				})
 
 				Convey("A job with retries that fails after NoRetriesOverWalltime is immediately buried", func() {
+					noRetriesCmd := "sleep 0.5 && false"
+					noRetriesEssence := &JobEssence{Cmd: noRetriesCmd}
 					var jobs2 []*Job
-					jobs2 = append(jobs2, &Job{Cmd: "sleep 0.5 && false", Cwd: "/tmp", ReqGroup: "fake_group", Requirements: standardReqs, Retries: uint8(1), NoRetriesOverWalltime: 10 * time.Millisecond, RepGroup: "manually_added"})
+
+					jobs2 = append(jobs2, &Job{
+						Cmd:                   noRetriesCmd,
+						Cwd:                   "/tmp",
+						ReqGroup:              "fake_group",
+						Requirements:          standardReqs,
+						Retries:               uint8(1),
+						NoRetriesOverWalltime: 10 * time.Millisecond,
+						RepGroup:              "manually_added",
+					})
 					inserts, already, err := jq.Add(jobs2, envVars, true)
 					So(err, ShouldBeNil)
 					So(inserts, ShouldEqual, 1)
 					So(already, ShouldEqual, 0)
 
-					job, err = jq.Reserve(50 * time.Millisecond)
+					noRetriesJob, err := jq.GetByEssence(noRetriesEssence, false, false)
 					So(err, ShouldBeNil)
-					So(job.Cmd, ShouldEqual, "sleep 0.5 && false")
+					So(noRetriesJob, ShouldNotBeNil)
+
+					noRetriesJobKey := noRetriesEssence.Key()
+					if noRetriesJob != nil {
+						noRetriesJobKey = noRetriesJob.Key()
+					}
+
+					for range 5 {
+						job, err = jq.Reserve(50 * time.Millisecond)
+						if err != nil || job == nil || job.Key() == noRetriesJobKey {
+							break
+						}
+
+						deleted, errd := jq.Delete([]*JobEssence{job.ToEssense()})
+						So(errd, ShouldBeNil)
+						So(deleted, ShouldEqual, 1)
+
+						if errd != nil || deleted != 1 {
+							return
+						}
+					}
+
+					So(err, ShouldBeNil)
+
+					if err != nil {
+						return
+					}
+
+					So(job, ShouldNotBeNil)
+
+					if job == nil {
+						return
+					}
+
+					So(job.Key(), ShouldEqual, noRetriesJobKey)
+
+					if job.Key() != noRetriesJobKey {
+						return
+					}
+
+					So(job.Cmd, ShouldEqual, noRetriesCmd)
 					So(job.State, ShouldEqual, JobStateReserved)
 					So(job.Attempts, ShouldEqual, 0)
 					So(job.UntilBuried, ShouldEqual, 2)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1049,7 +1049,7 @@ func Serve(ctx context.Context, config ServerConfig) (s *Server, msg string, tok
 		if err != nil {
 			errc := db.close(ctx)
 			if errc != nil {
-				err = fmt.Errorf("%s; db close also failed: %s", err.Error(), errc.Error())
+				err = fmt.Errorf("%w; db close also failed: %w", err, errc)
 			}
 		}
 	}()
@@ -1062,7 +1062,7 @@ func Serve(ctx context.Context, config ServerConfig) (s *Server, msg string, tok
 		if err != nil {
 			errc := sock.Close()
 			if errc != nil {
-				err = fmt.Errorf("%s; socket close also failed: %s", err.Error(), errc.Error())
+				err = fmt.Errorf("%w; socket close also failed: %w", err, errc)
 			}
 		}
 	}()
@@ -1327,7 +1327,7 @@ func Serve(ctx context.Context, config ServerConfig) (s *Server, msg string, tok
 			defer internal.LogPanic(ctx, "jobqueue web server listenAndServe", true)
 			defer wg.Done(wgk2)
 			errs := srv.ListenAndServeTLS(certFile, keyFile)
-			if errs != nil && errs != http.ErrServerClosed {
+			if errs != nil && !errors.Is(errs, http.ErrServerClosed) {
 				clog.Error(ctx, "server web interface had problems", "err", errs)
 			}
 		}()
@@ -1466,7 +1466,8 @@ func Serve(ctx context.Context, config ServerConfig) (s *Server, msg string, tok
 					s.krmutex.RLock()
 					inShutdown := s.killRunners
 					s.krmutex.RUnlock()
-					if !inShutdown && rerr != mangos.ErrRecvTimeout {
+
+					if !inShutdown && !errors.Is(rerr, mangos.ErrRecvTimeout) {
 						clog.Error(ctx, "Server socket Receive error", "err", rerr)
 					}
 					continue
@@ -1937,7 +1938,8 @@ func (s *Server) createQueue(ctx context.Context) {
 					// we could be trying to set the reserve group after the
 					// job has already completed, if they complete
 					// ~instantly
-					if qerr, ok := errs.(queue.Error); !ok || qerr.Err != queue.ErrNotFound {
+					var qerr queue.Error
+					if !errors.As(errs, &qerr) || !errors.Is(qerr.Err, queue.ErrNotFound) {
 						clog.Warn(ctx, "readycallback queue setreservegroup failed", "err", errs)
 					}
 				}
@@ -2876,7 +2878,8 @@ func (s *Server) getJobsByKeys(ctx context.Context, keys []string, getStd bool, 
 func (s *Server) checkJobByKey(key string) (bool, error) {
 	item, err := s.q.Get(key)
 	if err != nil {
-		if qerr, ok := err.(queue.Error); !ok || qerr.Err != queue.ErrNotFound {
+		var qerr queue.Error
+		if !errors.As(err, &qerr) || !errors.Is(qerr.Err, queue.ErrNotFound) {
 			return false, err
 		}
 	}
@@ -3362,13 +3365,16 @@ func (s *Server) scheduleRunners(ctx context.Context, group *sgroup) {
 	err := s.scheduler.Schedule(ctx, s.groupToScheduleCmd(ctx, rc, group.name, group.req), group.req, group.priority, group.count)
 	if err != nil {
 		problem := true
-		if serr, ok := err.(scheduler.Error); ok && serr.Err == scheduler.ErrImpossible {
+
+		var serr scheduler.Error
+		if errors.As(err, &serr) && serr.Err == scheduler.ErrImpossible {
 			// bury all jobs in this scheduler group
 			problem = false
 			for {
 				item, errr := s.q.Reserve(group.name, 0)
 				if errr != nil {
-					if qerr, ok := errr.(queue.Error); !ok || qerr.Err != queue.ErrNothingReady {
+					var qerr queue.Error
+					if !errors.As(errr, &qerr) || !errors.Is(qerr.Err, queue.ErrNothingReady) {
 						clog.Warn(ctx, "scheduleRunners failed to reserve an item", "group", group, "err", errr)
 						problem = true
 					}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -32,6 +32,7 @@ package jobqueue
 import (
 	"bytes"
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"time"
@@ -314,7 +315,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 			clog.Debug(ctx, "pause requested")
 			paused, err := s.Pause()
 			if err != nil {
-				if jqerr, ok := err.(Error); ok {
+				var jqerr Error
+				if errors.As(err, &jqerr) {
 					srerr = jqerr.Err
 				} else {
 					srerr = ErrInternalError
@@ -340,7 +342,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 			clog.Debug(ctx, "resume requested")
 			resumed, err := s.Resume(ctx)
 			if err != nil {
-				if jqerr, ok := err.(Error); ok {
+				var jqerr Error
+				if errors.As(err, &jqerr) {
 					srerr = jqerr.Err
 				} else {
 					srerr = ErrInternalError
@@ -503,11 +506,12 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 				if !skip {
 					item, err = s.reserveWithLimits(ctx, cr.SchedulerGroup, cr.Timeout)
 					if err != nil {
-						if qerr, ok := err.(queue.Error); ok {
-							switch qerr.Err {
-							case queue.ErrNothingReady:
+						var qerr queue.Error
+						if errors.As(err, &qerr) {
+							switch {
+							case errors.Is(qerr.Err, queue.ErrNothingReady):
 								srerr = ""
-							case queue.ErrQueueClosed:
+							case errors.Is(qerr.Err, queue.ErrQueueClosed):
 								srerr = ErrQueueClosed
 							default:
 								srerr = ErrInternalError
@@ -761,7 +765,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 				// afterwards
 				paused, err := s.Pause()
 				if err != nil {
-					if jqerr, ok := err.(Error); ok {
+					var jqerr Error
+					if errors.As(err, &jqerr) {
 						srerr = jqerr.Err
 					} else {
 						srerr = ErrInternalError
@@ -791,7 +796,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 
 					modified, err := cr.Modifier.Modify(toModifyJobs, s)
 					if err != nil {
-						if jqerr, ok := err.(Error); ok {
+						var jqerr Error
+						if errors.As(err, &jqerr) {
 							srerr = jqerr.Err
 						} else {
 							srerr = ErrInternalError

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -36,6 +36,7 @@ package jobqueue
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -299,7 +300,7 @@ func (jvj *JobViaJSON) Convert(jd *JobDefaults) (*Job, error) {
 	} else {
 		thismb, err := bytefmt.ToMegabytes(jvj.Memory)
 		if err != nil {
-			return nil, fmt.Errorf("memory value (%s) was not specified correctly: %s", jvj.Memory, err)
+			return nil, fmt.Errorf("memory value (%s) was not specified correctly: %w", jvj.Memory, err)
 		}
 		mb = int(thismb)
 	}
@@ -310,7 +311,7 @@ func (jvj *JobViaJSON) Convert(jd *JobDefaults) (*Job, error) {
 		var err error
 		dur, err = time.ParseDuration(jvj.Time)
 		if err != nil {
-			return nil, fmt.Errorf("time value (%s) was not specified correctly: %s", jvj.Time, err)
+			return nil, fmt.Errorf("time value (%s) was not specified correctly: %w", jvj.Time, err)
 		}
 	}
 
@@ -355,7 +356,7 @@ func (jvj *JobViaJSON) Convert(jd *JobDefaults) (*Job, error) {
 		var err error
 		noRetry, err = time.ParseDuration(jvj.NoRetriesOverWalltime)
 		if err != nil {
-			return nil, fmt.Errorf("time value (%s) was not specified correctly: %s", jvj.NoRetriesOverWalltime, err)
+			return nil, fmt.Errorf("time value (%s) was not specified correctly: %w", jvj.NoRetriesOverWalltime, err)
 		}
 	}
 
@@ -626,7 +627,7 @@ func restJobs(ctx context.Context, s *Server) http.HandlerFunc {
 		jstati := make([]JStatus, len(jobs))
 		for i, job := range jobs {
 			jstati[i], err = job.ToStatus()
-			if err != nil && err != io.ErrUnexpectedEOF {
+			if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 				http.Error(w, err.Error(), status)
 				return
 			}
@@ -870,7 +871,7 @@ func restJobsAdd(ctx context.Context, r *http.Request, s *Server) ([]*Job, int, 
 	for _, jvj := range jvjs {
 		job, errf := jvj.Convert(jd)
 		if errf != nil {
-			return nil, http.StatusBadRequest, fmt.Errorf("there was a problem interpreting your job: %s", errf)
+			return nil, http.StatusBadRequest, fmt.Errorf("there was a problem interpreting your job: %w", errf)
 		}
 		inputJobs = append(inputJobs, job)
 	}

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -35,6 +35,7 @@ import (
 	crand "crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -124,7 +125,7 @@ func copyFile(source string, dest string) error {
 			if err == nil {
 				err = errc
 			} else {
-				err = fmt.Errorf("%s (and closing source failed: %s)", err.Error(), errc)
+				err = fmt.Errorf("%w (and closing source failed: %w)", err, errc)
 			}
 		}
 	}()
@@ -138,7 +139,7 @@ func copyFile(source string, dest string) error {
 			if err == nil {
 				err = errc
 			} else {
-				err = fmt.Errorf("%s (and closing dest failed: %s)", err.Error(), errc)
+				err = fmt.Errorf("%w (and closing dest failed: %w)", err, errc)
 			}
 		}
 	}()
@@ -194,7 +195,7 @@ func currentMemory(pid int) (int, error) {
 			if err == nil {
 				err = errc
 			} else {
-				err = fmt.Errorf("%s (and closing smaps failed: %s)", err.Error(), errc)
+				err = fmt.Errorf("%w (and closing smaps failed: %w)", err, errc)
 			}
 		}
 	}()
@@ -225,7 +226,7 @@ func currentMemory(pid int) (int, error) {
 		return mem, err
 	}
 	children, err := p.Children()
-	if err != nil && err.Error() != "process does not have children" { // err != process.ErrorNoChildren
+	if err != nil && !errors.Is(err, process.ErrorNoChildren) {
 		return mem, err
 	}
 	for _, child := range children {
@@ -292,7 +293,7 @@ func getChildProcesses(pid int32) ([]*process.Process, error) {
 	}
 
 	children, err = p.Children()
-	if err != nil && err.Error() != "process does not have children" {
+	if err != nil && !errors.Is(err, process.ErrorNoChildren) {
 		return children, err
 	}
 
@@ -469,7 +470,7 @@ func mkHashedDir(baseDir, tohash string) (cwd, tmpDir string, err error) {
 			if err == nil {
 				err = errr
 			} else {
-				err = fmt.Errorf("%s (and removing the hold file failed: %s)", err.Error(), errr)
+				err = fmt.Errorf("%w (and removing the hold file failed: %w)", err, errr)
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary
- modernize top-level jobqueue error comparisons with `errors.Is` / `errors.As`
- preserve API-facing error text while adding useful `%w` wrapping
- keep this PR scoped to the jobqueue package slice of the broader sweep

Solves #301 for the jobqueue package slice. #301 should stay open for the remaining top-level package slices.

## Tests
- go test -tags netgo --count 1 ./jobqueue -run 'TestBehaviours|TestJobqueueUtils|TestREST|TestSubscriptionStateChangeEvents|TestJobqueueBasics|TestJobqueueMedium'\n- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue\n- make lint\n- make test