### PR TITLE
Add fast status count path

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -152,7 +152,11 @@ redirect (eg. "mycmd > stdout.txt").
 		}
 
 		useFastStatus := canUseFastStatusOutput(outputFormat)
+
 		statusSummaries := getFastStatusSummaries(jq, cmdStates, useFastStatus, outputFormat)
+		if statusSummaries == nil {
+			useFastStatus = false
+		}
 
 		var jobs []*jobqueue.Job
 		showextra := cmdFileStatus == ""
@@ -628,6 +632,10 @@ func getFastStatusSummaries(jq *jobqueue.Client, cmdStates []jobqueue.JobState, 
 
 	summaries, err := jq.GetStatusByRepGroupMatch(cmdIDStatus, match, cmdStates, includeComplete, includeStatusDetails)
 	if err != nil {
+		if fastStatusUnsupported(err) {
+			return nil
+		}
+
 		die("failed to get job status counts corresponding to your settings: %s", err)
 	}
 
@@ -643,6 +651,12 @@ func printStatusCounts(counts map[jobqueue.JobState]int) {
 		counts[jobqueue.JobStateLost],
 		counts[jobqueue.JobStateDelayed],
 		counts[jobqueue.JobStateBuried])
+}
+
+func fastStatusUnsupported(err error) bool {
+	var jqErr jobqueue.Error
+
+	return errors.As(err, &jqErr) && jqErr.Err == jobqueue.ErrUnknownCommand
 }
 
 func printStatusSummaries(summaries map[string]*jobqueue.RepGroupStatus) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -151,21 +151,36 @@ redirect (eg. "mycmd > stdout.txt").
 			showEnv = false
 		}
 
-		jobs := getJobsForStates(jq, cmdStates, set == 0, statusLimit, true, showEnv)
+		useFastStatus := canUseFastStatusOutput(outputFormat)
+		statusSummaries := getFastStatusSummaries(jq, cmdStates, useFastStatus, outputFormat)
+
+		var jobs []*jobqueue.Job
 		showextra := cmdFileStatus == ""
 
-		if fromHost != "" {
-			var subset []*jobqueue.Job
-			for _, job := range jobs {
-				if job.Host == fromHost || job.HostID == fromHost || job.HostIP == fromHost {
-					subset = append(subset, job)
+		if !useFastStatus {
+			jobs = getJobsForStates(jq, cmdStates, set == 0, statusLimit, true, showEnv)
+
+			if fromHost != "" {
+				var subset []*jobqueue.Job
+
+				for _, job := range jobs {
+					if job.Host == fromHost || job.HostID == fromHost || job.HostIP == fromHost {
+						subset = append(subset, job)
+					}
 				}
+
+				jobs = subset
 			}
-			jobs = subset
 		}
 
 		switch outputFormat {
 		case "counts", "c":
+			if useFastStatus {
+				printStatusCounts(mergeStatusSummaries(statusSummaries).Counts)
+
+				break
+			}
+
 			var d, re, b, ru, l, c, dep int
 			for _, job := range jobs {
 				switch job.State {
@@ -185,7 +200,16 @@ redirect (eg. "mycmd > stdout.txt").
 					dep += 1 + job.Similar
 				}
 			}
-			fmt.Printf("complete: %d\nrunning: %d\nready: %d\ndependent: %d\nlost contact: %d\ndelayed: %d\nburied: %d\n", c, ru, re, dep, l, d, b)
+
+			printStatusCounts(map[jobqueue.JobState]int{
+				jobqueue.JobStateComplete:  c,
+				jobqueue.JobStateRunning:   ru,
+				jobqueue.JobStateReady:     re,
+				jobqueue.JobStateDependent: dep,
+				jobqueue.JobStateLost:      l,
+				jobqueue.JobStateDelayed:   d,
+				jobqueue.JobStateBuried:    b,
+			})
 		case "plain", "p":
 			buried := false
 			for _, job := range jobs {
@@ -199,6 +223,12 @@ redirect (eg. "mycmd > stdout.txt").
 			}
 			os.Exit(0)
 		case "summary", "s":
+			if useFastStatus {
+				printStatusSummaries(statusSummaries)
+
+				break
+			}
+
 			counts := make(map[string]map[jobqueue.JobState]int)
 			buried := make(map[string]map[string][]string)
 			memory := make(map[string]*runningvariance.RunningStat)
@@ -567,6 +597,142 @@ func validateStatusStateFilters(cmdStates []jobqueue.JobState) error {
 	}
 
 	return nil
+}
+
+func canUseFastStatusOutput(format string) bool {
+	if fromHost != "" || cmdFileStatus != "" || cmdLine != "" || (cmdIDStatus != "" && cmdIDIsInternal) {
+		return false
+	}
+
+	switch format {
+	case "counts", "c", "summary", "s":
+		return true
+	default:
+		return false
+	}
+}
+
+func getFastStatusSummaries(jq *jobqueue.Client, cmdStates []jobqueue.JobState, useFastStatus bool,
+	format string) map[string]*jobqueue.RepGroupStatus {
+	if !useFastStatus {
+		return nil
+	}
+
+	match := jobqueue.RepGroupMatchExact
+	if cmdIDIsSubStr {
+		match = jobqueue.RepGroupMatchSubStr
+	}
+
+	includeComplete := cmdIDStatus != "" || cmdAll
+	includeStatusDetails := format == "summary" || format == "s"
+
+	summaries, err := jq.GetStatusByRepGroupMatch(cmdIDStatus, match, cmdStates, includeComplete, includeStatusDetails)
+	if err != nil {
+		die("failed to get job status counts corresponding to your settings: %s", err)
+	}
+
+	return summaries
+}
+
+func printStatusCounts(counts map[jobqueue.JobState]int) {
+	fmt.Printf("complete: %d\nrunning: %d\nready: %d\ndependent: %d\nlost contact: %d\ndelayed: %d\nburied: %d\n",
+		counts[jobqueue.JobStateComplete],
+		counts[jobqueue.JobStateRunning]+counts[jobqueue.JobStateReserved],
+		counts[jobqueue.JobStateReady],
+		counts[jobqueue.JobStateDependent],
+		counts[jobqueue.JobStateLost],
+		counts[jobqueue.JobStateDelayed],
+		counts[jobqueue.JobStateBuried])
+}
+
+func printStatusSummaries(summaries map[string]*jobqueue.RepGroupStatus) {
+	rgs := make([]string, 0, len(summaries))
+	for rg := range summaries {
+		rgs = append(rgs, rg)
+	}
+
+	sort.Strings(rgs)
+
+	if len(rgs) > 1 {
+		summaries[allRepGrps] = mergeStatusSummaries(summaries)
+		rgs = append(rgs, allRepGrps)
+	}
+
+	for _, rg := range rgs {
+		printRepGroupStatusSummary(rg, summaries[rg])
+	}
+}
+
+func mergeStatusSummaries(summaries map[string]*jobqueue.RepGroupStatus) *jobqueue.RepGroupStatus {
+	merged := jobqueue.NewRepGroupStatus()
+	for _, summary := range summaries {
+		merged.Merge(summary)
+	}
+
+	return merged
+}
+
+func printRepGroupStatusSummary(rg string, summary *jobqueue.RepGroupStatus) {
+	counts := summary.Counts
+	usage := statusSummaryUsage(summary)
+	dead := statusSummaryBuried(summary)
+
+	fmt.Printf("%s : complete=%d running=%d ready=%d dependent=%d lost=%d delayed=%d buried=%d%s%s\n",
+		rg,
+		counts[jobqueue.JobStateComplete],
+		counts[jobqueue.JobStateRunning]+counts[jobqueue.JobStateReserved],
+		counts[jobqueue.JobStateReady],
+		counts[jobqueue.JobStateDependent],
+		counts[jobqueue.JobStateLost],
+		counts[jobqueue.JobStateDelayed],
+		counts[jobqueue.JobStateBuried],
+		usage,
+		dead)
+}
+
+func statusSummaryUsage(summary *jobqueue.RepGroupStatus) string {
+	if summary.Counts[jobqueue.JobStateComplete] == 0 || summary.Memory.NumDataValues() == 0 {
+		return ""
+	}
+
+	usage := fmt.Sprintf(" memory=%dMB(+/-%dMB) disk=%dMB(+/-%dMB) walltime=%s(+/-%s) cputime=%s(+/-%s)",
+		int(summary.Memory.Mean()),
+		int(summary.Memory.StandardDeviation()),
+		int(summary.Disk.Mean()),
+		int(summary.Disk.StandardDeviation()),
+		time.Duration(summary.Walltime.Mean()),
+		time.Duration(summary.Walltime.StandardDeviation()),
+		time.Duration(summary.CPUtime.Mean()),
+		time.Duration(summary.CPUtime.StandardDeviation()))
+
+	if summary.Counts[jobqueue.JobStateComplete] > 1 && !summary.StartTime.IsZero() && !summary.EndTime.IsZero() {
+		usage += fmt.Sprintf(" started=%s ended=%s elapsed=%s",
+			summary.StartTime.Format(shortTimeFormat),
+			summary.EndTime.Format(shortTimeFormat),
+			summary.EndTime.Sub(summary.StartTime))
+	}
+
+	return usage
+}
+
+func statusSummaryBuried(summary *jobqueue.RepGroupStatus) string {
+	if summary.Counts[jobqueue.JobStateBuried] == 0 {
+		return ""
+	}
+
+	bgs := make([]string, 0, len(summary.Buried))
+	for bg := range summary.Buried {
+		bgs = append(bgs, bg)
+	}
+
+	sort.Strings(bgs)
+
+	var dead strings.Builder
+	for _, bg := range bgs {
+		fmt.Fprintf(&dead, " %s=%s", bg, strings.Join(summary.Buried[bg], ","))
+	}
+
+	return dead.String()
 }
 
 func getJobsForStates(jq *jobqueue.Client, cmdStates []jobqueue.JobState, all bool,

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -137,6 +137,7 @@ type clientRequest struct {
 	Env                     []byte // compressed binc encoding of []string
 	Jobs                    []*Job
 	Keys                    []string
+	States                  []JobState
 	File                    []byte // compressed bytes of file content
 	Token                   []byte
 	LimitGroup              string
@@ -156,6 +157,8 @@ type clientRequest struct {
 	GetEnv                  bool
 	GetStd                  bool
 	IgnoreComplete          bool
+	IncludeComplete         bool
+	IncludeStatusDetails    bool
 	Search                  bool
 	RepGroupMatch           RepGroupMatch
 	ConfirmDeadCloudServers bool
@@ -1938,6 +1941,26 @@ func (c *Client) GetByRepGroupMatch(repgroup string, match RepGroupMatch, limit 
 		return nil, err
 	}
 	return resp.Jobs, err
+}
+
+// GetStatusByRepGroupMatch gets compact per-state job counts, optionally with
+// summary details, for report groups that match repgroup.
+func (c *Client) GetStatusByRepGroupMatch(repgroup string, match RepGroupMatch,
+	states []JobState, includeComplete bool, includeStatusDetails bool) (map[string]*RepGroupStatus, error) {
+	resp, err := c.request(&clientRequest{
+		Method:               "getrs",
+		Job:                  &Job{RepGroup: repgroup},
+		Search:               match != RepGroupMatchExact,
+		RepGroupMatch:        match,
+		States:               states,
+		IncludeComplete:      includeComplete,
+		IncludeStatusDetails: includeStatusDetails,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.StatusSummaries, err
 }
 
 // GetIncomplete gets all Jobs that are currently in the jobqueue, ie. excluding

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -915,6 +915,62 @@ func (db *db) retrieveCompleteJobsByRepGroup(repgroup string) ([]*Job, error) {
 	return jobs, err
 }
 
+// retrieveCompleteJobStatusByRepGroup gets a compact status summary for
+// archived jobs in the given RepGroup. Count-only mode checks keys and does not
+// decode the archived jobs.
+func (db *db) retrieveCompleteJobStatusByRepGroup(repgroup string, includeDetails bool) (*RepGroupStatus, error) {
+	summary := NewRepGroupStatus()
+	err := db.bolt.View(func(tx *bolt.Tx) error {
+		return db.addCompleteJobStatusByRepGroup(tx, summary, repgroup, includeDetails)
+	})
+
+	return summary, err
+}
+
+func (db *db) addCompleteJobStatusByRepGroup(tx *bolt.Tx, summary *RepGroupStatus, repgroup string,
+	includeDetails bool) error {
+	newJobBucket := tx.Bucket(bucketJobsLive)
+	completeJobBucket := tx.Bucket(bucketJobsComplete)
+	lookupBucket := tx.Bucket(bucketRTK).Cursor()
+
+	prefix := []byte(repgroup + dbDelimiter)
+	for k, _ := lookupBucket.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = lookupBucket.Next() {
+		key := bytes.TrimPrefix(k, prefix)
+
+		encoded := completeJobBucket.Get(key)
+		if len(encoded) == 0 || newJobBucket.Get(key) != nil {
+			continue
+		}
+
+		if err := db.addCompleteJobStatus(summary, repgroup, encoded, includeDetails); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *db) addCompleteJobStatus(summary *RepGroupStatus, repgroup string, encoded []byte,
+	includeDetails bool) error {
+	if !includeDetails {
+		summary.AddState(JobStateComplete, 1)
+
+		return nil
+	}
+
+	dec := codec.NewDecoderBytes(encoded, db.ch)
+
+	job := &Job{}
+	if err := dec.Decode(job); err != nil {
+		return err
+	}
+
+	job.RepGroup = repgroup
+	summary.AddCompleteJob(job)
+
+	return nil
+}
+
 // retrieveDependentJobs gets previously stored jobs that had a dependency on
 // one for the input depGroups. If the job is found in the live bucket, then it
 // is returned in the jobsToUpdate return value. If it is found in the complete

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -276,6 +276,7 @@ type serverResponse struct {
 	SInfo           *ServerInfo
 	SStats          *ServerStats
 	CompletionTimes map[string]time.Time
+	StatusSummaries map[string]*RepGroupStatus
 	DB              []byte
 	Path            string
 	BadServers      []*BadServer
@@ -560,6 +561,14 @@ type lostJobRetryCheck struct {
 	checkTimeout time.Duration
 }
 
+type repGroupStatusOptions struct {
+	RepGroup             string
+	Match                RepGroupMatch
+	States               []JobState
+	IncludeComplete      bool
+	IncludeStatusDetails bool
+}
+
 // Server represents the server side of the socket that clients Connect() to.
 type Server struct {
 	token                     []byte
@@ -712,6 +721,173 @@ func (s *Server) waitForClientHandling(ctx context.Context) {
 	case <-timer.C:
 		clog.Warn(ctx, "server shutdown timed out waiting for client handling to stop")
 	}
+}
+
+// getStatusByRepGroup gets compact per-state status summaries for jobs in the
+// given group match.
+func (s *Server) getStatusByRepGroup(opts repGroupStatusOptions) (map[string]*RepGroupStatus, string, string) {
+	rgs, srerr, qerr := s.getStatusRepGroups(opts)
+	if srerr != "" {
+		return nil, srerr, qerr
+	}
+
+	summaries := make(map[string]*RepGroupStatus)
+	if opts.RepGroup == "" {
+		s.addAllQueueJobStatuses(summaries, opts)
+	} else {
+		for _, rg := range rgs {
+			s.addQueueJobStatusesByRepGroup(summaries, rg, opts)
+		}
+	}
+
+	srerr, qerr = s.addCompleteJobStatuses(summaries, rgs, opts)
+	if srerr != "" {
+		return nil, srerr, qerr
+	}
+
+	return summaries, "", ""
+}
+
+func (s *Server) addCompleteJobStatuses(summaries map[string]*RepGroupStatus, rgs []string,
+	opts repGroupStatusOptions) (string, string) {
+	if !opts.IncludeComplete || !statusStateMatches(JobStateComplete, opts.States) {
+		return "", ""
+	}
+
+	for _, rg := range rgs {
+		complete, err := s.db.retrieveCompleteJobStatusByRepGroup(rg, opts.IncludeStatusDetails)
+		if err != nil {
+			return ErrDBError, err.Error()
+		}
+
+		if !statusSummaryEmpty(complete) {
+			statusSummaryForRepGroup(summaries, rg).Merge(complete)
+		}
+	}
+
+	return "", ""
+}
+
+func statusStateMatches(state JobState, filters []JobState) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	for _, filter := range filters {
+		if normalizedStatusFilter(filter) == state {
+			return true
+		}
+	}
+
+	return false
+}
+
+func statusSummaryEmpty(summary *RepGroupStatus) bool {
+	if summary == nil {
+		return true
+	}
+
+	for _, count := range summary.Counts {
+		if count > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func statusSummaryForRepGroup(summaries map[string]*RepGroupStatus, repGroup string) *RepGroupStatus {
+	summary, ok := summaries[repGroup]
+	if ok {
+		return summary
+	}
+
+	summary = NewRepGroupStatus()
+	summaries[repGroup] = summary
+
+	return summary
+}
+
+func (s *Server) getStatusRepGroups(opts repGroupStatusOptions) ([]string, string, string) {
+	if opts.RepGroup != "" {
+		return s.getRepGroupsList(opts.RepGroup, opts.Match)
+	}
+
+	if !opts.IncludeComplete {
+		return nil, "", ""
+	}
+
+	rgs, err := s.db.retrieveRepGroups()
+	if err != nil {
+		return nil, ErrDBError, err.Error()
+	}
+
+	return rgs, "", ""
+}
+
+func (s *Server) addAllQueueJobStatuses(summaries map[string]*RepGroupStatus,
+	opts repGroupStatusOptions) {
+	for _, item := range s.q.AllItems() {
+		s.addQueueItemStatus(summaries, item, opts)
+	}
+}
+
+func (s *Server) addQueueJobStatusesByRepGroup(summaries map[string]*RepGroupStatus, repGroup string,
+	opts repGroupStatusOptions) {
+	for _, key := range s.rpl.Values(repGroup) {
+		item, _ := s.q.Get(key) //nolint:errcheck
+		if item == nil {
+			continue
+		}
+
+		s.addQueueItemStatus(summaries, item, opts)
+	}
+}
+
+func (s *Server) addQueueItemStatus(summaries map[string]*RepGroupStatus, item *queue.Item,
+	opts repGroupStatusOptions) {
+	job, ok := item.Data().(*Job)
+	if !ok {
+		return
+	}
+
+	itemState := item.State()
+
+	job.RLock()
+	repGroup := job.RepGroup
+	state := queueItemStatusState(itemState, job.Lost)
+	exitCode := job.Exitcode
+	failReason := job.FailReason
+	job.RUnlock()
+
+	if !statusStateMatches(state, opts.States) {
+		return
+	}
+
+	summary := statusSummaryForRepGroup(summaries, repGroup)
+	summary.AddState(state, 1)
+
+	if opts.IncludeStatusDetails && state == JobStateBuried {
+		group := fmt.Sprintf("exitcode.%d,\"%s\"", exitCode, failReason)
+		summary.AddBuried(group, item.Key)
+	}
+}
+
+func queueItemStatusState(itemState queue.ItemState, lost bool) JobState {
+	state := itemsStateToJobState[itemState]
+	if state == "" {
+		return JobStateUnknown
+	}
+
+	if state != JobStateReserved {
+		return state
+	}
+
+	if lost {
+		return JobStateLost
+	}
+
+	return JobStateRunning
 }
 
 func subscriptionUpdateState(_, to JobState) (JobState, bool) {
@@ -3077,6 +3253,14 @@ func (s *Server) getQueueJobsByRepGroupMatch(ctx context.Context, repGroup strin
 	}
 
 	return jobs
+}
+
+func normalizedStatusFilter(filter JobState) JobState {
+	if filter == JobStateReserved {
+		return JobStateRunning
+	}
+
+	return filter
 }
 
 func jobUnixNano(t time.Time) *int64 {

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -947,6 +947,26 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 					sr = &serverResponse{Jobs: jobs}
 				}
 			}
+		case "getrs":
+			var repGroup string
+			if cr.Job != nil {
+				repGroup = cr.Job.RepGroup
+			}
+
+			match := normalizeRepGroupMatch(cr.RepGroupMatch, cr.Search)
+			summaries, serr, qe := s.getStatusByRepGroup(repGroupStatusOptions{
+				RepGroup:             repGroup,
+				Match:                match,
+				States:               cr.States,
+				IncludeComplete:      cr.IncludeComplete,
+				IncludeStatusDetails: cr.IncludeStatusDetails,
+			})
+			srerr = serr
+			qerr = qe
+
+			if srerr == "" {
+				sr = &serverResponse{StatusSummaries: summaries}
+			}
 		case "getin":
 			// get incomplete jobs in the jobqueue, optionally filtered by rep group
 			var repGroup string

--- a/jobqueue/status_count_test.go
+++ b/jobqueue/status_count_test.go
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/internal"
+	. "github.com/smartystreets/goconvey/convey"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestRepGroupStatusCountsDoNotDecodeCompleteJobs(t *testing.T) {
+	Convey("Given complete-job lookup keys with an undecodable archived payload", t, func() {
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+
+		db, _, err := initDB(ctx, filepath.Join(tmpDir, "db"), filepath.Join(tmpDir, "db_bk"),
+			internal.Development, false, false)
+
+		So(err, ShouldBeNil)
+		defer func() {
+			So(db.close(ctx), ShouldBeNil)
+		}()
+
+		repGroup := "fast-count"
+		completeKey := []byte("complete-key")
+		rerunKey := []byte("rerun-key")
+
+		err = db.bolt.Update(func(tx *bolt.Tx) error {
+			if errp := tx.Bucket(bucketRGs).Put([]byte(repGroup), nil); errp != nil {
+				return errp
+			}
+
+			if errp := tx.Bucket(bucketRTK).Put(db.generateLookupKey(repGroup, completeKey), nil); errp != nil {
+				return errp
+			}
+
+			if errp := tx.Bucket(bucketRTK).Put(db.generateLookupKey(repGroup, rerunKey), nil); errp != nil {
+				return errp
+			}
+
+			if errp := tx.Bucket(bucketJobsComplete).Put(completeKey, []byte("not-a-job")); errp != nil {
+				return errp
+			}
+
+			if errp := tx.Bucket(bucketJobsComplete).Put(rerunKey, []byte("not-a-job")); errp != nil {
+				return errp
+			}
+
+			return tx.Bucket(bucketJobsLive).Put(rerunKey, []byte("live-rerun"))
+		})
+		So(err, ShouldBeNil)
+
+		Convey("count-only status uses the lookup keys without decoding full jobs", func() {
+			summary, errc := db.retrieveCompleteJobStatusByRepGroup(repGroup, false)
+			So(errc, ShouldBeNil)
+			So(summary.Counts[JobStateComplete], ShouldEqual, 1)
+		})
+
+		Convey("summary detail mode still decodes only when compact job stats are requested", func() {
+			_, errd := db.retrieveCompleteJobStatusByRepGroup(repGroup, true)
+			So(errd, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestClientRepGroupStatusCounts(t *testing.T) {
+	Convey("Given a server with live and complete jobs in matching report groups", t, func() {
+		ctx := context.Background()
+		_, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(false)
+
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		complete := &Job{
+			Cmd:          "echo complete status count",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "status-count-a",
+		}
+		ready := &Job{
+			Cmd:          "echo ready status count",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "status-count-a",
+		}
+		other := &Job{
+			Cmd:          "echo other status count",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "status-count-b",
+		}
+
+		added, existed, err := jq.Add([]*Job{complete, ready, other}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 3)
+		So(existed, ShouldEqual, 0)
+
+		item, err := server.q.Get(complete.Key())
+		So(err, ShouldBeNil)
+
+		archived, ok := item.Data().(*Job)
+		So(ok, ShouldBeTrue)
+
+		archived.StartTime = time.Now().Add(-2 * time.Second)
+		archived.EndTime = time.Now().Add(-1 * time.Second)
+		archived.State = JobStateComplete
+		archived.Exited = true
+		archived.PeakRAM = 10
+		archived.PeakDisk = 1
+		archived.CPUtime = time.Second
+
+		So(server.q.Remove(ctx, complete.Key()), ShouldBeNil)
+		So(server.db.archiveJob(ctx, complete.Key(), archived), ShouldBeNil)
+
+		summaries, err := jq.GetStatusByRepGroupMatch("status-count", RepGroupMatchPrefix, nil, true, false)
+		So(err, ShouldBeNil)
+		So(summaries["status-count-a"].Counts[JobStateComplete], ShouldEqual, 1)
+		So(summaries["status-count-a"].Counts[JobStateReady], ShouldEqual, 1)
+		So(summaries["status-count-b"].Counts[JobStateReady], ShouldEqual, 1)
+
+		countOnly := NewRepGroupStatus()
+		for _, summary := range summaries {
+			countOnly.Merge(summary)
+		}
+
+		So(countOnly.Counts[JobStateComplete], ShouldEqual, 1)
+		So(countOnly.Counts[JobStateReady], ShouldEqual, 2)
+
+		filtered, err := jq.GetStatusByRepGroupMatch("status-count", RepGroupMatchPrefix,
+			[]JobState{JobStateReady}, true, false)
+		So(err, ShouldBeNil)
+		So(filtered["status-count-a"].Counts[JobStateComplete], ShouldEqual, 0)
+		So(filtered["status-count-a"].Counts[JobStateReady], ShouldEqual, 1)
+		So(filtered["status-count-b"].Counts[JobStateReady], ShouldEqual, 1)
+
+		detailed, err := jq.GetStatusByRepGroupMatch("status-count-a", RepGroupMatchExact, nil, true, true)
+		So(err, ShouldBeNil)
+		So(detailed["status-count-a"].Memory.NumDataValues(), ShouldEqual, uint(1))
+		So(detailed["status-count-a"].StartTime.IsZero(), ShouldBeFalse)
+		So(detailed["status-count-a"].EndTime.IsZero(), ShouldBeFalse)
+	})
+}

--- a/jobqueue/status_summary.go
+++ b/jobqueue/status_summary.go
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"math"
+	"time"
+)
+
+// StatusMeasure stores mergeable running statistics for a numeric status
+// summary value.
+type StatusMeasure struct {
+	N         uint
+	MeanValue float64
+	M2        float64
+}
+
+// Push adds one value to the running statistics.
+func (m *StatusMeasure) Push(value float64) {
+	m.N++
+	if m.N == 1 {
+		m.MeanValue = value
+
+		return
+	}
+
+	delta := value - m.MeanValue
+	m.MeanValue += delta / float64(m.N)
+	m.M2 += delta * (value - m.MeanValue)
+}
+
+// Merge adds another measure's values into this one.
+func (m *StatusMeasure) Merge(other StatusMeasure) {
+	if other.N == 0 {
+		return
+	}
+
+	if m.N == 0 {
+		*m = other
+
+		return
+	}
+
+	total := m.N + other.N
+	delta := other.MeanValue - m.MeanValue
+	m.M2 += other.M2 + delta*delta*float64(m.N)*float64(other.N)/float64(total)
+	m.MeanValue += delta * float64(other.N) / float64(total)
+	m.N = total
+}
+
+// NumDataValues returns how many values have been added.
+func (m StatusMeasure) NumDataValues() uint {
+	return m.N
+}
+
+// Mean returns the current mean.
+func (m StatusMeasure) Mean() float64 {
+	return m.MeanValue
+}
+
+// StandardDeviation returns the sample standard deviation.
+func (m StatusMeasure) StandardDeviation() float64 {
+	if m.N <= 1 {
+		return 0
+	}
+
+	return math.Sqrt(m.M2 / (float64(m.N) - 1))
+}
+
+// RepGroupStatus is a compact status summary for one report group.
+type RepGroupStatus struct {
+	Counts    map[JobState]int
+	Buried    map[string][]string
+	Memory    StatusMeasure
+	Disk      StatusMeasure
+	Walltime  StatusMeasure
+	CPUtime   StatusMeasure
+	StartTime time.Time
+	EndTime   time.Time
+}
+
+// NewRepGroupStatus returns an initialised report-group status summary.
+func NewRepGroupStatus() *RepGroupStatus {
+	return &RepGroupStatus{
+		Counts: make(map[JobState]int),
+		Buried: make(map[string][]string),
+	}
+}
+
+// AddState adds count jobs to a state.
+func (s *RepGroupStatus) AddState(state JobState, count int) {
+	if count <= 0 {
+		return
+	}
+
+	s.ensureMaps()
+
+	if state == JobStateReserved {
+		state = JobStateRunning
+	}
+
+	s.Counts[state] += count
+}
+
+// AddBuried records a buried job key by its exit-code/fail-reason group.
+func (s *RepGroupStatus) AddBuried(group string, key string) {
+	s.ensureMaps()
+	s.Buried[group] = append(s.Buried[group], key)
+}
+
+// AddCompleteJob adds a completed job's compact status details.
+func (s *RepGroupStatus) AddCompleteJob(job *Job) {
+	s.AddState(JobStateComplete, 1)
+	s.Memory.Push(float64(job.PeakRAM))
+	s.Disk.Push(float64(job.PeakDisk))
+	s.Walltime.Push(float64(job.WallTime()))
+	s.CPUtime.Push(float64(job.CPUtime))
+	s.addStartEnd(job.StartTime, job.EndTime)
+}
+
+// Merge folds another report-group status into this one.
+func (s *RepGroupStatus) Merge(other *RepGroupStatus) {
+	if other == nil {
+		return
+	}
+
+	s.ensureMaps()
+
+	for state, count := range other.Counts {
+		s.AddState(state, count)
+	}
+
+	for group, keys := range other.Buried {
+		s.Buried[group] = append(s.Buried[group], keys...)
+	}
+
+	s.Memory.Merge(other.Memory)
+	s.Disk.Merge(other.Disk)
+	s.Walltime.Merge(other.Walltime)
+	s.CPUtime.Merge(other.CPUtime)
+	s.addStartEnd(other.StartTime, other.EndTime)
+}
+
+func (s *RepGroupStatus) ensureMaps() {
+	if s.Counts == nil {
+		s.Counts = make(map[JobState]int)
+	}
+
+	if s.Buried == nil {
+		s.Buried = make(map[string][]string)
+	}
+}
+
+func (s *RepGroupStatus) addStartEnd(start time.Time, end time.Time) {
+	if start.IsZero() || end.IsZero() {
+		return
+	}
+
+	if s.StartTime.IsZero() || start.Before(s.StartTime) {
+		s.StartTime = start
+	}
+
+	if s.EndTime.IsZero() || end.After(s.EndTime) {
+		s.EndTime = end
+	}
+}


### PR DESCRIPTION
## Summary
- add a compact client/server status-summary request for repgroup counts
- avoid decoding and returning full complete jobs for `wr status -o c` and `-o summary` when the request can use the fast path
- preserve fallback to full-job retrieval for filters that need it

Solves #322

## Tests
- go test -tags netgo --count 1 ./jobqueue -run 'TestRepGroupStatusCountsDoNotDecodeCompleteJobs|TestClientRepGroupStatusCounts' -v\n- go test -tags netgo --count 1 ./jobqueue ./cmd ./client\n- make lint\n- make test