### PR TITLE
Add web UI rerun action for completed jobs

### DIFF
--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -38,6 +38,7 @@ import (
 	"github.com/VertebrateResequencing/wr/clog"
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/queue"
+	"github.com/gofrs/uuid/v5"
 	"github.com/gorilla/websocket"
 )
 
@@ -46,6 +47,7 @@ var staticFS embed.FS
 
 const (
 	jstatusRequestDetails     = "details"
+	jstatusRequestRerun       = "rerun"
 	jstatusRequestUnsubscribe = requestMethodUnsubscribe
 )
 
@@ -56,6 +58,7 @@ type jstatusReq struct {
 	//           queue.
 	// details = get example job details for jobs in the RepGroup, grouped by
 	//           having the same Status, Exitcode and FailReason.
+	// rerun = add completed jobs to the queue again, using Key or RepGroup.
 	// retry = retry buried jobs.
 	// remove = remove non-running jobs.
 	// kill = kill running jobs or confirm lost jobs are dead.
@@ -82,6 +85,48 @@ type jstatusReq struct {
 	FailReason string
 	ServerID   string // required argument for confirmBadServer
 	Msg        string // required argument for dismissMsg
+}
+
+// reqToCompletedJobs takes a rerun request from the status webpage and returns
+// completed jobs that are not already live in the queue.
+func (s *Server) reqToCompletedJobs(req jstatusReq) ([]*Job, string, string) {
+	if req.Key != "" {
+		return s.completedJobByKey(req.Key)
+	}
+
+	return s.completedJobsByRepGroup(req)
+}
+
+func (s *Server) completedJobsByRepGroup(req jstatusReq) ([]*Job, string, string) {
+	if req.RepGroup == "" || (req.State != "" && req.State != JobStateComplete) {
+		return nil, "", ""
+	}
+
+	complete, srerr, qerr := s.getCompleteJobsByRepGroup(req.RepGroup)
+	if srerr != "" {
+		return nil, srerr, qerr
+	}
+
+	jobs := make([]*Job, 0, len(complete))
+	for _, job := range complete {
+		if !completedJobMatchesRerunRequest(job, req) {
+			continue
+		}
+
+		job.Lock()
+		job.RepGroup = req.RepGroup
+		job.Unlock()
+		jobs = append(jobs, job)
+	}
+
+	return jobs, "", ""
+}
+
+func completedJobMatchesRerunRequest(job *Job, req jstatusReq) bool {
+	job.RLock()
+	defer job.RUnlock()
+
+	return job.Exitcode == req.Exitcode && job.FailReason == req.FailReason
 }
 
 // JStatus is the job info we send to the status webpage (only real difference
@@ -448,6 +493,15 @@ func webInterfaceStatusWS(ctx context.Context, s *Server) http.HandlerFunc {
 					case "retry":
 						jobs := s.reqToJobs(req, []queue.ItemState{queue.ItemStateBury})
 						s.kickJobs(ctx, jobs)
+					case jstatusRequestRerun:
+						jobs, srerr, qerr := s.reqToCompletedJobs(req)
+						if srerr != "" {
+							clog.Warn(ctx, "web interface rerun lookup failed", "err", qerr)
+
+							break
+						}
+
+						s.rerunCompletedJobs(ctx, jobs)
 					case "remove":
 						jobs := s.reqToJobs(req, []queue.ItemState{queue.ItemStateBury, queue.ItemStateDelay, queue.ItemStateDependent, queue.ItemStateReady})
 						deleted := s.deleteJobs(ctx, jobs)
@@ -524,6 +578,64 @@ func statusSubscriptionStopped(stop <-chan bool) bool {
 	default:
 		return false
 	}
+}
+
+func resetCompletedJobForRerun(job *Job) {
+	job.Lock()
+	defer job.Unlock()
+
+	resetJobExecutionFields(job)
+	resetJobStatusFields(job)
+}
+
+func resetJobExecutionFields(job *Job) {
+	job.ActualCwd = ""
+	job.PeakRAM = 0
+	job.PeakDisk = 0
+	job.Exited = false
+	job.Exitcode = 0
+	job.Lost = false
+	job.FailReason = ""
+	job.Pid = 0
+	job.Host = ""
+	job.HostID = ""
+	job.HostIP = ""
+	job.StartTime = time.Time{}
+	job.EndTime = time.Time{}
+	job.CPUtime = 0
+	job.StdErrC = nil
+	job.StdOutC = nil
+}
+
+func resetJobStatusFields(job *Job) {
+	job.EnvC = nil
+	job.EnvCRetrieved = false
+	job.State = JobStateReady
+	job.Attempts = 0
+	job.UntilBuried = job.Retries + 1
+	job.ReservedBy = uuid.UUID{}
+	job.Similar = 0
+	job.DelayTime = 0
+	job.killCalled = false
+	job.incrementedLimitGroups = nil
+}
+
+func (s *Server) completedJobByKey(key string) ([]*Job, string, string) {
+	live, err := s.db.checkIfLive(key)
+	if err != nil {
+		return nil, ErrDBError, err.Error()
+	}
+
+	if live {
+		return nil, "", ""
+	}
+
+	jobs, err := s.db.retrieveCompleteJobsByKeys([]string{key})
+	if err != nil {
+		return nil, ErrDBError, err.Error()
+	}
+
+	return jobs, "", ""
 }
 
 // setupUpdateListener creates a goroutine that listens for updates from a
@@ -632,6 +744,30 @@ func webInterfaceStatusSendGroupStateCount(conn *websocket.Conn, repGroup string
 		}
 	}
 	return nil
+}
+
+func (s *Server) rerunCompletedJobs(ctx context.Context, jobs []*Job) {
+	jobsByEnvKey := make(map[string][]*Job)
+
+	for _, job := range jobs {
+		job.RLock()
+		envkey := job.EnvKey
+		job.RUnlock()
+
+		resetCompletedJobForRerun(job)
+		jobsByEnvKey[envkey] = append(jobsByEnvKey[envkey], job)
+	}
+
+	for envkey, envJobs := range jobsByEnvKey {
+		added, dups, _, srerr, err := s.createJobs(ctx, envJobs, envkey, false)
+		if err != nil {
+			clog.Warn(ctx, "web interface rerun failed", "err", err, "srerr", srerr)
+
+			continue
+		}
+
+		clog.Debug(ctx, "reran completed jobs", "new", added, "dups", dups)
+	}
 }
 
 func (s *Server) setupStatusSubscriptionUpdateListener(ctx context.Context, conn *websocket.Conn, stop chan bool,

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -46,6 +46,7 @@ import (
 var staticFS embed.FS
 
 const (
+	jstatusRequestCurrent     = "current"
 	jstatusRequestDetails     = "details"
 	jstatusRequestRerun       = "rerun"
 	jstatusRequestUnsubscribe = requestMethodUnsubscribe
@@ -91,7 +92,7 @@ type jstatusReq struct {
 // completed jobs that are not already live in the queue.
 func (s *Server) reqToCompletedJobs(req jstatusReq) ([]*Job, string, string) {
 	if req.Key != "" {
-		return s.completedJobByKey(req.Key)
+		return s.completedJobByKey(req)
 	}
 
 	return s.completedJobsByRepGroup(req)
@@ -379,7 +380,7 @@ func webInterfaceStatusWS(ctx context.Context, s *Server) http.HandlerFunc {
 				switch {
 				case req.Request != "":
 					switch req.Request {
-					case "current":
+					case jstatusRequestCurrent:
 						// get all current jobs
 						jobs := s.getJobsCurrent(ctx, "", RepGroupMatchExact, 0, "", false, false)
 						writeMutex.Lock()
@@ -620,8 +621,8 @@ func resetJobStatusFields(job *Job) {
 	job.incrementedLimitGroups = nil
 }
 
-func (s *Server) completedJobByKey(key string) ([]*Job, string, string) {
-	live, err := s.db.checkIfLive(key)
+func (s *Server) completedJobByKey(req jstatusReq) ([]*Job, string, string) {
+	live, err := s.db.checkIfLive(req.Key)
 	if err != nil {
 		return nil, ErrDBError, err.Error()
 	}
@@ -630,9 +631,17 @@ func (s *Server) completedJobByKey(key string) ([]*Job, string, string) {
 		return nil, "", ""
 	}
 
-	jobs, err := s.db.retrieveCompleteJobsByKeys([]string{key})
+	jobs, err := s.db.retrieveCompleteJobsByKeys([]string{req.Key})
 	if err != nil {
 		return nil, ErrDBError, err.Error()
+	}
+
+	if req.RepGroup != "" {
+		for _, job := range jobs {
+			job.Lock()
+			job.RepGroup = req.RepGroup
+			job.Unlock()
+		}
 	}
 
 	return jobs, "", ""

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -587,6 +587,42 @@ func TestServerWebI(t *testing.T) {
 				So(kickedJobs[0].Cmd, ShouldEqual, "echo 4 && false")
 			})
 
+			Convey("The websocket handler can rerun completed jobs", func() {
+				completeJobs, errg := jq.GetByRepGroup("rg1", false, 0, JobStateComplete, false, false)
+				So(errg, ShouldBeNil)
+				So(len(completeJobs), ShouldEqual, 1)
+				So(completeJobs[0].Cmd, ShouldEqual, "echo 2")
+				So(completeJobs[0].Exited, ShouldBeTrue)
+				So(completeJobs[0].Attempts, ShouldEqual, 1)
+
+				err = ws.WriteJSON(jstatusReq{
+					Request: "rerun",
+					Key:     completeJobs[0].Key(),
+				})
+				So(err, ShouldBeNil)
+
+				So(pollUntil(func() bool {
+					rerunJobs, errr := jq.GetByRepGroup("rg1", false, 0, JobStateReady, false, false)
+					if errr != nil || len(rerunJobs) != 1 {
+						return false
+					}
+
+					return rerunJobs[0].Cmd == "echo 2"
+				}), ShouldBeTrue)
+
+				rerunJobs, errg := jq.GetByRepGroup("rg1", false, 0, JobStateReady, false, false)
+				So(errg, ShouldBeNil)
+				So(len(rerunJobs), ShouldEqual, 1)
+				So(rerunJobs[0].Key(), ShouldEqual, completeJobs[0].Key())
+				So(rerunJobs[0].Exited, ShouldBeFalse)
+				So(rerunJobs[0].Attempts, ShouldEqual, 0)
+				So(rerunJobs[0].StartTime.IsZero(), ShouldBeTrue)
+				So(rerunJobs[0].EndTime.IsZero(), ShouldBeTrue)
+				So(rerunJobs[0].PeakRAM, ShouldEqual, 0)
+				So(rerunJobs[0].PeakDisk, ShouldEqual, 0)
+				So(rerunJobs[0].FailReason, ShouldBeBlank)
+			})
+
 			Convey("The websocket handler can remove jobs", func() {
 				var removeJobs []*Job
 				removeJobs = append(removeJobs, &Job{Cmd: "echo remove", Cwd: "/tmp",

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -207,8 +207,33 @@ func TestServerWebI(t *testing.T) {
 
 			defer ws.Close()
 
+			executeReservedJobs := func(expectedCmds ...string) {
+				expected := make(map[string]bool, len(expectedCmds))
+				for _, cmd := range expectedCmds {
+					expected[cmd] = true
+				}
+
+				for range expectedCmds {
+					job, errr := jq.Reserve(50 * time.Millisecond)
+					So(errr, ShouldBeNil)
+					So(job, ShouldNotBeNil)
+
+					if job == nil {
+						return
+					}
+
+					So(expected, ShouldContainKey, job.Cmd)
+					delete(expected, job.Cmd)
+
+					errr = jq.Execute(ctx, job, config.RunnerExecShell)
+					So(errr, ShouldBeNil)
+				}
+
+				So(len(expected), ShouldEqual, 0)
+			}
+
 			Convey("The websocket handler responds to current requests", func() {
-				err = ws.WriteJSON(jstatusReq{Request: "current"})
+				err = ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				receivedJobs := make(map[string]bool)
@@ -596,8 +621,9 @@ func TestServerWebI(t *testing.T) {
 				So(completeJobs[0].Attempts, ShouldEqual, 1)
 
 				err = ws.WriteJSON(jstatusReq{
-					Request: "rerun",
-					Key:     completeJobs[0].Key(),
+					Request:  jstatusRequestRerun,
+					Key:      completeJobs[0].Key(),
+					RepGroup: completeJobs[0].RepGroup,
 				})
 				So(err, ShouldBeNil)
 
@@ -623,10 +649,142 @@ func TestServerWebI(t *testing.T) {
 				So(rerunJobs[0].FailReason, ShouldBeBlank)
 			})
 
+			Convey("The websocket handler can rerun completed jobs by key in the requested RepGroup", func() {
+				firstGroup := "rerun_key_rg1"
+				secondGroup := "rerun_key_rg2"
+				cmd := "echo webi rerun duplicate key"
+
+				inserts, already, erra := jq.Add([]*Job{{
+					Cmd:          cmd,
+					Cwd:          "/tmp",
+					ReqGroup:     "rerun_key_group",
+					Requirements: standardReqs,
+					RepGroup:     firstGroup,
+				}}, envVars, true)
+				So(erra, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
+
+				executeReservedJobs(cmd)
+
+				inserts, already, erra = jq.Add([]*Job{{
+					Cmd:          cmd,
+					Cwd:          "/tmp",
+					ReqGroup:     "rerun_key_group",
+					Requirements: standardReqs,
+					RepGroup:     secondGroup,
+				}}, envVars, false)
+				So(erra, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
+
+				executeReservedJobs(cmd)
+
+				firstGroupJobs, errg := jq.GetByRepGroup(firstGroup, false, 0, JobStateComplete, false, false)
+				So(errg, ShouldBeNil)
+				So(len(firstGroupJobs), ShouldEqual, 1)
+				So(firstGroupJobs[0].RepGroup, ShouldEqual, firstGroup)
+
+				err = ws.WriteJSON(jstatusReq{
+					Request:  jstatusRequestRerun,
+					Key:      firstGroupJobs[0].Key(),
+					RepGroup: firstGroupJobs[0].RepGroup,
+				})
+				So(err, ShouldBeNil)
+
+				So(pollUntil(func() bool {
+					rerunJobs, errr := jq.GetByRepGroup(firstGroup, false, 0, JobStateReady, false, false)
+					if errr != nil || len(rerunJobs) != 1 {
+						return false
+					}
+
+					return rerunJobs[0].Cmd == cmd
+				}), ShouldBeTrue)
+
+				firstGroupReady, errg := jq.GetByRepGroup(firstGroup, false, 0, JobStateReady, false, false)
+				So(errg, ShouldBeNil)
+				So(len(firstGroupReady), ShouldEqual, 1)
+				So(firstGroupReady[0].RepGroup, ShouldEqual, firstGroup)
+
+				secondGroupReady, errg := jq.GetByRepGroup(secondGroup, false, 0, JobStateReady, false, false)
+				So(errg, ShouldBeNil)
+				So(len(secondGroupReady), ShouldEqual, 0)
+			})
+
+			Convey("The websocket handler can rerun all matching completed jobs", func() {
+				repGroup := "rerun_all_rg"
+				otherRepGroup := "rerun_all_other_rg"
+				reqGroup := "rerun_all_group"
+				jobsToRerun := []*Job{
+					{Cmd: "echo webi rerun all 1", Cwd: "/tmp", ReqGroup: reqGroup,
+						Requirements: standardReqs, RepGroup: repGroup},
+					{Cmd: "echo webi rerun all 2", Cwd: "/tmp", ReqGroup: reqGroup,
+						Requirements: standardReqs, RepGroup: repGroup},
+					{Cmd: "echo webi rerun all other", Cwd: "/tmp", ReqGroup: reqGroup,
+						Requirements: standardReqs, RepGroup: otherRepGroup},
+				}
+
+				inserts, already, erra := jq.Add(jobsToRerun, envVars, true)
+				So(erra, ShouldBeNil)
+				So(inserts, ShouldEqual, 3)
+				So(already, ShouldEqual, 0)
+
+				executeReservedJobs(
+					"echo webi rerun all 1",
+					"echo webi rerun all 2",
+					"echo webi rerun all other",
+				)
+
+				completeJobs, errg := jq.GetByRepGroup(repGroup, false, 0, JobStateComplete, false, false)
+				So(errg, ShouldBeNil)
+				So(len(completeJobs), ShouldEqual, 2)
+				So(completeJobs[0].Exited, ShouldBeTrue)
+				So(completeJobs[0].Attempts, ShouldEqual, 1)
+
+				err = ws.WriteJSON(jstatusReq{
+					Request:    jstatusRequestRerun,
+					RepGroup:   repGroup,
+					State:      JobStateComplete,
+					Exitcode:   completeJobs[0].Exitcode,
+					FailReason: completeJobs[0].FailReason,
+				})
+				So(err, ShouldBeNil)
+
+				So(pollUntil(func() bool {
+					rerunJobs, errr := jq.GetByRepGroup(repGroup, false, 0, JobStateReady, false, false)
+
+					return errr == nil && len(rerunJobs) == 2
+				}), ShouldBeTrue)
+
+				rerunJobs, errg := jq.GetByRepGroup(repGroup, false, 0, JobStateReady, false, false)
+				So(errg, ShouldBeNil)
+				So(len(rerunJobs), ShouldEqual, 2)
+
+				rerunKeys := make(map[string]bool, len(rerunJobs))
+				for _, job := range rerunJobs {
+					rerunKeys[job.Key()] = true
+					So(job.RepGroup, ShouldEqual, repGroup)
+					So(job.Exited, ShouldBeFalse)
+					So(job.Attempts, ShouldEqual, 0)
+					So(job.StartTime.IsZero(), ShouldBeTrue)
+					So(job.EndTime.IsZero(), ShouldBeTrue)
+					So(job.PeakRAM, ShouldEqual, 0)
+					So(job.PeakDisk, ShouldEqual, 0)
+					So(job.FailReason, ShouldBeBlank)
+				}
+
+				for _, job := range completeJobs {
+					So(rerunKeys, ShouldContainKey, job.Key())
+				}
+
+				otherReady, errg := jq.GetByRepGroup(otherRepGroup, false, 0, JobStateReady, false, false)
+				So(errg, ShouldBeNil)
+				So(len(otherReady), ShouldEqual, 0)
+			})
+
 			Convey("The websocket handler can remove jobs", func() {
-				var removeJobs []*Job
-				removeJobs = append(removeJobs, &Job{Cmd: "echo remove", Cwd: "/tmp",
-					ReqGroup: "group3", Requirements: standardReqs, RepGroup: "rg3"})
+				removeJobs := []*Job{{Cmd: "echo remove", Cwd: "/tmp",
+					ReqGroup: "group3", Requirements: standardReqs, RepGroup: "rg3"}}
 				inserts, _, erra := jq.Add(removeJobs, envVars, true)
 				So(erra, ShouldBeNil)
 				So(inserts, ShouldEqual, 1)
@@ -664,11 +822,11 @@ func TestServerWebI(t *testing.T) {
 				So(erra, ShouldBeNil)
 				So(inserts, ShouldEqual, 1)
 
-				err = ws.WriteJSON(jstatusReq{Request: "current"})
+				err = ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
-				err = ws2.WriteJSON(jstatusReq{Request: "current"})
+				err = ws2.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
-				err = ws3.WriteJSON(jstatusReq{Request: "current"})
+				err = ws3.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				var wg sync.WaitGroup
@@ -731,7 +889,7 @@ func TestServerWebI(t *testing.T) {
 
 				ws2.Close()
 
-				err = ws.WriteJSON(jstatusReq{Request: "current"})
+				err = ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				var sc jstateCount
@@ -739,7 +897,7 @@ func TestServerWebI(t *testing.T) {
 				err = ws.ReadJSON(&sc)
 				So(err, ShouldBeNil)
 
-				err = ws3.WriteJSON(jstatusReq{Request: "current"})
+				err = ws3.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				err = ws3.ReadJSON(&sc)
@@ -762,7 +920,7 @@ func TestServerWebI(t *testing.T) {
 
 				server.schedCaster.Send(si)
 
-				err = ws.WriteJSON(jstatusReq{Request: "current"})
+				err = ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				foundMessage := false
@@ -786,7 +944,7 @@ func TestServerWebI(t *testing.T) {
 						case <-resendStop:
 							return
 						case <-ticker.C:
-							if werr := ws.WriteJSON(jstatusReq{Request: "current"}); werr != nil {
+							if werr := ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent}); werr != nil {
 								return
 							}
 						}
@@ -880,7 +1038,7 @@ func TestServerWebI(t *testing.T) {
 
 				<-time.After(100 * time.Millisecond)
 
-				err = ws.WriteJSON(jstatusReq{Request: "current"})
+				err = ws.WriteJSON(jstatusReq{Request: jstatusRequestCurrent})
 				So(err, ShouldBeNil)
 
 				foundBadServer := false
@@ -1182,7 +1340,7 @@ func TestJobSubscriptions(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			err = ws3.WriteJSON(jstatusReq{
-				Request: "current",
+				Request: jstatusRequestCurrent,
 			})
 			So(err, ShouldBeNil)
 

--- a/jobqueue/static/js/wr/action-handlers.js
+++ b/jobqueue/static/js/wr/action-handlers.js
@@ -40,6 +40,12 @@ export const actionHandlers = {
         viewModel.actionModalVisible(true);
     },
 
+    confirmRerun: function (viewModel, job) {
+        jobToActionDetails(viewModel, job, 'rerun', 'rerun');
+        viewModel.actionModalHeader('Rerun Completed Commands');
+        viewModel.actionModalVisible(true);
+    },
+
     confirmRemoveFail: function (viewModel, job) {
         jobToActionDetails(viewModel, job, 'remove', 'remove');
         viewModel.actionModalHeader('Remove Failed Commands');

--- a/jobqueue/static/js/wr/modal-handlers.js
+++ b/jobqueue/static/js/wr/modal-handlers.js
@@ -44,10 +44,16 @@ export function commitAction(viewModel, all) {
             FailReason: viewModel.actionDetails.failReason(),
         }));
     } else {
-        viewModel.ws.send(JSON.stringify({
+        const request = {
             Request: viewModel.actionDetails.action(),
             Key: viewModel.actionDetails.key(),
-        }));
+        };
+
+        if (viewModel.actionDetails.action() === 'rerun') {
+            request.RepGroup = viewModel.actionDetails.repGroup();
+        }
+
+        viewModel.ws.send(JSON.stringify(request));
     }
 
     // Reset the UI

--- a/jobqueue/static/js/wr/status-viewmodel.js
+++ b/jobqueue/static/js/wr/status-viewmodel.js
@@ -643,6 +643,10 @@ export function StatusViewModel() {
         actionHandlers.confirmRetry(self, job);
     };
 
+    self.confirmRerun = function (job) {
+        actionHandlers.confirmRerun(self, job);
+    };
+
     self.confirmRemoveFail = function (job) {
         actionHandlers.confirmRemoveFail(self, job);
     };

--- a/jobqueue/static/status.html
+++ b/jobqueue/static/status.html
@@ -783,6 +783,10 @@
                                     data-bind="click: $root.confirmRetry">Retry</button>
                             </div>
                             <!-- /ko -->
+                            <!-- ko if: State == "complete" -->
+                            <button type="button" class="btn btn-primary pull-right"
+                                data-bind="click: $root.confirmRerun">Rerun</button>
+                            <!-- /ko -->
                         </div>
                     </div>
                     <!-- /ko -->
@@ -804,8 +808,8 @@
                 Are you sure you want to <span data-bind="text: action"></span> the <span data-bind="text: count"></span>
         commands with the identifier "<span data-bind="text: repGroup"></span>"
         <!-- ko if: exited -->
-        that had exit code <span data-bind="text: exitCode"></span> and failed because "<span
-            data-bind="text: failReason"></span>"?
+        that had exit code <span data-bind="text: exitCode"></span><!-- ko if: failReason --> and failed because "<span
+            data-bind="text: failReason"></span>"<!-- /ko -->?
         <!-- /ko -->
         <!-- ko if: ! exited -->
         ?


### PR DESCRIPTION
## Summary
- add a rerun action for completed jobs in the web status UI
- reuse the existing add+rerun path instead of adding a separate rerun endpoint
- add confirmation and browser-facing coverage for the action

Solves #20

## Tests
- go test -tags netgo --count 1 ./jobqueue -run "Test(ServerWebI|REST)" -v
- node --check jobqueue/static/js/wr/job-details.js
- make lint
- make test