### PR TITLE
Add status table output and scheduler alerts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -132,6 +132,7 @@ type jobqueueClient interface {
 		limit int, state jobqueue.JobState, getStd bool, getEnv bool) ([]*jobqueue.Job, error)
 	GetLastCompletionTimeByRepGroup(repgroup string,
 		match jobqueue.RepGroupMatch) (map[string]time.Time, error)
+	GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error)
 	Delete(jes []*jobqueue.JobEssence) (int, error)
 	Disconnect() error
 }
@@ -253,6 +254,10 @@ func (p *pretendJobqueue) SubmittedJobs() []*jobqueue.Job {
 	sj := p.jobBuffer
 
 	return sj
+}
+
+func (p *pretendJobqueue) GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error) {
+	return &jobqueue.SchedulerAlerts{}, nil
 }
 
 // GetByRepGroup behaves like jobqueue.GetByRepGroup, but only repgroup is
@@ -866,6 +871,12 @@ func (s *Scheduler) NewJobFromJSON(spec *jobqueue.JobViaJSON) (*jobqueue.Job, er
 	}
 
 	return spec.Convert(s.JobDefaults())
+}
+
+// GetSchedulerAlerts returns the scheduler alerts currently shown by wr's web
+// UI, including dismissible scheduler issues and bad cloud servers.
+func (s *Scheduler) GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error) {
+	return s.jq.GetSchedulerAlerts()
 }
 
 func unfinishedWaitForJobKeys(keys []string,

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -96,7 +96,7 @@ option that was used when the command was added, if any. You can do this by
 using the -c and --mounts/--mounts_json options in -l mode, or by providing the
 same file you gave to "wr add" in -f mode.
 
-There are 4 output formats to choose from with -o (you can shorten the output
+There are 6 output formats to choose from with -o (you can shorten the output
 name to just the first letter, eg. -o c):
   "counts" just displays the count of jobs in each possible state.
   "summary" shows the counts broken down by report group, along with the mean
@@ -113,6 +113,8 @@ name to just the first letter, eg. -o c):
   "plain" outputs 2 tab separated columns: internal job id and current state of
 	that job. Possible states are: delayed, ready, reserved, running, lost,
 	buried, complete. If any jobs are buried, exits non-0 as well.
+  "table" outputs one aligned row per status group. Columns can be customised
+    with WR_STATUS_FORMAT using FIELD:width entries.
   "json" simply dumps the complete details of every job out as an array of
     JSON objects. The properties of the JSON objects are described in the
     documentation for wr's REST API. If more than 1000 buried jobs get
@@ -146,7 +148,7 @@ redirect (eg. "mycmd > stdout.txt").
 			}
 		}()
 
-		if !strings.HasPrefix(outputFormat, "d") && !strings.HasPrefix(outputFormat, "j") {
+		if !statusOutputUsesGroupedJobs(outputFormat) {
 			statusLimit = 0
 			showEnv = false
 		}
@@ -162,7 +164,7 @@ redirect (eg. "mycmd > stdout.txt").
 		showextra := cmdFileStatus == ""
 
 		if !useFastStatus {
-			jobs = getJobsForStates(jq, cmdStates, set == 0, statusLimit, true, showEnv)
+			jobs = getJobsForStates(jq, cmdStates, set == 0, statusLimit, statusOutputGetsStd(outputFormat), showEnv)
 
 			if fromHost != "" {
 				var subset []*jobqueue.Job
@@ -514,8 +516,17 @@ redirect (eg. "mycmd > stdout.txt").
 			if err != nil {
 				die("failed to encode jobs: %s", err)
 			}
+		case "table", "t":
+			err = writeStatusTable(os.Stdout, jobs)
+			if err != nil {
+				die("failed to write status table: %s", err)
+			}
 		default:
 			die("invalid -o format specified")
+		}
+
+		if statusOutputShowsAlerts(outputFormat) {
+			writeStatusAlerts(jq)
 		}
 
 		fmt.Printf("\n")
@@ -542,7 +553,8 @@ func init() {
 	statusCmd.Flags().BoolVar(&showDependent, "dependent", false,
 		"in default or -i mode only, only show the status of dependent commands")
 	statusCmd.Flags().BoolVarP(&showEnv, "env", "e", false, "in -o d mode, except in -f mode, also show the environment variables the command(s) ran with")
-	statusCmd.Flags().StringVarP(&outputFormat, "output", "o", "details", "['counts','summary','details','json'] output format")
+	statusCmd.Flags().StringVarP(&outputFormat, "output", "o", "details",
+		"['counts','summary','details','plain','table','json'] output format")
 	statusCmd.Flags().IntVar(&statusLimit, "limit", 1, "in -o d mode, number of commands that share the same properties to display; 0 displays all")
 
 	statusCmd.Flags().IntVar(&timeoutint, "timeout", 120, "how long (seconds) to wait to get a reply from 'wr manager'")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -113,8 +113,10 @@ name to just the first letter, eg. -o c):
   "plain" outputs 2 tab separated columns: internal job id and current state of
 	that job. Possible states are: delayed, ready, reserved, running, lost,
 	buried, complete. If any jobs are buried, exits non-0 as well.
-  "table" outputs one aligned row per status group. Columns can be customised
-    with WR_STATUS_FORMAT using FIELD:width entries.
+  "table" outputs aligned rows for the grouped jobs returned by the status
+    query. As with details/json, --limit controls how many matching jobs can be
+    shown from each status group. Columns can be customised with WR_STATUS_FORMAT
+    using FIELD:width entries.
   "json" simply dumps the complete details of every job out as an array of
     JSON objects. The properties of the JSON objects are described in the
     documentation for wr's REST API. If more than 1000 buried jobs get

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -180,7 +180,7 @@ redirect (eg. "mycmd > stdout.txt").
 		}
 
 		switch outputFormat {
-		case "counts", "c":
+		case statusOutputFormatCounts, statusOutputFormatCountsAlias:
 			if useFastStatus {
 				printStatusCounts(mergeStatusSummaries(statusSummaries).Counts)
 
@@ -216,7 +216,7 @@ redirect (eg. "mycmd > stdout.txt").
 				jobqueue.JobStateDelayed:   d,
 				jobqueue.JobStateBuried:    b,
 			})
-		case "plain", "p":
+		case statusOutputFormatPlain, statusOutputFormatPlainAlias:
 			buried := false
 			for _, job := range jobs {
 				fmt.Printf("%s\t%s\n", job.Key(), job.State)
@@ -228,7 +228,7 @@ redirect (eg. "mycmd > stdout.txt").
 				os.Exit(1)
 			}
 			os.Exit(0)
-		case "summary", "s":
+		case statusOutputFormatSummary, statusOutputFormatSummaryAlias:
 			if useFastStatus {
 				printStatusSummaries(statusSummaries)
 
@@ -341,7 +341,7 @@ redirect (eg. "mycmd > stdout.txt").
 
 				fmt.Printf("%s : complete=%d running=%d ready=%d dependent=%d lost=%d delayed=%d buried=%d%s%s\n", rg, counts[rg][jobqueue.JobStateComplete], counts[rg][jobqueue.JobStateRunning], counts[rg][jobqueue.JobStateReady], counts[rg][jobqueue.JobStateDependent], counts[rg][jobqueue.JobStateLost], counts[rg][jobqueue.JobStateDelayed], counts[rg][jobqueue.JobStateBuried], usage, dead)
 			}
-		case "details", "d":
+		case statusOutputFormatDetails, statusOutputFormatDetailsAlias:
 			// print out status information for each job
 			for _, job := range jobs {
 				cwd := job.Cwd
@@ -501,7 +501,7 @@ redirect (eg. "mycmd > stdout.txt").
 					fmt.Printf("+ %d other commands with the same status%s%s\n", job.Similar, er, fr)
 				}
 			}
-		case "json", "j":
+		case statusOutputFormatJSON, statusOutputFormatJSONAlias:
 			jstati := make([]jobqueue.JStatus, len(jobs))
 			for i, job := range jobs {
 				jstati[i], err = job.ToStatus()
@@ -516,7 +516,7 @@ redirect (eg. "mycmd > stdout.txt").
 			if err != nil {
 				die("failed to encode jobs: %s", err)
 			}
-		case "table", "t":
+		case statusOutputFormatTable, statusOutputFormatTableAlias:
 			err = writeStatusTable(os.Stdout, jobs)
 			if err != nil {
 				die("failed to write status table: %s", err)
@@ -525,9 +525,7 @@ redirect (eg. "mycmd > stdout.txt").
 			die("invalid -o format specified")
 		}
 
-		if statusOutputShowsAlerts(outputFormat) {
-			writeStatusAlerts(jq)
-		}
+		writeStatusAlerts(os.Stdout, jq, outputFormat)
 
 		fmt.Printf("\n")
 	},

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -554,7 +554,9 @@ func init() {
 	statusCmd.Flags().BoolVarP(&showEnv, "env", "e", false, "in -o d mode, except in -f mode, also show the environment variables the command(s) ran with")
 	statusCmd.Flags().StringVarP(&outputFormat, "output", "o", "details",
 		"['counts','summary','details','plain','table','json'] output format")
-	statusCmd.Flags().IntVar(&statusLimit, "limit", 1, "in -o d mode, number of commands that share the same properties to display; 0 displays all")
+	statusCmd.Flags().IntVar(&statusLimit, "limit", 1,
+		"for grouped outputs (details, table and json), number of commands that share "+
+			"the same properties to display per group; 0 displays all")
 
 	statusCmd.Flags().IntVar(&timeoutint, "timeout", 120, "how long (seconds) to wait to get a reply from 'wr manager'")
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -150,8 +150,9 @@ redirect (eg. "mycmd > stdout.txt").
 
 		if !statusOutputUsesGroupedJobs(outputFormat) {
 			statusLimit = 0
-			showEnv = false
 		}
+
+		showEnv = showEnv && statusOutputGetsEnv(outputFormat)
 
 		useFastStatus := canUseFastStatusOutput(outputFormat)
 

--- a/cmd/status_alerts.go
+++ b/cmd/status_alerts.go
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/jobqueue"
+)
+
+func writeStatusAlerts(jq *jobqueue.Client) {
+	alerts, err := jq.GetSchedulerAlerts()
+	if err != nil {
+		warn("failed to retrieve scheduler alerts: %s", err)
+
+		return
+	}
+
+	writeStatusAlertsFooter(os.Stdout, alerts)
+}
+
+func writeStatusAlertsFooter(w io.Writer, alerts *jobqueue.SchedulerAlerts) {
+	if alerts == nil || (len(alerts.Issues) == 0 && len(alerts.BadServers) == 0) {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Scheduler alerts:")
+	writeStatusIssueAlerts(w, alerts.Issues)
+	writeStatusBadServerAlerts(w, alerts.BadServers)
+}
+
+func writeStatusIssueAlerts(w io.Writer, issues []*jobqueue.SchedulerIssue) {
+	for _, issue := range sortedStatusIssues(issues) {
+		if issue == nil {
+			continue
+		}
+
+		writeStatusIssueAlert(w, issue)
+	}
+}
+
+func sortedStatusIssues(issues []*jobqueue.SchedulerIssue) []*jobqueue.SchedulerIssue {
+	issues = slices.Clone(issues)
+	slices.SortFunc(issues, func(a, b *jobqueue.SchedulerIssue) int {
+		if a == nil || b == nil {
+			return compareNilStatusAlerts(a == nil, b == nil)
+		}
+
+		return strings.Compare(a.Msg, b.Msg)
+	})
+
+	return issues
+}
+
+func writeStatusIssueAlert(w io.Writer, issue *jobqueue.SchedulerIssue) {
+	fmt.Fprintf(w, "- Scheduler Issue: %s", issue.Msg)
+	fmt.Fprint(w, statusIssueAlertSuffix(issue))
+	fmt.Fprintln(w)
+}
+
+func statusIssueAlertSuffix(issue *jobqueue.SchedulerIssue) string {
+	switch {
+	case issue.LastDate > 0 && issue.Count > 1:
+		return fmt.Sprintf(" (reported at %s; first reported at %s; reported %d times)",
+			formatStatusAlertTime(issue.LastDate), formatStatusAlertTime(issue.FirstDate), issue.Count)
+	case issue.LastDate > 0:
+		return fmt.Sprintf(" (reported at %s)", formatStatusAlertTime(issue.LastDate))
+	case issue.Count > 1:
+		return fmt.Sprintf(" (reported %d times)", issue.Count)
+	default:
+		return ""
+	}
+}
+
+func writeStatusBadServerAlerts(w io.Writer, badServers []*jobqueue.BadServer) {
+	for _, server := range sortedStatusBadServers(badServers) {
+		if server == nil {
+			continue
+		}
+
+		writeStatusBadServerAlert(w, server)
+	}
+}
+
+func sortedStatusBadServers(badServers []*jobqueue.BadServer) []*jobqueue.BadServer {
+	badServers = slices.Clone(badServers)
+	slices.SortFunc(badServers, func(a, b *jobqueue.BadServer) int {
+		if a == nil || b == nil {
+			return compareNilStatusAlerts(a == nil, b == nil)
+		}
+
+		return strings.Compare(a.ID, b.ID)
+	})
+
+	return badServers
+}
+
+func compareNilStatusAlerts(aNil, bNil bool) int {
+	switch {
+	case aNil && bNil:
+		return 0
+	case aNil:
+		return 1
+	default:
+		return -1
+	}
+}
+
+func writeStatusBadServerAlert(w io.Writer, server *jobqueue.BadServer) {
+	fmt.Fprintf(w, "- Bad server: %s (%s, %s) %s",
+		server.Name, server.ID, server.IP, statusBadServerAlertState(server))
+
+	if server.Date > 0 {
+		fmt.Fprintf(w, "; reported at %s", formatStatusAlertTime(server.Date))
+	}
+
+	fmt.Fprintln(w)
+}
+
+func statusBadServerAlertState(server *jobqueue.BadServer) string {
+	if server.Problem == "" {
+		return "might be dead"
+	}
+
+	return "is no longer usable; problem: " + server.Problem
+}
+
+func formatStatusAlertTime(unixSeconds int64) string {
+	return time.Unix(unixSeconds, 0).Format(shortTimeFormat)
+}

--- a/cmd/status_alerts.go
+++ b/cmd/status_alerts.go
@@ -28,7 +28,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -36,7 +35,15 @@ import (
 	"github.com/VertebrateResequencing/wr/jobqueue"
 )
 
-func writeStatusAlerts(jq *jobqueue.Client) {
+type schedulerAlertsGetter interface {
+	GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error)
+}
+
+func writeStatusAlerts(w io.Writer, jq schedulerAlertsGetter, format string) {
+	if !statusOutputShowsAlerts(format) {
+		return
+	}
+
 	alerts, err := jq.GetSchedulerAlerts()
 	if err != nil {
 		warn("failed to retrieve scheduler alerts: %s", err)
@@ -44,7 +51,7 @@ func writeStatusAlerts(jq *jobqueue.Client) {
 		return
 	}
 
-	writeStatusAlertsFooter(os.Stdout, alerts)
+	writeStatusAlertsFooter(w, alerts)
 }
 
 func writeStatusAlertsFooter(w io.Writer, alerts *jobqueue.SchedulerAlerts) {

--- a/cmd/status_alerts.go
+++ b/cmd/status_alerts.go
@@ -161,6 +161,7 @@ func statusBadServerAlertState(server *jobqueue.BadServer) string {
 	return "is no longer usable; problem: " + server.Problem
 }
 
+//nolint:gosmopolitan // wr status intentionally renders alert times in the user's local timezone.
 func formatStatusAlertTime(unixSeconds int64) string {
-	return time.Unix(unixSeconds, 0).Format(shortTimeFormat)
+	return time.Unix(unixSeconds, 0).Local().Format(shortTimeFormat)
 }

--- a/cmd/status_alerts.go
+++ b/cmd/status_alerts.go
@@ -55,7 +55,7 @@ func writeStatusAlerts(w io.Writer, jq schedulerAlertsGetter, format string) {
 }
 
 func writeStatusAlertsFooter(w io.Writer, alerts *jobqueue.SchedulerAlerts) {
-	if alerts == nil || (len(alerts.Issues) == 0 && len(alerts.BadServers) == 0) {
+	if alerts == nil || (len(alerts.Issues) == 0 && !hasActiveStatusBadServerAlert(alerts.BadServers)) {
 		return
 	}
 
@@ -63,6 +63,16 @@ func writeStatusAlertsFooter(w io.Writer, alerts *jobqueue.SchedulerAlerts) {
 	fmt.Fprintln(w, "Scheduler alerts:")
 	writeStatusIssueAlerts(w, alerts.Issues)
 	writeStatusBadServerAlerts(w, alerts.BadServers)
+}
+
+func hasActiveStatusBadServerAlert(badServers []*jobqueue.BadServer) bool {
+	for _, server := range badServers {
+		if server != nil && server.IsBad {
+			return true
+		}
+	}
+
+	return false
 }
 
 func writeStatusIssueAlerts(w io.Writer, issues []*jobqueue.SchedulerIssue) {
@@ -110,7 +120,7 @@ func statusIssueAlertSuffix(issue *jobqueue.SchedulerIssue) string {
 
 func writeStatusBadServerAlerts(w io.Writer, badServers []*jobqueue.BadServer) {
 	for _, server := range sortedStatusBadServers(badServers) {
-		if server == nil {
+		if server == nil || !server.IsBad {
 			continue
 		}
 

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/VertebrateResequencing/wr/jobqueue"
+)
+
+const (
+	statusFormatEnv                  = "WR_STATUS_FORMAT"
+	defaultStatusTableColumns        = "command:36 id:32 status:10 attempts:8 host:16 reqgroup:18 count:5"
+	statusTableColumnSeparator       = "  "
+	statusTableDefaultTruncateMarker = "..."
+	statusTableStatusFieldName       = "status"
+)
+
+type statusTableField struct {
+	header string
+	right  bool
+	value  func(*jobqueue.Job) string
+}
+
+var (
+	errStatusFormatEmpty    = errors.New("no fields supplied")
+	errStatusFormatBadWidth = errors.New("field width must be a positive integer")
+	errStatusFormatUnknown  = errors.New("unknown field")
+	statusTableCommandField = statusTableField{
+		header: "Command",
+		value:  func(job *jobqueue.Job) string { return job.Cmd },
+	}
+	statusTableIDField = statusTableField{
+		header: "ID",
+		value:  func(job *jobqueue.Job) string { return job.Key() },
+	}
+	statusTableStatusField = statusTableField{
+		header: "Status",
+		value:  func(job *jobqueue.Job) string { return string(job.State) },
+	}
+	statusTableAttemptsField = statusTableField{
+		header: "Attempts",
+		right:  true,
+		value:  func(job *jobqueue.Job) string { return strconv.FormatUint(uint64(job.Attempts), 10) },
+	}
+	statusTableHostField = statusTableField{
+		header: "Host",
+		value:  statusTableHost,
+	}
+	statusTableReqGroupField = statusTableField{
+		header: "Requirements group",
+		value:  func(job *jobqueue.Job) string { return job.ReqGroup },
+	}
+	statusTableCountField = statusTableField{
+		header: "Count",
+		right:  true,
+		value:  func(job *jobqueue.Job) string { return strconv.Itoa(1 + job.Similar) },
+	}
+	statusTableFieldsByName = map[string]statusTableField{
+		"command":                  statusTableCommandField,
+		"cmd":                      statusTableCommandField,
+		"id":                       statusTableIDField,
+		"jobid":                    statusTableIDField,
+		"key":                      statusTableIDField,
+		statusTableStatusFieldName: statusTableStatusField,
+		"state":                    statusTableStatusField,
+		"attempts":                 statusTableAttemptsField,
+		"tries":                    statusTableAttemptsField,
+		"host":                     statusTableHostField,
+		"reqgroup":                 statusTableReqGroupField,
+		"requirements":             statusTableReqGroupField,
+		"requirementsgroup":        statusTableReqGroupField,
+		"count":                    statusTableCountField,
+		"similar":                  statusTableCountField,
+	}
+)
+
+func statusOutputShowsAlerts(format string) bool {
+	return format != "json" && format != "j" && format != "plain" && format != "p"
+}
+
+func statusTableHost(job *jobqueue.Job) string {
+	switch {
+	case job.Host != "":
+		return job.Host
+	case job.HostID != "":
+		return job.HostID
+	case job.HostIP != "":
+		return job.HostIP
+	default:
+		return ""
+	}
+}
+
+func statusTableFieldForName(name string) (statusTableField, error) {
+	if strings.TrimSpace(name) == "" {
+		return statusTableField{}, errStatusFormatEmpty
+	}
+
+	field, found := statusTableFieldsByName[normaliseStatusTableFieldName(name)]
+	if !found {
+		return statusTableField{}, errStatusFormatUnknown
+	}
+
+	return field, nil
+}
+
+type statusTableColumn struct {
+	field statusTableField
+	width int
+}
+
+func parseStatusTableColumn(part string) (statusTableColumn, error) {
+	name, widthText, found := strings.Cut(part, ":")
+	if !found {
+		return statusTableColumn{}, errStatusFormatEmpty
+	}
+
+	width, err := parseStatusTableColumnWidth(widthText)
+	if err != nil {
+		return statusTableColumn{}, err
+	}
+
+	field, err := statusTableFieldForName(name)
+	if err != nil {
+		return statusTableColumn{}, err
+	}
+
+	if len(field.header) > width {
+		width = len(field.header)
+	}
+
+	return statusTableColumn{field: field, width: width}, nil
+}
+
+func writeStatusTable(w io.Writer, jobs []*jobqueue.Job) error {
+	columns, err := parseStatusTableColumns(os.Getenv(statusFormatEnv))
+	if err != nil {
+		return err
+	}
+
+	writeStatusTableRow(w, columns, func(column statusTableColumn) string {
+		return column.field.header
+	})
+
+	for _, job := range jobs {
+		writeStatusTableRow(w, columns, func(column statusTableColumn) string {
+			return column.field.value(job)
+		})
+	}
+
+	return nil
+}
+
+func parseStatusTableColumns(format string) ([]statusTableColumn, error) {
+	if strings.TrimSpace(format) == "" {
+		format = defaultStatusTableColumns
+	}
+
+	parts := strings.Fields(format)
+	if len(parts) == 0 {
+		return nil, errStatusFormatEmpty
+	}
+
+	columns := make([]statusTableColumn, 0, len(parts))
+	for _, part := range parts {
+		column, err := parseStatusTableColumn(part)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", part, err)
+		}
+
+		columns = append(columns, column)
+	}
+
+	return columns, nil
+}
+
+func writeStatusTableRow(w io.Writer, columns []statusTableColumn, value func(statusTableColumn) string) {
+	for n, column := range columns {
+		if n > 0 {
+			fmt.Fprint(w, statusTableColumnSeparator)
+		}
+
+		writeStatusTableCell(w, column, value(column))
+	}
+
+	fmt.Fprintln(w)
+}
+
+func writeStatusTableCell(w io.Writer, column statusTableColumn, value string) {
+	value = fitStatusTableValue(value, column.width)
+	if column.field.right {
+		fmt.Fprintf(w, "%*s", column.width, value)
+
+		return
+	}
+
+	fmt.Fprintf(w, "%-*s", column.width, value)
+}
+
+func fitStatusTableValue(value string, width int) string {
+	if len(value) <= width {
+		return value
+	}
+
+	if width <= len(statusTableDefaultTruncateMarker) {
+		return value[:width]
+	}
+
+	return value[:width-len(statusTableDefaultTruncateMarker)] + statusTableDefaultTruncateMarker
+}
+
+func parseStatusTableColumnWidth(widthText string) (int, error) {
+	if strings.TrimSpace(widthText) == "" {
+		return 0, errStatusFormatEmpty
+	}
+
+	width, err := strconv.Atoi(widthText)
+	if err != nil || width <= 0 {
+		return 0, errStatusFormatBadWidth
+	}
+
+	return width, nil
+}
+
+func statusOutputUsesGroupedJobs(format string) bool {
+	return strings.HasPrefix(format, "d") || strings.HasPrefix(format, "j") || statusOutputIsTable(format)
+}
+
+func statusOutputGetsStd(format string) bool {
+	return !statusOutputIsTable(format)
+}
+
+func statusOutputIsTable(format string) bool {
+	return format == "table" || format == "t"
+}
+
+func normaliseStatusTableFieldName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	name = strings.ReplaceAll(name, "_", "")
+	name = strings.ReplaceAll(name, "-", "")
+
+	return name
+}

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -139,6 +139,10 @@ func statusTableHost(job *jobqueue.Job) string {
 	}
 }
 
+func statusOutputGetsEnv(format string) bool {
+	return format == statusOutputFormatDetails || format == statusOutputFormatDetailsAlias
+}
+
 func statusTableFieldForName(name string) (statusTableField, error) {
 	if strings.TrimSpace(name) == "" {
 		return statusTableField{}, errStatusFormatEmpty
@@ -273,15 +277,24 @@ func parseStatusTableColumnWidth(widthText string) (int, error) {
 }
 
 func statusOutputUsesGroupedJobs(format string) bool {
-	return strings.HasPrefix(format, "d") || strings.HasPrefix(format, "j") || statusOutputIsTable(format)
+	switch format {
+	case statusOutputFormatDetails, statusOutputFormatDetailsAlias,
+		statusOutputFormatJSON, statusOutputFormatJSONAlias,
+		statusOutputFormatTable, statusOutputFormatTableAlias:
+		return true
+	default:
+		return false
+	}
 }
 
 func statusOutputGetsStd(format string) bool {
-	return !statusOutputIsTable(format)
-}
-
-func statusOutputIsTable(format string) bool {
-	return format == statusOutputFormatTable || format == statusOutputFormatTableAlias
+	switch format {
+	case statusOutputFormatDetails, statusOutputFormatDetailsAlias,
+		statusOutputFormatJSON, statusOutputFormatJSONAlias:
+		return true
+	default:
+		return false
+	}
 }
 
 func normaliseStatusTableFieldName(name string) string {

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -59,7 +59,7 @@ const (
 type statusTableField struct {
 	header string
 	right  bool
-	value  func(*jobqueue.Job) string
+	value  func(statusTableRow) string
 }
 
 var (
@@ -69,33 +69,33 @@ var (
 	errStatusFormatUnknown  = errors.New("unknown field")
 	statusTableCommandField = statusTableField{
 		header: "Command",
-		value:  func(job *jobqueue.Job) string { return job.Cmd },
+		value:  func(row statusTableRow) string { return row.job.Cmd },
 	}
 	statusTableIDField = statusTableField{
 		header: "ID",
-		value:  func(job *jobqueue.Job) string { return job.Key() },
+		value:  func(row statusTableRow) string { return row.job.Key() },
 	}
 	statusTableStatusField = statusTableField{
 		header: "Status",
-		value:  func(job *jobqueue.Job) string { return string(job.State) },
+		value:  func(row statusTableRow) string { return string(row.displayState) },
 	}
 	statusTableAttemptsField = statusTableField{
 		header: "Attempts",
 		right:  true,
-		value:  func(job *jobqueue.Job) string { return strconv.FormatUint(uint64(job.Attempts), 10) },
+		value:  func(row statusTableRow) string { return strconv.FormatUint(uint64(row.job.Attempts), 10) },
 	}
 	statusTableHostField = statusTableField{
 		header: "Host",
-		value:  statusTableHost,
+		value:  statusTableRowHost,
 	}
 	statusTableReqGroupField = statusTableField{
 		header: "Requirements group",
-		value:  func(job *jobqueue.Job) string { return job.ReqGroup },
+		value:  func(row statusTableRow) string { return row.job.ReqGroup },
 	}
 	statusTableCountField = statusTableField{
 		header: "Count",
 		right:  true,
-		value:  func(job *jobqueue.Job) string { return strconv.Itoa(1 + job.Similar) },
+		value:  func(row statusTableRow) string { return strconv.Itoa(row.count) },
 	}
 	statusTableFieldsByName = map[string]statusTableField{
 		"command":                  statusTableCommandField,
@@ -127,6 +127,16 @@ func statusOutputShowsAlerts(format string) bool {
 	}
 }
 
+type statusTableRow struct {
+	job          *jobqueue.Job
+	displayState jobqueue.JobState
+	count        int
+}
+
+func statusTableRowHost(row statusTableRow) string {
+	return statusTableHost(row.job)
+}
+
 func statusTableHost(job *jobqueue.Job) string {
 	switch {
 	case job.Host != "":
@@ -144,6 +154,48 @@ func statusOutputGetsEnv(format string) bool {
 	return format == statusOutputFormatDetails || format == statusOutputFormatDetailsAlias
 }
 
+func newStatusTableRows(jobs []*jobqueue.Job) []statusTableRow {
+	totals := statusTableGroupTotals(jobs)
+	rows := make([]statusTableRow, 0, len(jobs))
+
+	for _, job := range jobs {
+		key := statusTableGroupKeyForJob(job)
+		rows = append(rows, statusTableRow{
+			job:          job,
+			displayState: key.state,
+			count:        totals[key],
+		})
+	}
+
+	return rows
+}
+
+func statusTableGroupTotals(jobs []*jobqueue.Job) map[statusTableGroupKey]int {
+	totals := make(map[statusTableGroupKey]int)
+
+	for _, job := range jobs {
+		totals[statusTableGroupKeyForJob(job)] += 1 + job.Similar
+	}
+
+	return totals
+}
+
+func statusTableGroupKeyForJob(job *jobqueue.Job) statusTableGroupKey {
+	return statusTableGroupKey{
+		state:      statusTableDisplayState(job.State),
+		exitcode:   job.Exitcode,
+		failReason: job.FailReason,
+	}
+}
+
+func statusTableDisplayState(state jobqueue.JobState) jobqueue.JobState {
+	if state == jobqueue.JobStateReserved {
+		return jobqueue.JobStateRunning
+	}
+
+	return state
+}
+
 func statusTableFieldForName(name string) (statusTableField, error) {
 	if strings.TrimSpace(name) == "" {
 		return statusTableField{}, errStatusFormatBadField
@@ -155,6 +207,12 @@ func statusTableFieldForName(name string) (statusTableField, error) {
 	}
 
 	return field, nil
+}
+
+type statusTableGroupKey struct {
+	state      jobqueue.JobState
+	exitcode   int
+	failReason string
 }
 
 type statusTableColumn struct {
@@ -195,9 +253,9 @@ func writeStatusTable(w io.Writer, jobs []*jobqueue.Job) error {
 		return column.field.header
 	})
 
-	for _, job := range jobs {
+	for _, row := range newStatusTableRows(jobs) {
 		writeStatusTableRow(w, columns, func(column statusTableColumn) string {
-			return column.field.value(job)
+			return column.field.value(row)
 		})
 	}
 

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -64,6 +64,7 @@ type statusTableField struct {
 
 var (
 	errStatusFormatEmpty    = errors.New("no fields supplied")
+	errStatusFormatBadField = errors.New("field must use FIELD:width syntax")
 	errStatusFormatBadWidth = errors.New("field width must be a positive integer")
 	errStatusFormatUnknown  = errors.New("unknown field")
 	statusTableCommandField = statusTableField{
@@ -145,7 +146,7 @@ func statusOutputGetsEnv(format string) bool {
 
 func statusTableFieldForName(name string) (statusTableField, error) {
 	if strings.TrimSpace(name) == "" {
-		return statusTableField{}, errStatusFormatEmpty
+		return statusTableField{}, errStatusFormatBadField
 	}
 
 	field, found := statusTableFieldsByName[normaliseStatusTableFieldName(name)]
@@ -163,8 +164,8 @@ type statusTableColumn struct {
 
 func parseStatusTableColumn(part string) (statusTableColumn, error) {
 	name, widthText, found := strings.Cut(part, ":")
-	if !found {
-		return statusTableColumn{}, errStatusFormatEmpty
+	if !found || strings.TrimSpace(name) == "" {
+		return statusTableColumn{}, errStatusFormatBadField
 	}
 
 	width, err := parseStatusTableColumnWidth(widthText)
@@ -264,8 +265,9 @@ func fitStatusTableValue(value string, width int) string {
 }
 
 func parseStatusTableColumnWidth(widthText string) (int, error) {
-	if strings.TrimSpace(widthText) == "" {
-		return 0, errStatusFormatEmpty
+	widthText = strings.TrimSpace(widthText)
+	if widthText == "" {
+		return 0, errStatusFormatBadWidth
 	}
 
 	width, err := strconv.Atoi(widthText)

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -246,15 +246,17 @@ func writeStatusTableCell(w io.Writer, column statusTableColumn, value string) {
 }
 
 func fitStatusTableValue(value string, width int) string {
-	if len(value) <= width {
+	runes := []rune(value)
+	if len(runes) <= width {
 		return value
 	}
 
-	if width <= len(statusTableDefaultTruncateMarker) {
-		return value[:width]
+	truncateMarkerRunes := []rune(statusTableDefaultTruncateMarker)
+	if width <= len(truncateMarkerRunes) {
+		return string(runes[:width])
 	}
 
-	return value[:width-len(statusTableDefaultTruncateMarker)] + statusTableDefaultTruncateMarker
+	return string(runes[:width-len(truncateMarkerRunes)]) + statusTableDefaultTruncateMarker
 }
 
 func parseStatusTableColumnWidth(widthText string) (int, error) {

--- a/cmd/status_table.go
+++ b/cmd/status_table.go
@@ -42,6 +42,18 @@ const (
 	statusTableColumnSeparator       = "  "
 	statusTableDefaultTruncateMarker = "..."
 	statusTableStatusFieldName       = "status"
+	statusOutputFormatCounts         = "counts"
+	statusOutputFormatCountsAlias    = "c"
+	statusOutputFormatSummary        = "summary"
+	statusOutputFormatSummaryAlias   = "s"
+	statusOutputFormatDetails        = "details"
+	statusOutputFormatDetailsAlias   = "d"
+	statusOutputFormatPlain          = "plain"
+	statusOutputFormatPlainAlias     = "p"
+	statusOutputFormatTable          = "table"
+	statusOutputFormatTableAlias     = "t"
+	statusOutputFormatJSON           = "json"
+	statusOutputFormatJSONAlias      = "j"
 )
 
 type statusTableField struct {
@@ -104,7 +116,14 @@ var (
 )
 
 func statusOutputShowsAlerts(format string) bool {
-	return format != "json" && format != "j" && format != "plain" && format != "p"
+	switch format {
+	case statusOutputFormatCounts, statusOutputFormatCountsAlias,
+		statusOutputFormatJSON, statusOutputFormatJSONAlias,
+		statusOutputFormatPlain, statusOutputFormatPlainAlias:
+		return false
+	default:
+		return true
+	}
 }
 
 func statusTableHost(job *jobqueue.Job) string {
@@ -260,7 +279,7 @@ func statusOutputGetsStd(format string) bool {
 }
 
 func statusOutputIsTable(format string) bool {
-	return format == "table" || format == "t"
+	return format == statusOutputFormatTable || format == statusOutputFormatTableAlias
 }
 
 func normaliseStatusTableFieldName(name string) string {

--- a/cmd/status_table_test.go
+++ b/cmd/status_table_test.go
@@ -27,6 +27,7 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"testing"
 	"unicode/utf8"
 
@@ -43,6 +44,39 @@ func TestStatusTableUnicodeCells(t *testing.T) {
 
 		So(output.String(), ShouldEqual, "é...")
 		So(utf8.ValidString(output.String()), ShouldBeTrue)
+	})
+}
+
+func TestStatusTableFormatErrors(t *testing.T) {
+	Convey("wr status table reports missing FIELD:width syntax", t, func() {
+		t.Setenv(statusFormatEnv, statusTableStatusFieldName)
+
+		err := writeStatusTable(io.Discard, nil)
+
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "FIELD:width")
+		So(err.Error(), ShouldNotContainSubstring, errStatusFormatEmpty.Error())
+	})
+
+	Convey("wr status table reports empty widths as bad positive widths", t, func() {
+		t.Setenv(statusFormatEnv, statusTableStatusFieldName+":")
+
+		err := writeStatusTable(io.Discard, nil)
+
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, errStatusFormatBadWidth.Error())
+		So(err.Error(), ShouldNotContainSubstring, errStatusFormatEmpty.Error())
+	})
+}
+
+func TestStatusLimitHelp(t *testing.T) {
+	Convey("wr status --limit help describes grouped outputs", t, func() {
+		flag := statusCmd.Flags().Lookup("limit")
+
+		So(flag, ShouldNotBeNil)
+		So(flag.Usage, ShouldContainSubstring, "grouped outputs")
+		So(flag.Usage, ShouldContainSubstring, "details")
+		So(flag.Usage, ShouldContainSubstring, "table")
 	})
 }
 

--- a/cmd/status_table_test.go
+++ b/cmd/status_table_test.go
@@ -80,6 +80,15 @@ func TestStatusLimitHelp(t *testing.T) {
 	})
 }
 
+func TestStatusTableOutputHelp(t *testing.T) {
+	Convey("wr status table output help describes rows without promising exactly one per status group", t, func() {
+		So(statusCmd.Long, ShouldContainSubstring, `"table" outputs aligned rows`)
+		So(statusCmd.Long, ShouldContainSubstring, "--limit")
+		So(statusCmd.Long, ShouldContainSubstring, "WR_STATUS_FORMAT")
+		So(statusCmd.Long, ShouldNotContainSubstring, "one aligned row per status group")
+	})
+}
+
 func TestStatusOutputRetrievalNeeds(t *testing.T) {
 	Convey("wr status only retrieves stdout and stderr for outputs that render them", t, func() {
 		for _, tc := range []struct {

--- a/cmd/status_table_test.go
+++ b/cmd/status_table_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/VertebrateResequencing/wr/jobqueue"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -66,6 +67,53 @@ func TestStatusTableFormatErrors(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, errStatusFormatBadWidth.Error())
 		So(err.Error(), ShouldNotContainSubstring, errStatusFormatEmpty.Error())
+	})
+}
+
+func TestStatusTableRows(t *testing.T) {
+	Convey("wr status table renders reserved jobs as running", t, func() {
+		t.Setenv(statusFormatEnv, "status:9 count:5")
+
+		jobs := []*jobqueue.Job{
+			{State: jobqueue.JobStateReserved},
+		}
+
+		var output bytes.Buffer
+
+		err := writeStatusTable(&output, jobs)
+
+		So(err, ShouldBeNil)
+		So(output.String(), ShouldContainSubstring, "running")
+		So(output.String(), ShouldNotContainSubstring, "reserved")
+	})
+
+	Convey("wr status table repeats the limited status group total on each row", t, func() {
+		t.Setenv(statusFormatEnv, "command:9 status:9 count:5")
+
+		jobs := []*jobqueue.Job{
+			{Cmd: "first", State: jobqueue.JobStateBuried, Exitcode: 1, FailReason: jobqueue.FailReasonExit},
+			{
+				Cmd:        "second",
+				State:      jobqueue.JobStateBuried,
+				Exitcode:   1,
+				FailReason: jobqueue.FailReasonExit,
+				Similar:    2,
+			},
+		}
+
+		var output bytes.Buffer
+
+		err := writeStatusTable(&output, jobs)
+		lines := nonEmptyStatusLines(output.String())
+
+		So(err, ShouldBeNil)
+		So(lines, ShouldHaveLength, 3)
+		So(lines[1], ShouldContainSubstring, "first")
+		So(lines[1], ShouldContainSubstring, "buried")
+		So(lines[1], ShouldContainSubstring, "4")
+		So(lines[2], ShouldContainSubstring, "second")
+		So(lines[2], ShouldContainSubstring, "buried")
+		So(lines[2], ShouldContainSubstring, "4")
 	})
 }
 

--- a/cmd/status_table_test.go
+++ b/cmd/status_table_test.go
@@ -45,3 +45,49 @@ func TestStatusTableUnicodeCells(t *testing.T) {
 		So(utf8.ValidString(output.String()), ShouldBeTrue)
 	})
 }
+
+func TestStatusOutputRetrievalNeeds(t *testing.T) {
+	Convey("wr status only retrieves stdout and stderr for outputs that render them", t, func() {
+		for _, tc := range []struct {
+			format string
+			want   bool
+		}{
+			{statusOutputFormatCounts, false},
+			{statusOutputFormatCountsAlias, false},
+			{statusOutputFormatSummary, false},
+			{statusOutputFormatSummaryAlias, false},
+			{statusOutputFormatDetails, true},
+			{statusOutputFormatDetailsAlias, true},
+			{statusOutputFormatPlain, false},
+			{statusOutputFormatPlainAlias, false},
+			{statusOutputFormatTable, false},
+			{statusOutputFormatTableAlias, false},
+			{statusOutputFormatJSON, true},
+			{statusOutputFormatJSONAlias, true},
+		} {
+			So(statusOutputGetsStd(tc.format), ShouldEqual, tc.want)
+		}
+	})
+
+	Convey("wr status only applies --env to details output", t, func() {
+		for _, tc := range []struct {
+			format string
+			want   bool
+		}{
+			{statusOutputFormatCounts, false},
+			{statusOutputFormatCountsAlias, false},
+			{statusOutputFormatSummary, false},
+			{statusOutputFormatSummaryAlias, false},
+			{statusOutputFormatDetails, true},
+			{statusOutputFormatDetailsAlias, true},
+			{statusOutputFormatPlain, false},
+			{statusOutputFormatPlainAlias, false},
+			{statusOutputFormatTable, false},
+			{statusOutputFormatTableAlias, false},
+			{statusOutputFormatJSON, false},
+			{statusOutputFormatJSONAlias, false},
+		} {
+			So(statusOutputGetsEnv(tc.format), ShouldEqual, tc.want)
+		}
+	})
+}

--- a/cmd/status_table_test.go
+++ b/cmd/status_table_test.go
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"unicode/utf8"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStatusTableUnicodeCells(t *testing.T) {
+	Convey("status table cells truncate non-ASCII text by rune", t, func() {
+		column := statusTableColumn{width: 4}
+
+		var output bytes.Buffer
+
+		writeStatusTableCell(&output, column, "éabcd")
+
+		So(output.String(), ShouldEqual, "é...")
+		So(utf8.ValidString(output.String()), ShouldBeTrue)
+	})
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -26,6 +26,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -51,6 +52,53 @@ const (
 	statusTestReqGroup = "status"
 	statusTestRepGroup = "status-filter"
 )
+
+func TestStatusSchedulerAlertsFooter(t *testing.T) {
+	Convey("wr status renders scheduler alerts as a footer", t, func() {
+		alerts := &jobqueue.SchedulerAlerts{
+			Issues: []*jobqueue.SchedulerIssue{
+				{
+					Msg:       "scheduler backed off",
+					FirstDate: 1710000000,
+					LastDate:  1710000060,
+					Count:     2,
+				},
+			},
+			BadServers: []*jobqueue.BadServer{
+				{
+					ID:      "serverid-footer-alert",
+					Name:    "worker-alert",
+					IP:      "192.168.0.9",
+					Date:    1710000120,
+					IsBad:   true,
+					Problem: "boot failed",
+				},
+				{
+					ID:    "serverid-footer-maybe",
+					Name:  "worker-maybe",
+					IP:    "192.168.0.10",
+					Date:  1710000180,
+					IsBad: false,
+				},
+			},
+		}
+
+		var output bytes.Buffer
+
+		writeStatusAlertsFooter(&output, alerts)
+
+		got := output.String()
+		So(got, ShouldContainSubstring, "Scheduler alerts:")
+		So(got, ShouldContainSubstring, "Scheduler Issue")
+		So(got, ShouldContainSubstring, "scheduler backed off")
+		So(got, ShouldContainSubstring, "reported 2 times")
+		So(got, ShouldContainSubstring, "Bad server")
+		So(got, ShouldContainSubstring, "worker-alert")
+		So(got, ShouldContainSubstring, "boot failed")
+		So(got, ShouldContainSubstring, "worker-maybe")
+		So(got, ShouldContainSubstring, "might be dead")
+	})
+}
 
 func TestStatusFiltersPendingAndDependentJobs(t *testing.T) {
 	Convey("wr status filters pending and dependent jobs", t, func() {
@@ -171,6 +219,79 @@ func TestStatusFiltersPendingAndDependentJobs(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, tc.want)
 			})
 		}
+	})
+}
+
+func TestStatusTableOutput(t *testing.T) {
+	Convey("wr status renders an aligned table", t, func() {
+		ctx := context.Background()
+		testConfig, serverConfig, addr, reqs, server, token := startStatusTestServer(ctx, t)
+
+		oldConfig, oldCAFile := config, caFile
+
+		config, caFile = testConfig, testConfig.ManagerCAFile
+		defer func() {
+			config, caFile = oldConfig, oldCAFile
+		}()
+
+		defer server.Stop(ctx, true)
+
+		jq, err := jobqueue.Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, 2*time.Second)
+
+		So(err, ShouldBeNil)
+		defer func() {
+			So(jq.Disconnect(), ShouldBeNil)
+		}()
+
+		jobs := []*jobqueue.Job{
+			{
+				Cmd:          "echo status table one",
+				Cwd:          statusTestCwd,
+				ReqGroup:     statusTestReqGroup,
+				Requirements: reqs,
+				RepGroup:     statusTestRepGroup,
+			},
+			{
+				Cmd:          "echo status table two",
+				Cwd:          statusTestCwd,
+				ReqGroup:     statusTestReqGroup,
+				Requirements: reqs,
+				RepGroup:     statusTestRepGroup,
+			},
+		}
+		inserts, already, err := jq.Add(jobs, os.Environ(), true)
+		So(err, ShouldBeNil)
+		So(inserts, ShouldEqual, 2)
+		So(already, ShouldEqual, 0)
+
+		output := runStatusForTest(t, "--output", "table")
+		lines := nonEmptyStatusLines(output)
+
+		So(lines, ShouldHaveLength, 2)
+		So(lines[0], ShouldContainSubstring, "Command")
+		So(lines[0], ShouldContainSubstring, "ID")
+		So(lines[0], ShouldContainSubstring, "Status")
+		So(lines[0], ShouldContainSubstring, "Attempts")
+		So(lines[0], ShouldContainSubstring, "Host")
+		So(lines[0], ShouldContainSubstring, "Requirements group")
+		So(lines[0], ShouldContainSubstring, "Count")
+		So(lines[1], ShouldContainSubstring, "echo status table")
+		So(lines[1], ShouldContainSubstring, "ready")
+		So(lines[1], ShouldContainSubstring, statusTestReqGroup)
+		So(lines[1], ShouldContainSubstring, "2")
+		So(strings.Count(output, "echo status table"), ShouldEqual, 1)
+
+		t.Setenv("WR_STATUS_FORMAT", "status:9 count:5")
+
+		output = runStatusForTest(t, "--output", "t")
+		lines = nonEmptyStatusLines(output)
+
+		So(lines, ShouldHaveLength, 2)
+		So(lines[0], ShouldContainSubstring, "Status")
+		So(lines[0], ShouldContainSubstring, "Count")
+		So(lines[0], ShouldNotContainSubstring, "Command")
+		So(lines[1], ShouldContainSubstring, "ready")
+		So(lines[1], ShouldContainSubstring, "2")
 	})
 }
 
@@ -349,4 +470,16 @@ func startStatusTestServer(ctx context.Context, t *testing.T) (
 	So(err, ShouldBeNil)
 
 	return testConfig, serverConfig, addr, reqs, server, token
+}
+
+func nonEmptyStatusLines(output string) []string {
+	var lines []string
+
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return lines
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -100,6 +100,13 @@ func TestStatusSchedulerAlertsFooter(t *testing.T) {
 					Name:  "worker-maybe",
 					IP:    "192.168.0.10",
 					Date:  1710000180,
+					IsBad: true,
+				},
+				{
+					ID:    "serverid-footer-recovered",
+					Name:  "worker-recovered",
+					IP:    "192.168.0.11",
+					Date:  1710000240,
 					IsBad: false,
 				},
 			},
@@ -119,6 +126,28 @@ func TestStatusSchedulerAlertsFooter(t *testing.T) {
 		So(got, ShouldContainSubstring, "boot failed")
 		So(got, ShouldContainSubstring, "worker-maybe")
 		So(got, ShouldContainSubstring, "might be dead")
+		So(got, ShouldNotContainSubstring, "worker-recovered")
+	})
+
+	Convey("wr status skips recovered bad servers in the footer", t, func() {
+		alerts := &jobqueue.SchedulerAlerts{
+			BadServers: []*jobqueue.BadServer{
+				{
+					ID:      "serverid-footer-recovered",
+					Name:    "worker-recovered",
+					IP:      "192.168.0.11",
+					Date:    1710000240,
+					IsBad:   false,
+					Problem: "boot failed",
+				},
+			},
+		}
+
+		var output bytes.Buffer
+
+		writeStatusAlertsFooter(&output, alerts)
+
+		So(output.String(), ShouldBeEmpty)
 	})
 }
 

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -53,6 +53,22 @@ const (
 	statusTestRepGroup = "status-filter"
 )
 
+//nolint:gosmopolitan // This test fixes time.Local to assert local CLI rendering.
+func TestStatusAlertTimeFormatting(t *testing.T) {
+	Convey("wr status renders scheduler alert Unix timestamps in local time", t, func() {
+		oldLocal := time.Local
+
+		time.Local = time.FixedZone("status-alert-test", 90*60)
+		defer func() {
+			time.Local = oldLocal
+		}()
+
+		unixSeconds := time.Date(2024, 3, 9, 12, 0, 0, 0, time.UTC).Unix()
+
+		So(formatStatusAlertTime(unixSeconds), ShouldEqual, "24/3/9-13:30:00")
+	})
+}
+
 type statusAlertsGetterFunc func() (*jobqueue.SchedulerAlerts, error)
 
 func (f statusAlertsGetterFunc) GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error) {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -45,13 +45,19 @@ import (
 
 const (
 	statusTestCwd      = "/tmp"
-	statusTestDetails  = "details"
+	statusTestDetails  = statusOutputFormatDetails
 	statusTestFalse    = "false"
 	statusTestFlagBury = "buried"
 	statusTestHost     = "localhost"
 	statusTestReqGroup = "status"
 	statusTestRepGroup = "status-filter"
 )
+
+type statusAlertsGetterFunc func() (*jobqueue.SchedulerAlerts, error)
+
+func (f statusAlertsGetterFunc) GetSchedulerAlerts() (*jobqueue.SchedulerAlerts, error) {
+	return f()
+}
 
 func TestStatusSchedulerAlertsFooter(t *testing.T) {
 	Convey("wr status renders scheduler alerts as a footer", t, func() {
@@ -98,6 +104,64 @@ func TestStatusSchedulerAlertsFooter(t *testing.T) {
 		So(got, ShouldContainSubstring, "worker-maybe")
 		So(got, ShouldContainSubstring, "might be dead")
 	})
+}
+
+func TestStatusSchedulerAlertsFooterOutputModes(t *testing.T) {
+	Convey("wr status leaves count and machine-readable outputs unchanged by scheduler alerts", t, func() {
+		calls := 0
+		getter := statusAlertsGetterFunc(func() (*jobqueue.SchedulerAlerts, error) {
+			calls++
+
+			return statusAlertsForTest(), nil
+		})
+
+		for _, format := range []string{
+			statusOutputFormatCounts,
+			statusOutputFormatCountsAlias,
+			statusOutputFormatJSON,
+			statusOutputFormatJSONAlias,
+			statusOutputFormatPlain,
+			statusOutputFormatPlainAlias,
+		} {
+			var output bytes.Buffer
+
+			writeStatusAlerts(&output, getter, format)
+
+			So(output.String(), ShouldBeEmpty)
+		}
+
+		So(calls, ShouldEqual, 0)
+	})
+
+	Convey("wr status appends scheduler alerts to human-readable outputs", t, func() {
+		for _, format := range []string{
+			statusOutputFormatDetails,
+			statusOutputFormatDetailsAlias,
+			statusOutputFormatSummary,
+			statusOutputFormatSummaryAlias,
+			statusOutputFormatTable,
+			statusOutputFormatTableAlias,
+		} {
+			var output bytes.Buffer
+
+			writeStatusAlerts(&output, statusAlertsGetterFunc(func() (*jobqueue.SchedulerAlerts, error) {
+				return statusAlertsForTest(), nil
+			}), format)
+
+			So(output.String(), ShouldContainSubstring, "Scheduler alerts:")
+			So(output.String(), ShouldContainSubstring, "scheduler backed off")
+		}
+	})
+}
+
+func statusAlertsForTest() *jobqueue.SchedulerAlerts {
+	return &jobqueue.SchedulerAlerts{
+		Issues: []*jobqueue.SchedulerIssue{
+			{
+				Msg: "scheduler backed off",
+			},
+		},
+	}
 }
 
 func TestStatusFiltersPendingAndDependentJobs(t *testing.T) {

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -194,6 +194,7 @@ type Client struct {
 	sync.Mutex
 	teMutex    sync.Mutex // to protect Touch() from other methods during Execute()
 	token      []byte
+	timeout    time.Duration
 	ServerInfo *ServerInfo
 	host       string
 	port       string
@@ -295,6 +296,7 @@ func Connect(addr, caFile, certDomain string, token []byte, timeout time.Duratio
 		sock:     sock,
 		ch:       new(codec.BincHandle),
 		token:    token,
+		timeout:  timeout,
 		clientid: u,
 		host:     addrParts[0],
 		port:     addrParts[1],

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -195,6 +196,7 @@ type Client struct {
 	teMutex    sync.Mutex // to protect Touch() from other methods during Execute()
 	token      []byte
 	timeout    time.Duration
+	restClient *http.Client
 	ServerInfo *ServerInfo
 	host       string
 	port       string
@@ -348,6 +350,11 @@ func ConnectUsingConfig(ctx context.Context, deployment string, timeout time.Dur
 func (c *Client) Disconnect() error {
 	c.Lock()
 	defer c.Unlock()
+
+	if c.restClient != nil {
+		c.restClient.CloseIdleConnections()
+	}
+
 	return c.sock.Close()
 }
 

--- a/jobqueue/client_rest.go
+++ b/jobqueue/client_rest.go
@@ -115,9 +115,9 @@ func (c *Client) restURL(endpoint string) (string, error) {
 		return "", errSchedulerAlertsNoServerInfo
 	}
 
-	host := c.ServerInfo.Host
+	host := c.host
 	if host == "" {
-		host = c.host
+		host = c.ServerInfo.Host
 	}
 
 	return "https://" + net.JoinHostPort(host, c.ServerInfo.WebPort) + endpoint, nil

--- a/jobqueue/client_rest.go
+++ b/jobqueue/client_rest.go
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultRESTClientTimeout = 30 * time.Second
+	restErrorReadLimit       = 4096
+	restClientArgsCAFile     = 1
+	restClientArgsCertDomain = 2
+)
+
+var (
+	errSchedulerAlertsNoServerInfo = errors.New("client has no server web interface details")
+	errRESTUnexpectedStatus        = errors.New("REST request returned unexpected status")
+)
+
+func restCheckStatus(endpoint string, resp *http.Response) error {
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, restErrorReadLimit))
+	if err != nil {
+		return fmt.Errorf("%w: failed to read GET %s response: %w", errRESTUnexpectedStatus, endpoint, err)
+	}
+
+	return fmt.Errorf("%w: GET %s returned %s: %s", errRESTUnexpectedStatus,
+		endpoint, resp.Status, string(bytes.TrimSpace(body)))
+}
+
+// GetSchedulerAlerts returns scheduler issues and bad cloud servers currently
+// exposed by the manager web API. Reading Issues dismisses them on the manager,
+// matching the existing warnings REST endpoint behaviour used by the web UI.
+func (c *Client) GetSchedulerAlerts() (*SchedulerAlerts, error) {
+	alerts := &SchedulerAlerts{}
+	if err := c.restGet(restBadServersEndpoint, &alerts.BadServers); err != nil {
+		return nil, err
+	}
+
+	if err := c.restGet(restWarningsEndpoint, &alerts.Issues); err != nil {
+		return nil, err
+	}
+
+	return alerts, nil
+}
+
+func (c *Client) restGet(endpoint string, response any) error {
+	url, err := c.restURL(endpoint)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", bearerSchema+string(c.token))
+
+	resp, err := c.restHTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err = restCheckStatus(endpoint, resp); err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+
+	return decoder.Decode(response)
+}
+
+func (c *Client) restURL(endpoint string) (string, error) {
+	if c.ServerInfo == nil || c.ServerInfo.WebPort == "" {
+		return "", errSchedulerAlertsNoServerInfo
+	}
+
+	host := c.ServerInfo.Host
+	if host == "" {
+		host = c.host
+	}
+
+	return "https://" + net.JoinHostPort(host, c.ServerInfo.WebPort) + endpoint, nil
+}
+
+func (c *Client) restHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   c.restTimeout(),
+		Transport: &http.Transport{TLSClientConfig: c.restTLSConfig()},
+	}
+}
+
+func (c *Client) restTimeout() time.Duration {
+	if c.timeout > 0 {
+		return c.timeout
+	}
+
+	return defaultRESTClientTimeout
+}
+
+func (c *Client) restTLSConfig() *tls.Config {
+	caFile := ""
+	certDomain := ""
+
+	if len(c.args) > restClientArgsCAFile {
+		caFile = c.args[restClientArgsCAFile]
+	}
+
+	if len(c.args) > restClientArgsCertDomain {
+		certDomain = c.args[restClientArgsCertDomain]
+	}
+
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: certDomain}
+
+	caCert, err := os.ReadFile(caFile)
+	if err == nil {
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = certPool
+	}
+
+	return tlsConfig
+}

--- a/jobqueue/client_rest.go
+++ b/jobqueue/client_rest.go
@@ -159,7 +159,7 @@ func (c *Client) newRestHTTPClient() *http.Client {
 }
 
 func (c *Client) restTimeout() time.Duration {
-	if c.timeout > 0 {
+	if c.timeout > 0 && c.timeout < defaultRESTClientTimeout {
 		return c.timeout
 	}
 

--- a/jobqueue/client_rest.go
+++ b/jobqueue/client_rest.go
@@ -66,6 +66,20 @@ func restCheckStatus(endpoint string, resp *http.Response) error {
 		endpoint, resp.Status, string(bytes.TrimSpace(body)))
 }
 
+func restRootCAPool(caFile string) *x509.CertPool {
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil
+	}
+
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(caCert) {
+		return nil
+	}
+
+	return certPool
+}
+
 // GetSchedulerAlerts returns scheduler issues and bad cloud servers currently
 // exposed by the manager web API. Reading Issues dismisses them on the manager,
 // matching the existing warnings REST endpoint behaviour used by the web UI.
@@ -157,10 +171,7 @@ func (c *Client) restTLSConfig() *tls.Config {
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: certDomain}
 
-	caCert, err := os.ReadFile(caFile)
-	if err == nil {
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(caCert)
+	if certPool := restRootCAPool(caFile); certPool != nil {
 		tlsConfig.RootCAs = certPool
 	}
 

--- a/jobqueue/client_rest.go
+++ b/jobqueue/client_rest.go
@@ -124,9 +124,23 @@ func (c *Client) restURL(endpoint string) (string, error) {
 }
 
 func (c *Client) restHTTPClient() *http.Client {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.restClient == nil {
+		c.restClient = c.newRestHTTPClient()
+	}
+
+	return c.restClient
+}
+
+func (c *Client) newRestHTTPClient() *http.Client {
 	return &http.Client{
-		Timeout:   c.restTimeout(),
-		Transport: &http.Transport{TLSClientConfig: c.restTLSConfig()},
+		Timeout: c.restTimeout(),
+		Transport: &http.Transport{
+			Proxy:           nil,
+			TLSClientConfig: c.restTLSConfig(),
+		},
 	}
 }
 
@@ -139,16 +153,7 @@ func (c *Client) restTimeout() time.Duration {
 }
 
 func (c *Client) restTLSConfig() *tls.Config {
-	caFile := ""
-	certDomain := ""
-
-	if len(c.args) > restClientArgsCAFile {
-		caFile = c.args[restClientArgsCAFile]
-	}
-
-	if len(c.args) > restClientArgsCertDomain {
-		certDomain = c.args[restClientArgsCertDomain]
-	}
+	caFile, certDomain := c.restTLSConfigInputs()
 
 	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, ServerName: certDomain}
 
@@ -160,4 +165,19 @@ func (c *Client) restTLSConfig() *tls.Config {
 	}
 
 	return tlsConfig
+}
+
+func (c *Client) restTLSConfigInputs() (string, string) {
+	caFile := ""
+	certDomain := ""
+
+	if len(c.args) > restClientArgsCAFile {
+		caFile = c.args[restClientArgsCAFile]
+	}
+
+	if len(c.args) > restClientArgsCertDomain {
+		certDomain = c.args[restClientArgsCertDomain]
+	}
+
+	return caFile, certDomain
 }

--- a/jobqueue/client_rest_test.go
+++ b/jobqueue/client_rest_test.go
@@ -26,12 +26,18 @@
 package jobqueue
 
 import (
+	crand "crypto/rand"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/wr/internal"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+const restTestCertDomain = "manager-cert.example.org"
 
 func TestRESTHTTPClientReuse(t *testing.T) {
 	Convey("REST calls reuse an HTTP client that ignores proxy environment variables", t, func() {
@@ -54,7 +60,7 @@ func TestRESTURLUsesConnectedHost(t *testing.T) {
 	Convey("REST URLs prefer the host used for the RPC connection", t, func() {
 		jq := &Client{
 			ServerInfo: &ServerInfo{
-				Host:    "manager-cert.example.org",
+				Host:    restTestCertDomain,
 				WebPort: "1234",
 			},
 			host: "127.0.0.1",
@@ -69,7 +75,7 @@ func TestRESTURLUsesConnectedHost(t *testing.T) {
 	Convey("REST URLs fall back to the server host when no connected host is known", t, func() {
 		jq := &Client{
 			ServerInfo: &ServerInfo{
-				Host:    "manager-cert.example.org",
+				Host:    restTestCertDomain,
 				WebPort: "1234",
 			},
 		}
@@ -77,6 +83,37 @@ func TestRESTURLUsesConnectedHost(t *testing.T) {
 		url, err := jq.restURL("/api")
 
 		So(err, ShouldBeNil)
-		So(url, ShouldEqual, "https://manager-cert.example.org:1234/api")
+		So(url, ShouldEqual, "https://"+restTestCertDomain+":1234/api")
+	})
+}
+
+func TestRESTTLSConfigCAPool(t *testing.T) {
+	Convey("REST TLS config uses system roots when the configured CA file has no PEM certificates", t, func() {
+		caFile := filepath.Join(t.TempDir(), "ca.pem")
+		So(os.WriteFile(caFile, []byte("not a certificate"), 0o600), ShouldBeNil)
+
+		jq := &Client{args: []string{localhost + ":0", caFile, restTestCertDomain}}
+
+		tlsConfig := jq.restTLSConfig()
+
+		So(tlsConfig.ServerName, ShouldEqual, restTestCertDomain)
+		So(tlsConfig.RootCAs, ShouldBeNil)
+	})
+
+	Convey("REST TLS config uses a custom root pool when the configured CA file contains PEM certificates", t, func() {
+		certDir := t.TempDir()
+		caFile := filepath.Join(certDir, "ca.pem")
+		certFile := filepath.Join(certDir, "cert.pem")
+		keyFile := filepath.Join(certDir, "key.pem")
+
+		err := internal.GenerateCerts(caFile, certFile, keyFile, localhost, internal.DefaultBitsForRootRSAKey,
+			internal.DefualtBitsForServerRSAKey, crand.Reader, internal.DefaultCertFileFlags)
+		So(err, ShouldBeNil)
+
+		jq := &Client{args: []string{localhost + ":0", caFile, localhost}}
+
+		tlsConfig := jq.restTLSConfig()
+
+		So(tlsConfig.RootCAs, ShouldNotBeNil)
 	})
 }

--- a/jobqueue/client_rest_test.go
+++ b/jobqueue/client_rest_test.go
@@ -56,6 +56,25 @@ func TestRESTHTTPClientReuse(t *testing.T) {
 	})
 }
 
+func TestRESTHTTPClientTimeout(t *testing.T) {
+	Convey("REST calls cap long RPC timeouts at the default REST client timeout", t, func() {
+		jq := &Client{timeout: 2 * defaultRESTClientTimeout}
+
+		client := jq.restHTTPClient()
+
+		So(client.Timeout, ShouldEqual, defaultRESTClientTimeout)
+	})
+
+	Convey("REST calls preserve RPC timeouts shorter than the default REST client timeout", t, func() {
+		shorterTimeout := defaultRESTClientTimeout / 3
+		jq := &Client{timeout: shorterTimeout}
+
+		client := jq.restHTTPClient()
+
+		So(client.Timeout, ShouldEqual, shorterTimeout)
+	})
+}
+
 func TestRESTURLUsesConnectedHost(t *testing.T) {
 	Convey("REST URLs prefer the host used for the RPC connection", t, func() {
 		jq := &Client{

--- a/jobqueue/client_rest_test.go
+++ b/jobqueue/client_rest_test.go
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRESTHTTPClientReuse(t *testing.T) {
+	Convey("REST calls reuse an HTTP client that ignores proxy environment variables", t, func() {
+		t.Setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+
+		jq := &Client{
+			timeout: time.Second,
+			args:    []string{localhost + ":0", "", localhost},
+		}
+		client := jq.restHTTPClient()
+		transport, ok := client.Transport.(*http.Transport)
+
+		So(jq.restHTTPClient() == client, ShouldBeTrue)
+		So(ok, ShouldBeTrue)
+		So(transport.Proxy, ShouldBeNil)
+	})
+}

--- a/jobqueue/client_rest_test.go
+++ b/jobqueue/client_rest_test.go
@@ -49,3 +49,34 @@ func TestRESTHTTPClientReuse(t *testing.T) {
 		So(transport.Proxy, ShouldBeNil)
 	})
 }
+
+func TestRESTURLUsesConnectedHost(t *testing.T) {
+	Convey("REST URLs prefer the host used for the RPC connection", t, func() {
+		jq := &Client{
+			ServerInfo: &ServerInfo{
+				Host:    "manager-cert.example.org",
+				WebPort: "1234",
+			},
+			host: "127.0.0.1",
+		}
+
+		url, err := jq.restURL("/api")
+
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "https://127.0.0.1:1234/api")
+	})
+
+	Convey("REST URLs fall back to the server host when no connected host is known", t, func() {
+		jq := &Client{
+			ServerInfo: &ServerInfo{
+				Host:    "manager-cert.example.org",
+				WebPort: "1234",
+			},
+		}
+
+		url, err := jq.restURL("/api")
+
+		So(err, ShouldBeNil)
+		So(url, ShouldEqual, "https://manager-cert.example.org:1234/api")
+	})
+}

--- a/jobqueue/jobqueue_runners2_test.go
+++ b/jobqueue/jobqueue_runners2_test.go
@@ -27,6 +27,7 @@ package jobqueue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math"
@@ -44,6 +45,8 @@ import (
 	"github.com/shirou/gopsutil/v4/process"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+var errWaitForJobRunningOrDoneTimeout = errors.New("timed out waiting for job to reach running or terminal state")
 
 // TestJobqueueRunners2 holds the second half of TestJobqueueRunners's
 // runner-spawning scenarios. It lives in its own test (and file) purely so the
@@ -590,7 +593,22 @@ func waitForJobRunningOrDone(jq *Client, essence *JobEssence, maxWait time.Durat
 		select {
 		case <-ticker.C:
 		case <-limit:
-			return job, nil
+			if job == nil {
+				return nil, fmt.Errorf(
+					"%w after %s for job %q: job not found",
+					errWaitForJobRunningOrDoneTimeout,
+					maxWait,
+					essence.Cmd,
+				)
+			}
+
+			return job, fmt.Errorf(
+				"%w after %s for job %q: last state %s",
+				errWaitForJobRunningOrDoneTimeout,
+				maxWait,
+				essence.Cmd,
+				job.State,
+			)
 		}
 	}
 }

--- a/jobqueue/jobqueue_runners2_test.go
+++ b/jobqueue/jobqueue_runners2_test.go
@@ -287,9 +287,7 @@ func TestJobqueueRunners2(t *testing.T) {
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				<-time.After(500 * time.Millisecond)
-
-				job, err := jq.GetByEssence(&JobEssence{Cmd: "echo 1 && sleep 2"}, false, false)
+				job, err := waitForJobRunningOrDone(jq, &JobEssence{Cmd: "echo 1 && sleep 2"}, 30*time.Second)
 				So(err, ShouldBeNil)
 				So(job, ShouldNotBeNil)
 				So(job.State, ShouldEqual, JobStateRunning)
@@ -300,9 +298,7 @@ func TestJobqueueRunners2(t *testing.T) {
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				<-time.After(500 * time.Millisecond)
-
-				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 2 && sleep 2"}, false, false)
+				job, err = waitForJobRunningOrDone(jq, &JobEssence{Cmd: "echo 2 && sleep 2"}, 30*time.Second)
 				So(err, ShouldBeNil)
 				So(job, ShouldNotBeNil)
 				So(job.State, ShouldEqual, JobStateRunning)
@@ -313,9 +309,7 @@ func TestJobqueueRunners2(t *testing.T) {
 				So(inserts, ShouldEqual, 1)
 				So(already, ShouldEqual, 0)
 
-				<-time.After(500 * time.Millisecond)
-
-				job, err = jq.GetByEssence(&JobEssence{Cmd: "echo 3 && sleep 2"}, false, false)
+				job, err = waitForJobRunningOrDone(jq, &JobEssence{Cmd: "echo 3 && sleep 2"}, 30*time.Second)
 				So(err, ShouldBeNil)
 				So(job, ShouldNotBeNil)
 				So(job.State, ShouldEqual, JobStateRunning)
@@ -568,6 +562,46 @@ func TestJobqueueRunners2(t *testing.T) {
 			}
 		})
 	})
+}
+
+// waitForJobRunningOrDone polls until the job starts running, reaches a state
+// that means it will not become running, or maxWait elapses.
+func waitForJobRunningOrDone(jq *Client, essence *JobEssence, maxWait time.Duration) (*Job, error) {
+	limit := time.After(maxWait)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var job *Job
+
+	for {
+		got, err := jq.GetByEssence(essence, false, false)
+		if err != nil {
+			return nil, err
+		}
+
+		if got != nil {
+			job = got
+			if jobStateStopsRunningWait(job.State) {
+				return job, nil
+			}
+		}
+
+		select {
+		case <-ticker.C:
+		case <-limit:
+			return job, nil
+		}
+	}
+}
+
+func jobStateStopsRunningWait(state JobState) bool {
+	switch state {
+	case JobStateRunning, JobStateComplete, JobStateBuried, JobStateLost, JobStateDeleted, JobStateUnknown:
+		return true
+	default:
+		return false
+	}
 }
 
 // countSleepingProcs returns the number of currently-sleeping processes whose

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -832,6 +832,50 @@ func TestREST(t *testing.T) {
 			})
 		})
 
+		Convey("The Go client can retrieve the scheduler alerts shown by the web UI", func() {
+			server.simutex.Lock()
+			server.schedIssues["client scheduler message"] = &schedulerIssue{
+				Msg:       "client scheduler message",
+				FirstDate: 1710000000,
+				LastDate:  1710000060,
+				Count:     3,
+			}
+			server.simutex.Unlock()
+
+			cloudServer := &cloud.Server{
+				ID:   "serverid-client-alert",
+				Name: "alert-server",
+				IP:   "192.168.0.7",
+			}
+			cloudServer.GoneBad("boot failed")
+
+			server.bsmutex.Lock()
+			server.badServers[cloudServer.ID] = cloudServer
+			server.bsmutex.Unlock()
+
+			alerts, err := jq.GetSchedulerAlerts()
+			So(err, ShouldBeNil)
+			So(alerts, ShouldNotBeNil)
+			So(alerts.Issues, ShouldHaveLength, 1)
+			So(alerts.Issues[0].Msg, ShouldEqual, "client scheduler message")
+			So(alerts.Issues[0].FirstDate, ShouldEqual, 1710000000)
+			So(alerts.Issues[0].LastDate, ShouldEqual, 1710000060)
+			So(alerts.Issues[0].Count, ShouldEqual, 3)
+			So(alerts.BadServers, ShouldHaveLength, 1)
+			So(alerts.BadServers[0].ID, ShouldEqual, "serverid-client-alert")
+			So(alerts.BadServers[0].Name, ShouldEqual, "alert-server")
+			So(alerts.BadServers[0].IP, ShouldEqual, "192.168.0.7")
+			So(alerts.BadServers[0].Problem, ShouldEqual, "boot failed")
+
+			server.simutex.RLock()
+			So(server.schedIssues, ShouldHaveLength, 0)
+			server.simutex.RUnlock()
+
+			server.bsmutex.RLock()
+			So(server.badServers, ShouldHaveLength, 1)
+			server.bsmutex.RUnlock()
+		})
+
 		Reset(func() {
 			server.Stop(ctx, true)
 		})

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -387,13 +387,24 @@ type BadServer struct {
 	Problem string
 }
 
-// schedulerIssue is the details of scheduler problems encountered that we send
-// to the status webpage.
-type schedulerIssue struct {
+// SchedulerIssue is the details of a scheduler problem encountered that we send
+// to the status webpage and expose to clients.
+type SchedulerIssue struct {
 	Msg       string
 	FirstDate int64 // seconds since Unix epoch
 	LastDate  int64
 	Count     int // the number of identical Msg sent
+}
+
+// schedulerIssue is retained as the package-internal name used by the existing
+// web UI paths.
+type schedulerIssue = SchedulerIssue
+
+// SchedulerAlerts contains every scheduler alert currently surfaced by the web
+// UI: dismissible scheduler issues and cloud servers thought to be bad.
+type SchedulerAlerts struct {
+	Issues     []*SchedulerIssue
+	BadServers []*BadServer
 }
 
 // sgroup represents a scheduler group


### PR DESCRIPTION
## Summary
- add `wr status -o table` / `-o t` with `WR_STATUS_FORMAT` column configuration
- add client/REST plumbing to fetch scheduler warnings, bad servers, and dismissible messages
- print alert footers for human-readable status output while keeping counts/plain/json machine output clean

Solves #506
Solves #288

## Tests
- go test -tags netgo --count 1 ./cmd -run 'TestStatus(SchedulerAlertsFooter|SchedulerAlertsFooterOutputModes|TableOutput|FiltersPendingAndDependentJobs)' -v\n- go test -tags netgo --count 1 ./jobqueue -run TestREST -v\n- go test -tags netgo --count 1 ./cmd ./client ./jobqueue\n- make lint\n- make test