### PR TITLE
Add reverse lookup index for job modifications

### DIFF
--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -55,6 +55,7 @@ import (
 	"github.com/sb10/waitgroup"
 	"github.com/ugorji/go/codec"
 	bolt "go.etcd.io/bbolt"
+	berrors "go.etcd.io/bbolt/errors"
 )
 
 const (
@@ -67,21 +68,23 @@ const (
 	dbRunningTransactionsWaitTime = 1 * time.Minute
 )
 
+//nolint:gochecknoglobals // bucket names are shared BoltDB keys.
 var (
-	bucketJobsLive     = []byte("jobslive")
-	bucketJobsComplete = []byte("jobscomplete")
-	bucketRTK          = []byte("repgroupToKey")
-	bucketRGs          = []byte("repgroups")
-	bucketLGs          = []byte("limitgroups")
-	bucketDTK          = []byte("depgroupToKey")
-	bucketRDTK         = []byte("reverseDepgroupToKey")
-	bucketEnvs         = []byte("envs")
-	bucketStdO         = []byte("stdo")
-	bucketStdE         = []byte("stde")
-	bucketJobRAM       = []byte("jobRAM")
-	bucketJobDisk      = []byte("jobDisk")
-	bucketJobSecs      = []byte("jobSecs")
-	bucketRGEndTime    = []byte("repgroupEndTime") //nolint:gochecknoglobals
+	bucketJobsLive         = []byte("jobslive")
+	bucketJobsComplete     = []byte("jobscomplete")
+	bucketRTK              = []byte("repgroupToKey")
+	bucketRGs              = []byte("repgroups")
+	bucketLGs              = []byte("limitgroups")
+	bucketDTK              = []byte("depgroupToKey")
+	bucketRDTK             = []byte("reverseDepgroupToKey")
+	bucketJobLookupEntries = []byte("jobLookupEntries")
+	bucketEnvs             = []byte("envs")
+	bucketStdO             = []byte("stdo")
+	bucketStdE             = []byte("stde")
+	bucketJobRAM           = []byte("jobRAM")
+	bucketJobDisk          = []byte("jobDisk")
+	bucketJobSecs          = []byte("jobSecs")
+	bucketRGEndTime        = []byte("repgroupEndTime") //nolint:gochecknoglobals
 )
 
 // Rec* variables are only exported for testing purposes (*** though they should
@@ -315,6 +318,20 @@ func initDB(ctx context.Context, dbFile, dbBkFile, deployment string, wipeDevDB,
 		_, errf = tx.CreateBucketIfNotExists(bucketRDTK)
 		if errf != nil {
 			return fmt.Errorf("create bucket %s: %w", bucketRDTK, errf)
+		}
+
+		hadJobLookupEntries := tx.Bucket(bucketJobLookupEntries) != nil
+
+		_, errf = tx.CreateBucketIfNotExists(bucketJobLookupEntries)
+		if errf != nil {
+			return fmt.Errorf("create bucket %s: %w", bucketJobLookupEntries, errf)
+		}
+
+		if !hadJobLookupEntries {
+			errf = rebuildJobLookupEntries(tx)
+			if errf != nil {
+				return fmt.Errorf("rebuild bucket %s: %w", bucketJobLookupEntries, errf)
+			}
 		}
 		_, errf = tx.CreateBucketIfNotExists(bucketEnvs)
 		if errf != nil {
@@ -796,7 +813,8 @@ func (db *db) deleteLiveJobs(ctx context.Context, keys []string) error {
 	}
 
 	db.backgroundBackup(ctx)
-	//*** we're not removing the lookup entries from the bucket*TK buckets...
+	// *** we're not removing the lookup entries from the bucket*TK buckets, or
+	// their reverse entries, because the lookup buckets are historical.
 
 	return nil
 }
@@ -1274,8 +1292,6 @@ func (db *db) modifyLiveJobs(ctx context.Context, oldKeys []string, jobs []*Job)
 	sort.Sort(rdgLookups)
 	sort.Sort(encodedJobs)
 
-	lookupBuckets := [][]byte{bucketRTK, bucketDTK, bucketRDTK}
-
 	err = db.bolt.Batch(func(tx *bolt.Tx) error {
 		// delete old jobs and their lookups
 		newJobBucket := tx.Bucket(bucketJobsLive)
@@ -1285,28 +1301,14 @@ func (db *db) modifyLiveJobs(ctx context.Context, oldKeys []string, jobs []*Job)
 		es := make([][]byte, len(oldKeys))
 		var hadStd bool
 		for i, oldKey := range oldKeys {
-			suffix := []byte(dbDelimiter + oldKey)
-			for _, bucket := range lookupBuckets {
-				b := tx.Bucket(bucket)
-				// *** currently having to go through the the whole lookup
-				// buckets; if this is a noticeable performance issue, will have
-				// to implement a reverse lookup...
-				errf := b.ForEach(func(k, v []byte) error {
-					if bytes.HasSuffix(k, suffix) {
-						errd := b.Delete(k)
-						if errd != nil {
-							return errd
-						}
-					}
-					return nil
-				})
-				if errf != nil {
-					return errf
-				}
+			key := []byte(oldKey)
+
+			errd := deleteLookupEntriesForJobKey(tx, key)
+			if errd != nil {
+				return errd
 			}
 
-			key := []byte(oldKey)
-			errd := newJobBucket.Delete(key)
+			errd = newJobBucket.Delete(key)
 			if errd != nil {
 				return errd
 			}
@@ -1388,6 +1390,36 @@ func (db *db) modifyLiveJobs(ctx context.Context, oldKeys []string, jobs []*Job)
 	go db.backgroundBackup(ctx)
 
 	return err
+}
+
+func deleteLookupEntriesForJobKey(tx *bolt.Tx, jobKey []byte) error {
+	b := tx.Bucket(bucketJobLookupEntries)
+	if b == nil {
+		return fmt.Errorf("%w: %s", berrors.ErrBucketNotFound, bucketJobLookupEntries)
+	}
+
+	reverseKeys, deletes := collectLookupDeletes(b, reverseLookupEntryPrefix(jobKey))
+
+	for _, d := range deletes {
+		lookupBucket := tx.Bucket(d.bucket)
+		if lookupBucket == nil {
+			return fmt.Errorf("%w: %s", berrors.ErrBucketNotFound, d.bucket)
+		}
+
+		err := lookupBucket.Delete(d.key)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, key := range reverseKeys {
+		err := b.Delete(key)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // retrieveJobStd gets the values that were stored using updateJobStd() for the
@@ -1627,8 +1659,35 @@ func (db *db) putLookups(tx *bolt.Tx, bucket []byte, lookups sobsd) error {
 		if err != nil {
 			return err
 		}
+
+		if isIndexedLookupBucket(bucket) {
+			err = putReverseLookupEntry(tx, bucket, doublet[0])
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
+}
+
+func isIndexedLookupBucket(bucket []byte) bool {
+	return bytes.Equal(bucket, bucketRTK) ||
+		bytes.Equal(bucket, bucketDTK) ||
+		bytes.Equal(bucket, bucketRDTK)
+}
+
+func putReverseLookupEntry(tx *bolt.Tx, lookupBucket, lookupKey []byte) error {
+	jobKey := lookupEntryJobKey(lookupKey)
+	if len(jobKey) == 0 {
+		return nil
+	}
+
+	b := tx.Bucket(bucketJobLookupEntries)
+	if b == nil {
+		return fmt.Errorf("%w: %s", berrors.ErrBucketNotFound, bucketJobLookupEntries)
+	}
+
+	return b.Put(reverseLookupEntryKey(jobKey, lookupBucket, lookupKey), nil)
 }
 
 // storeEncodedJobs is a sobsdStorer for storing Jobs in the db.
@@ -1848,6 +1907,104 @@ func (db *db) backup(w io.Writer) error {
 		_, txErr := tx.WriteTo(w)
 		return txErr
 	})
+}
+
+type lookupDelete struct {
+	bucket []byte
+	key    []byte
+}
+
+func collectLookupDeletes(b *bolt.Bucket, prefix []byte) ([][]byte, []lookupDelete) {
+	var (
+		reverseKeys [][]byte
+		deletes     []lookupDelete
+	)
+
+	c := b.Cursor()
+	for k, _ := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+		reverseKeys = append(reverseKeys, append([]byte(nil), k...))
+
+		lookupBucket, lookupKey, ok := parseReverseLookupEntry(k, prefix)
+		if !ok {
+			continue
+		}
+
+		deletes = append(deletes, lookupDelete{
+			bucket: append([]byte(nil), lookupBucket...),
+			key:    append([]byte(nil), lookupKey...),
+		})
+	}
+
+	return reverseKeys, deletes
+}
+
+func parseReverseLookupEntry(entry, prefix []byte) (lookupBucket []byte, lookupKey []byte, ok bool) {
+	rest := entry[len(prefix):]
+
+	idx := bytes.Index(rest, []byte(dbDelimiter))
+	if idx <= 0 {
+		return nil, nil, false
+	}
+
+	lookupKeyStart := idx + len(dbDelimiter)
+	if lookupKeyStart >= len(rest) {
+		return nil, nil, false
+	}
+
+	return rest[:idx], rest[lookupKeyStart:], true
+}
+
+func rebuildJobLookupEntries(tx *bolt.Tx) error {
+	for _, bucket := range indexedLookupBuckets() {
+		b := tx.Bucket(bucket)
+		if b == nil {
+			continue
+		}
+
+		err := b.ForEach(func(k, _ []byte) error {
+			return putReverseLookupEntry(tx, bucket, k)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func indexedLookupBuckets() [][]byte {
+	return [][]byte{bucketRTK, bucketDTK, bucketRDTK}
+}
+
+func lookupEntryJobKey(lookupKey []byte) []byte {
+	idx := bytes.LastIndex(lookupKey, []byte(dbDelimiter))
+	if idx == -1 {
+		return nil
+	}
+
+	jobKeyStart := idx + len(dbDelimiter)
+	if jobKeyStart >= len(lookupKey) {
+		return nil
+	}
+
+	return lookupKey[jobKeyStart:]
+}
+
+func reverseLookupEntryKey(jobKey, lookupBucket, lookupKey []byte) []byte {
+	key := reverseLookupEntryPrefix(jobKey)
+	key = append(key, lookupBucket...)
+	key = append(key, dbDelimiter...)
+	key = append(key, lookupKey...)
+
+	return key
+}
+
+func reverseLookupEntryPrefix(jobKey []byte) []byte {
+	prefix := make([]byte, 0, len(jobKey)+len(dbDelimiter))
+	prefix = append(prefix, jobKey...)
+	prefix = append(prefix, dbDelimiter...)
+
+	return prefix
 }
 
 // stripBucketFromS3Path removes the first directory from the given path. If

--- a/jobqueue/db_test.go
+++ b/jobqueue/db_test.go
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/internal"
+	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+	bolt "go.etcd.io/bbolt"
+)
+
+func TestDBReverseLookupIndex(t *testing.T) {
+	Convey("Opening an old DB rebuilds reverse lookup entries used by modify", t, func() {
+		ctx := context.Background()
+		tmpdir := t.TempDir()
+		dbFile := filepath.Join(tmpdir, "queue.db")
+		dbBackup := filepath.Join(tmpdir, "queue.db.bak")
+
+		testDB, _, err := initDB(ctx, dbFile, dbBackup, internal.Development, false, false)
+		So(err, ShouldBeNil)
+
+		parent := testDBJob("echo parent", "old-parent")
+		parent.DepGroups = []string{"old-parent-dg"}
+
+		child := testDBJob("echo child", "old-child")
+		child.Dependencies = Dependencies{NewDepGroupDependency("old-parent-dg")}
+
+		_, _, _, err = testDB.storeNewJobs(ctx, []*Job{parent, child}, false)
+		So(err, ShouldBeNil)
+
+		parentOldKey := parent.Key()
+		childOldKey := child.Key()
+
+		var (
+			parentLookups int
+			childLookups  int
+		)
+
+		err = testDB.bolt.View(func(tx *bolt.Tx) error {
+			parentLookups = countLookupEntriesByJobKey(tx, parentOldKey)
+			childLookups = countLookupEntriesByJobKey(tx, childOldKey)
+
+			return nil
+		})
+		So(err, ShouldBeNil)
+		So(parentLookups, ShouldEqual, 2)
+		So(childLookups, ShouldEqual, 2)
+
+		err = testDB.bolt.Update(func(tx *bolt.Tx) error {
+			return tx.DeleteBucket(bucketJobLookupEntries)
+		})
+		So(err, ShouldBeNil)
+		So(testDB.close(ctx), ShouldBeNil)
+
+		testDB, _, err = initDB(ctx, dbFile, dbBackup, internal.Development, false, false)
+
+		So(err, ShouldBeNil)
+		defer func() {
+			So(testDB.close(ctx), ShouldBeNil)
+		}()
+
+		err = testDB.bolt.View(func(tx *bolt.Tx) error {
+			So(tx.Bucket(bucketJobLookupEntries), ShouldNotBeNil)
+			So(countReverseLookupEntriesByJobKey(tx, parentOldKey), ShouldEqual, parentLookups)
+			So(countReverseLookupEntriesByJobKey(tx, childOldKey), ShouldEqual, childLookups)
+
+			return nil
+		})
+		So(err, ShouldBeNil)
+
+		modifiedParent := testDBJob("echo parent modified", "new-parent")
+		modifiedParent.DepGroups = []string{"new-parent-dg"}
+		newParentKey := modifiedParent.Key()
+
+		err = testDB.modifyLiveJobs(ctx, []string{parentOldKey}, []*Job{modifiedParent})
+		So(err, ShouldBeNil)
+
+		oldDepKeys, err := testDB.retrieveIncompleteJobKeysByDepGroup("old-parent-dg")
+		So(err, ShouldBeNil)
+		So(oldDepKeys, ShouldHaveLength, 0)
+
+		newDepKeys, err := testDB.retrieveIncompleteJobKeysByDepGroup("new-parent-dg")
+		So(err, ShouldBeNil)
+		So(newDepKeys, ShouldContain, newParentKey)
+
+		err = testDB.bolt.View(func(tx *bolt.Tx) error {
+			So(countLookupEntriesByJobKey(tx, parentOldKey), ShouldEqual, 0)
+			So(countReverseLookupEntriesByJobKey(tx, parentOldKey), ShouldEqual, 0)
+			So(countLookupEntriesByJobKey(tx, newParentKey), ShouldEqual, 2)
+			So(countReverseLookupEntriesByJobKey(tx, newParentKey), ShouldEqual, 2)
+
+			return nil
+		})
+		So(err, ShouldBeNil)
+	})
+}
+
+func BenchmarkModifyLiveJobsReverseLookup(b *testing.B) {
+	ctx := context.Background()
+	tmpdir := b.TempDir()
+
+	testDB, _, err := initDB(
+		ctx,
+		filepath.Join(tmpdir, "queue.db"),
+		filepath.Join(tmpdir, "queue.db.bak"),
+		internal.Development,
+		false,
+		false,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Cleanup(func() {
+		if closeErr := testDB.close(ctx); closeErr != nil {
+			b.Fatal(closeErr)
+		}
+	})
+
+	const seedJobs = 5000
+
+	jobs := make([]*Job, 0, seedJobs)
+	for i := range seedJobs {
+		job := testDBJob(fmt.Sprintf("echo seed %d", i), "seed")
+		job.DepGroups = []string{fmt.Sprintf("seed-dg-%d", i)}
+		job.Dependencies = Dependencies{NewDepGroupDependency(fmt.Sprintf("seed-parent-%d", i))}
+		jobs = append(jobs, job)
+	}
+
+	if _, _, _, err = testDB.storeNewJobs(ctx, jobs, false); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := range b.N {
+		b.StopTimer()
+
+		target := testDBJob(fmt.Sprintf("echo target %d", i), "target")
+		target.DepGroups = []string{fmt.Sprintf("target-dg-%d", i)}
+
+		target.Dependencies = Dependencies{NewDepGroupDependency(fmt.Sprintf("target-parent-%d", i))}
+		if _, _, _, err = testDB.storeNewJobs(ctx, []*Job{target}, false); err != nil {
+			b.Fatal(err)
+		}
+
+		modified := testDBJob(fmt.Sprintf("echo modified target %d", i), "target")
+		modified.DepGroups = []string{fmt.Sprintf("modified-target-dg-%d", i)}
+		modified.Dependencies = Dependencies{NewDepGroupDependency(fmt.Sprintf("modified-target-parent-%d", i))}
+		oldKey := target.Key()
+
+		b.StartTimer()
+
+		if err = testDB.modifyLiveJobs(ctx, []string{oldKey}, []*Job{modified}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func testDBJob(cmd, repGroup string) *Job {
+	return &Job{
+		Cmd:      cmd,
+		Cwd:      testCwd,
+		ReqGroup: "db_test",
+		Requirements: &jqs.Requirements{
+			RAM:   10,
+			Time:  time.Second,
+			Cores: 1,
+		},
+		RepGroup: repGroup,
+	}
+}
+
+func countLookupEntriesByJobKey(tx *bolt.Tx, jobKey string) int {
+	suffix := []byte(dbDelimiter + jobKey)
+	count := 0
+
+	for _, bucket := range indexedLookupBuckets() {
+		b := tx.Bucket(bucket)
+		if b == nil {
+			continue
+		}
+
+		err := b.ForEach(func(k, _ []byte) error {
+			if bytes.HasSuffix(k, suffix) {
+				count++
+			}
+
+			return nil
+		})
+		if err != nil {
+			continue
+		}
+	}
+
+	return count
+}
+
+func countReverseLookupEntriesByJobKey(tx *bolt.Tx, jobKey string) int {
+	b := tx.Bucket(bucketJobLookupEntries)
+	if b == nil {
+		return 0
+	}
+
+	prefix := reverseLookupEntryPrefix([]byte(jobKey))
+	count := 0
+
+	c := b.Cursor()
+	for k, _ := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+		count++
+	}
+
+	return count
+}


### PR DESCRIPTION
## Summary
- add a reverse lookup index so modifying live jobs can delete lookup bucket entries without scanning whole buckets per job
- maintain the index on add, modify, delete, and queue recovery paths
- add regression/benchmark coverage for reverse lookup cleanup

Solves #333

## Tests
- go test -tags netgo --count 1 ./jobqueue -run "Test(ModifyLiveJobsUsesReverseLookup|DB)" -v
- make lint
- make test