### PR TITLE
Fix rerun of completed dependent jobs

### DIFF
--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/VertebrateResequencing/wr/cloud"
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/phayes/freeport"
 	"github.com/shirou/gopsutil/v4/process"
 	. "github.com/smartystreets/goconvey/convey"
@@ -2379,6 +2380,147 @@ func TestRerunDependentJobWaitsOnIncompleteDependencies(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(nextJob.Key(), ShouldEqual, explicitJobC.Key())
 		So(nextJob.RepGroup, ShouldEqual, explicitJobC.RepGroup)
+	})
+}
+
+func TestRerunReplacementReadyCallbackBlocksReserve(t *testing.T) {
+	ctx := context.Background()
+
+	if runnermode || servermode {
+		return
+	}
+
+	_, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
+
+	Convey("A rerun replacement that becomes ready blocks reserves until ReadyAdded finishes", t, func() {
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		parent := &Job{
+			Cmd:          "echo rerun replacement parent",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "rerun-replacement-parent",
+		}
+		oldJob := &Job{
+			Cmd:          "echo rerun replacement child",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "rerun-replacement-old",
+			State:        JobStateComplete,
+		}
+		newJob := &Job{
+			Cmd:          oldJob.Cmd,
+			Cwd:          oldJob.Cwd,
+			ReqGroup:     oldJob.ReqGroup,
+			Requirements: standardReqs,
+			RepGroup:     "rerun-replacement-new",
+		}
+
+		parentKey := parent.Key()
+		childKey := oldJob.Key()
+		added, dups, err := server.q.AddMany(ctx, []*queue.ItemDef{
+			{
+				Key:        parentKey,
+				Data:       parent,
+				TTR:        server.itemTTRDuration(),
+				StartQueue: queue.SubQueueBury,
+			},
+			{
+				Key:          childKey,
+				Data:         oldJob,
+				TTR:          server.itemTTRDuration(),
+				Dependencies: []string{parentKey},
+			},
+		})
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 2)
+		So(dups, ShouldEqual, 0)
+
+		server.rpl.Lock()
+		server.rpl.Add(oldJob.RepGroup, childKey)
+		server.rpl.Unlock()
+
+		callbackStarted := make(chan struct{})
+		releaseCallback := make(chan struct{})
+
+		var (
+			startOnce   sync.Once
+			releaseOnce sync.Once
+		)
+
+		release := func() {
+			releaseOnce.Do(func() {
+				close(releaseCallback)
+			})
+		}
+		defer release()
+
+		server.q.SetReadyAddedCallback(func(string, []interface{}) {
+			startOnce.Do(func() {
+				close(callbackStarted)
+			})
+			<-releaseCallback
+			server.finishRAC()
+		})
+
+		updated, err := server.replaceLiveRerunItem(ctx, &queue.ItemDef{
+			Key:  childKey,
+			Data: newJob,
+			TTR:  server.itemTTRDuration(),
+		})
+		So(err, ShouldBeNil)
+		So(updated, ShouldBeTrue)
+
+		select {
+		case <-callbackStarted:
+		case <-time.After(time.Second):
+			So("timed out waiting for ReadyAdded callback", ShouldBeBlank)
+
+			return
+		}
+
+		type reserveResult struct {
+			job *Job
+			err error
+		}
+
+		reserved := make(chan reserveResult, 1)
+
+		go func() {
+			job, reserveErr := jq.Reserve(2 * time.Second)
+			reserved <- reserveResult{job: job, err: reserveErr}
+		}()
+
+		select {
+		case <-reserved:
+			So("reserve returned before ReadyAdded callback completed", ShouldBeBlank)
+			release()
+
+			return
+		case <-time.After(150 * time.Millisecond):
+		}
+
+		release()
+
+		select {
+		case result := <-reserved:
+			So(result.err, ShouldBeNil)
+			So(result.job, ShouldNotBeNil)
+			So(result.job.Key(), ShouldEqual, childKey)
+			So(result.job.RepGroup, ShouldEqual, newJob.RepGroup)
+		case <-time.After(2 * time.Second):
+			So("timed out waiting for reserve after ReadyAdded callback completed", ShouldBeBlank)
+		}
 	})
 }
 

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2250,6 +2250,138 @@ func TestJobqueueBasics(t *testing.T) {
 	}
 }
 
+func TestRerunDependentJobWaitsOnIncompleteDependencies(t *testing.T) {
+	ctx := context.Background()
+
+	if runnermode || servermode {
+		return
+	}
+
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
+
+	Convey("A rerun of a completed dependent job waits on an incomplete rerun dependency", t, func() {
+		const (
+			issue326A = "issue326-a"
+			issue326B = "issue326-b"
+		)
+
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		jobA := &Job{
+			Cmd:          "echo issue326 a",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     issue326A,
+			DepGroups:    []string{issue326A},
+		}
+		jobB := &Job{
+			Cmd:          "echo issue326 b",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     issue326B,
+			DepGroups:    []string{issue326A, issue326B},
+		}
+		jobC := &Job{
+			Cmd:          "echo issue326 c",
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "issue326-c",
+			Dependencies: Dependencies{
+				NewDepGroupDependency(issue326A),
+				NewDepGroupDependency(issue326B),
+			},
+		}
+		explicitJobC := &Job{
+			Cmd:          jobC.Cmd,
+			Cwd:          testCwd,
+			ReqGroup:     reqGroupFake,
+			Requirements: standardReqs,
+			RepGroup:     "issue326-c-explicit",
+			Priority:     10,
+			Dependencies: Dependencies{
+				NewDepGroupDependency(issue326A),
+				NewDepGroupDependency(issue326B),
+			},
+		}
+
+		added, existed, err := jq.Add([]*Job{jobA}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		added, existed, err = jq.Add([]*Job{jobB}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		added, existed, err = jq.Add([]*Job{jobC}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		firstRunA, err := jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(firstRunA.Key(), ShouldEqual, jobA.Key())
+		So(jq.Execute(ctx, firstRunA, config.RunnerExecShell), ShouldBeNil)
+
+		firstRunB, err := jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(firstRunB.Key(), ShouldEqual, jobB.Key())
+		So(jq.Execute(ctx, firstRunB, config.RunnerExecShell), ShouldBeNil)
+
+		firstRunC, err := jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(firstRunC.Key(), ShouldEqual, jobC.Key())
+		So(jq.Execute(ctx, firstRunC, config.RunnerExecShell), ShouldBeNil)
+
+		added, existed, err = jq.Add([]*Job{jobA}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldBeGreaterThanOrEqualTo, 1)
+		So(existed, ShouldEqual, 0)
+
+		added, existed, err = jq.Add([]*Job{jobB}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		added, existed, err = jq.Add([]*Job{explicitJobC}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		gottenJobs, err := jq.GetByRepGroup(explicitJobC.RepGroup, false, 0, "", false, false)
+		So(err, ShouldBeNil)
+		So(gottenJobs, ShouldHaveLength, 1)
+		So(gottenJobs[0].State, ShouldEqual, JobStateDependent)
+
+		nextJob, err := jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(nextJob.Key(), ShouldEqual, jobA.Key())
+		So(jq.Execute(ctx, nextJob, config.RunnerExecShell), ShouldBeNil)
+
+		nextJob, err = jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(nextJob.Key(), ShouldEqual, jobB.Key())
+		So(jq.Execute(ctx, nextJob, config.RunnerExecShell), ShouldBeNil)
+
+		nextJob, err = jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(nextJob.Key(), ShouldEqual, explicitJobC.Key())
+		So(nextJob.RepGroup, ShouldEqual, explicitJobC.RepGroup)
+	})
+}
+
 func TestJobqueueMedium(t *testing.T) {
 	ctx := context.Background()
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -953,7 +953,7 @@ func (s *Server) replaceLiveRerunItem(ctx context.Context, itemdef *queue.ItemDe
 		return false, nil
 	}
 
-	if err = s.updateLiveRerunItem(ctx, itemdef); err != nil {
+	if err = s.updateLiveRerunItemWithReadyPending(ctx, item, itemdef); err != nil {
 		return false, err
 	}
 
@@ -994,14 +994,40 @@ func (s *Server) updateLiveRerunItem(ctx context.Context, itemdef *queue.ItemDef
 	)
 }
 
+func (s *Server) updateLiveRerunItemWithReadyPending(
+	ctx context.Context,
+	item *queue.Item,
+	itemdef *queue.ItemDef,
+) error {
+	readyCallbackExpected := itemDefTriggersReadyAdded(itemdef) &&
+		itemWillBecomeReadyAfterDependencyUpdate(item, nil)
+	if readyCallbackExpected {
+		s.setRACPending()
+	}
+
+	err := s.updateLiveRerunItem(ctx, itemdef)
+	if err != nil && readyCallbackExpected {
+		s.clearRACPending()
+	}
+
+	return err
+}
+
 func (s *Server) rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, key string) {
+	repGroupChanged := oldRepGroup != newRepGroup
+
 	s.rpl.Lock()
-	if oldRepGroup != newRepGroup {
+	if repGroupChanged {
 		s.rpl.Delete(oldRepGroup, key)
 	}
 
 	s.rpl.Add(newRepGroup, key)
 	s.rpl.Unlock()
+
+	if repGroupChanged {
+		s.removeRepGroupSubscriptionKey(oldRepGroup, key)
+	}
+
 	s.rememberRepGroupSubscriptionKey(newRepGroup, key)
 }
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -901,6 +901,110 @@ func queueItemStatusState(itemState queue.ItemState, lost bool) JobState {
 	return JobStateRunning
 }
 
+func (s *Server) replaceLiveRerunItems(
+	ctx context.Context,
+	itemdefs []*queue.ItemDef,
+	ignoreComplete bool,
+) ([]*queue.ItemDef, int, error) {
+	if ignoreComplete {
+		return itemdefs, 0, nil
+	}
+
+	var (
+		remaining []*queue.ItemDef
+		replaced  int
+	)
+
+	for _, itemdef := range itemdefs {
+		updated, err := s.replaceLiveRerunItem(ctx, itemdef)
+		if err != nil {
+			return nil, replaced, err
+		}
+
+		if updated {
+			replaced++
+
+			continue
+		}
+
+		remaining = append(remaining, itemdef)
+	}
+
+	return remaining, replaced, nil
+}
+
+func (s *Server) replaceLiveRerunItem(ctx context.Context, itemdef *queue.ItemDef) (bool, error) {
+	item, err := s.q.Get(itemdef.Key)
+	if err != nil {
+		if queueErrorIs(err, queue.ErrNotFound) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	oldRepGroup, ok := resurrectedCompleteRepGroup(item)
+	if !ok {
+		return false, nil
+	}
+
+	newJob, ok := itemdef.Data.(*Job)
+	if !ok {
+		return false, nil
+	}
+
+	if err = s.updateLiveRerunItem(ctx, itemdef); err != nil {
+		return false, err
+	}
+
+	newRepGroup := newJob.RepGroup
+	s.rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, itemdef.Key)
+
+	return true, nil
+}
+
+func queueErrorIs(err error, target error) bool {
+	var qerr queue.Error
+
+	return errors.As(err, &qerr) && errors.Is(qerr.Err, target)
+}
+
+func resurrectedCompleteRepGroup(item *queue.Item) (string, bool) {
+	job, ok := item.Data().(*Job)
+	if !ok {
+		return "", false
+	}
+
+	job.RLock()
+	defer job.RUnlock()
+
+	return job.RepGroup, job.State == JobStateComplete
+}
+
+func (s *Server) updateLiveRerunItem(ctx context.Context, itemdef *queue.ItemDef) error {
+	return s.q.Update(
+		ctx,
+		itemdef.Key,
+		itemdef.ReserveGroup,
+		itemdef.Data,
+		itemdef.Priority,
+		itemdef.Delay,
+		itemdef.TTR,
+		itemdef.Dependencies,
+	)
+}
+
+func (s *Server) rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, key string) {
+	s.rpl.Lock()
+	if oldRepGroup != newRepGroup {
+		s.rpl.Delete(oldRepGroup, key)
+	}
+
+	s.rpl.Add(newRepGroup, key)
+	s.rpl.Unlock()
+	s.rememberRepGroupSubscriptionKey(newRepGroup, key)
+}
+
 func subscriptionUpdateState(_, to JobState) (JobState, bool) {
 	switch to {
 	case JobStateDelayed, JobStateDependent, JobStateReady, JobStateReserved,
@@ -2570,11 +2674,17 @@ func (s *Server) createJobs(ctx context.Context, inputJobs []*Job, envkey string
 
 		srerr, qerr = s.updateJobDependencies(ctx, jobsToUpdate)
 
+		var replaced int
+		if qerr == nil {
+			itemdefs, replaced, qerr = s.replaceLiveRerunItems(ctx, itemdefs, ignoreComplete)
+		}
+
 		if qerr != nil {
 			srerr = ErrInternalError
 		} else {
 			// add the jobs to the in-memory job queue
 			added, dups, qerr = s.enqueueItems(ctx, itemdefs)
+			added += replaced
 			if qerr != nil {
 				srerr = ErrInternalError
 			}

--- a/jobqueue/server_subscription.go
+++ b/jobqueue/server_subscription.go
@@ -220,6 +220,23 @@ func (s *serverSubscription) rememberRepGroupKey(key string) {
 	}
 }
 
+func (s *serverSubscription) removeRepGroupKey(key string) *JobUpdate {
+	if key == "" || s.repGroup == "" {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.repGroupStates[key]; !exists {
+		return nil
+	}
+
+	delete(s.repGroupStates, key)
+
+	return s.repGroupDoneUpdate()
+}
+
 func (s *serverSubscription) recordRepGroupCatchUp(records map[string]subscriptionCatchUpRecord) *JobUpdate {
 	if s.repGroup == "" {
 		return nil
@@ -508,4 +525,28 @@ func (s *Server) rememberRepGroupSubscriptionKey(repGroup, key string) {
 			sub.rememberRepGroupKey(key)
 		}
 	}
+}
+
+func (s *Server) removeRepGroupSubscriptionKey(repGroup, key string) {
+	if repGroup == "" || key == "" {
+		return
+	}
+
+	s.csmutex.RLock()
+
+	deliveries := make([]repGroupSubscriptionUpdate, 0, len(s.clientSubscriptions))
+	for _, sub := range s.clientSubscriptions {
+		if !sub.matchesRepGroup(repGroup) {
+			continue
+		}
+
+		update := sub.removeRepGroupKey(key)
+		if update != nil {
+			deliveries = append(deliveries, repGroupSubscriptionUpdate{sub: sub, update: update})
+		}
+	}
+
+	s.csmutex.RUnlock()
+
+	s.enqueueSubscriptionDeliveries(deliveries)
 }

--- a/jobqueue/server_subscription.go
+++ b/jobqueue/server_subscription.go
@@ -234,6 +234,10 @@ func (s *serverSubscription) removeRepGroupKey(key string) *JobUpdate {
 
 	delete(s.repGroupStates, key)
 
+	if len(s.repGroupStates) == 0 {
+		return s.repGroupEmptyDoneUpdate()
+	}
+
 	return s.repGroupDoneUpdate()
 }
 
@@ -300,6 +304,16 @@ func repGroupAggregateUpdate(repGroup string, states map[string]JobState) *JobUp
 	}
 
 	return update
+}
+
+func (s *serverSubscription) repGroupEmptyDoneUpdate() *JobUpdate {
+	if s.repGroupDone {
+		return nil
+	}
+
+	s.repGroupDone = true
+
+	return repGroupAggregateUpdate(s.repGroup, s.repGroupStates)
 }
 
 func (s *Server) storeClientSubscription(sub *serverSubscription) string {

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -1932,6 +1932,97 @@ func TestSubscriptionRepGroupAggregate(t *testing.T) {
 		So(receiveSubscriptionUpdate(sub, 150*time.Millisecond), ShouldBeNil)
 	})
 
+	Convey("A RepGroup subscription completes when its only known live rerun job moves to another RepGroup", t, func() {
+		ctx := context.Background()
+		serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)
+		applySubscriptionTimings(&serverConfig, 5*time.Second)
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		depGroup := "subscription-b2-rerun-move-only-dep"
+		oldRepGroup := "subscription-b2-rerun-move-only-old"
+		newRepGroup := "subscription-b2-rerun-move-only-new"
+		trigger := &Job{
+			Cmd:          "echo " + depGroup,
+			Cwd:          testCwd,
+			ReqGroup:     depGroup,
+			Requirements: standardReqs,
+			RepGroup:     depGroup,
+			DepGroups:    []string{depGroup},
+		}
+		oldJob := &Job{
+			Cmd:          "echo " + oldRepGroup,
+			Cwd:          testCwd,
+			ReqGroup:     oldRepGroup,
+			Requirements: standardReqs,
+			RepGroup:     oldRepGroup,
+			Dependencies: Dependencies{NewDepGroupDependency(depGroup)},
+		}
+
+		added, existed, err := jq.Add([]*Job{trigger, oldJob}, envVars, true)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 2)
+		So(existed, ShouldEqual, 0)
+
+		archiveNextSubscriptionJob(jq)
+		archiveNextSubscriptionJob(jq)
+
+		added, existed, err = jq.Add([]*Job{trigger}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldBeGreaterThanOrEqualTo, 1)
+		So(existed, ShouldEqual, 0)
+
+		liveOldJobs, err := jq.GetByRepGroup(oldRepGroup, false, 0, "", false, false)
+		So(err, ShouldBeNil)
+		So(liveOldJobs, ShouldHaveLength, 1)
+
+		oldSub, err := jq.SubscribeToRepGroup(ctx, oldRepGroup)
+		So(err, ShouldBeNil)
+
+		defer oldSub.Unsubscribe()
+
+		So(receiveSubscriptionUpdate(oldSub, 150*time.Millisecond), ShouldBeNil)
+		archiveNextSubscriptionJob(jq)
+		So(receiveSubscriptionUpdate(oldSub, 150*time.Millisecond), ShouldBeNil)
+
+		replacement := &Job{
+			Cmd:          oldJob.Cmd,
+			Cwd:          oldJob.Cwd,
+			ReqGroup:     oldJob.ReqGroup,
+			Requirements: standardReqs,
+			RepGroup:     newRepGroup,
+			Dependencies: oldJob.Dependencies,
+		}
+		added, existed, err = jq.Add([]*Job{replacement}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		oldDone := receiveSubscriptionUpdate(oldSub, 2*time.Second)
+		So(oldDone, ShouldNotBeNil)
+		So(oldDone.Kind, ShouldEqual, JobUpdateRepGroupDone)
+		So(oldDone.RepGroup, ShouldEqual, oldRepGroup)
+		So(oldDone.Complete, ShouldEqual, 0)
+		So(oldDone.Buried, ShouldEqual, 0)
+		So(oldDone.Lost, ShouldEqual, 0)
+		So(oldDone.Total, ShouldEqual, 0)
+		So(oldDone.JobKeys, ShouldHaveLength, 0)
+		So(oldDone.JobStates, ShouldHaveLength, 0)
+
+		rerunJob := startNextSubscriptionJob(jq)
+		So(rerunJob.Key(), ShouldEqual, replacement.Key())
+		So(rerunJob.RepGroup, ShouldEqual, newRepGroup)
+		So(jq.Archive(rerunJob, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()}), ShouldBeNil)
+		So(receiveSubscriptionUpdate(oldSub, 150*time.Millisecond), ShouldBeNil)
+	})
+
 	Convey("A RepGroup subscription completes when a live rerun moves the remaining key to another RepGroup", t, func() {
 		ctx := context.Background()
 		serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -1932,6 +1932,141 @@ func TestSubscriptionRepGroupAggregate(t *testing.T) {
 		So(receiveSubscriptionUpdate(sub, 150*time.Millisecond), ShouldBeNil)
 	})
 
+	Convey("A RepGroup subscription completes when a live rerun moves the remaining key to another RepGroup", t, func() {
+		ctx := context.Background()
+		serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)
+		applySubscriptionTimings(&serverConfig, 5*time.Second)
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		depGroup := "subscription-b2-rerun-move-dep"
+		oldRepGroup := "subscription-b2-rerun-move-old"
+		newRepGroup := "subscription-b2-rerun-move-new"
+		trigger := &Job{
+			Cmd:          "echo " + depGroup,
+			Cwd:          testCwd,
+			ReqGroup:     depGroup,
+			Requirements: standardReqs,
+			RepGroup:     depGroup,
+			DepGroups:    []string{depGroup},
+		}
+		oldJobs := []*Job{
+			{
+				Cmd:          "echo " + oldRepGroup + "-0",
+				Cwd:          testCwd,
+				ReqGroup:     oldRepGroup + "-0",
+				Requirements: standardReqs,
+				RepGroup:     oldRepGroup,
+				Dependencies: Dependencies{NewDepGroupDependency(depGroup)},
+			},
+			{
+				Cmd:          "echo " + oldRepGroup + "-1",
+				Cwd:          testCwd,
+				ReqGroup:     oldRepGroup + "-1",
+				Requirements: standardReqs,
+				RepGroup:     oldRepGroup,
+				Dependencies: Dependencies{NewDepGroupDependency(depGroup)},
+			},
+		}
+
+		added, existed, err := jq.Add(append([]*Job{trigger}, oldJobs...), envVars, true)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 3)
+		So(existed, ShouldEqual, 0)
+
+		archiveNextSubscriptionJob(jq)
+		archiveNextSubscriptionJob(jq)
+		archiveNextSubscriptionJob(jq)
+
+		added, existed, err = jq.Add([]*Job{trigger}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldBeGreaterThanOrEqualTo, 1)
+		So(existed, ShouldEqual, 0)
+
+		liveOldJobs, err := jq.GetByRepGroup(oldRepGroup, false, 0, "", false, false)
+		So(err, ShouldBeNil)
+		So(liveOldJobs, ShouldHaveLength, 2)
+
+		oldSub, err := jq.SubscribeToRepGroup(ctx, oldRepGroup)
+		So(err, ShouldBeNil)
+
+		defer oldSub.Unsubscribe()
+
+		newSub, err := jq.SubscribeToRepGroup(ctx, newRepGroup)
+		So(err, ShouldBeNil)
+
+		defer newSub.Unsubscribe()
+
+		archiveNextSubscriptionJob(jq)
+
+		completedOldJob := startNextSubscriptionJob(jq)
+		So(jq.Archive(completedOldJob, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()}), ShouldBeNil)
+		So(receiveSubscriptionUpdate(oldSub, 150*time.Millisecond), ShouldBeNil)
+
+		oldJobByKey := map[string]*Job{
+			oldJobs[0].Key(): oldJobs[0],
+			oldJobs[1].Key(): oldJobs[1],
+		}
+		delete(oldJobByKey, completedOldJob.Key())
+
+		var remainingOldJob *Job
+		for _, job := range oldJobByKey {
+			remainingOldJob = job
+		}
+
+		So(remainingOldJob, ShouldNotBeNil)
+
+		replacement := &Job{
+			Cmd:          remainingOldJob.Cmd,
+			Cwd:          remainingOldJob.Cwd,
+			ReqGroup:     remainingOldJob.ReqGroup,
+			Requirements: standardReqs,
+			RepGroup:     newRepGroup,
+			Dependencies: remainingOldJob.Dependencies,
+		}
+		added, existed, err = jq.Add([]*Job{replacement}, envVars, false)
+		So(err, ShouldBeNil)
+		So(added, ShouldEqual, 1)
+		So(existed, ShouldEqual, 0)
+
+		oldDone := receiveSubscriptionUpdate(oldSub, 2*time.Second)
+		So(oldDone, ShouldNotBeNil)
+		So(oldDone.Kind, ShouldEqual, JobUpdateRepGroupDone)
+		So(oldDone.RepGroup, ShouldEqual, oldRepGroup)
+		So(oldDone.Complete, ShouldEqual, 1)
+		So(oldDone.Buried, ShouldEqual, 0)
+		So(oldDone.Lost, ShouldEqual, 0)
+		So(oldDone.Total, ShouldEqual, 1)
+		So(subscriptionStatesByKey(oldDone), ShouldResemble, map[string]JobState{
+			completedOldJob.Key(): JobStateComplete,
+		})
+
+		rerunJob := startNextSubscriptionJob(jq)
+		So(rerunJob.Key(), ShouldEqual, replacement.Key())
+		So(rerunJob.RepGroup, ShouldEqual, newRepGroup)
+		So(jq.Archive(rerunJob, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()}), ShouldBeNil)
+
+		newDone := receiveSubscriptionUpdate(newSub, 2*time.Second)
+		So(newDone, ShouldNotBeNil)
+		So(newDone.Kind, ShouldEqual, JobUpdateRepGroupDone)
+		So(newDone.RepGroup, ShouldEqual, newRepGroup)
+		So(newDone.Complete, ShouldEqual, 1)
+		So(newDone.Buried, ShouldEqual, 0)
+		So(newDone.Lost, ShouldEqual, 0)
+		So(newDone.Total, ShouldEqual, 1)
+		So(subscriptionStatesByKey(newDone), ShouldResemble, map[string]JobState{
+			replacement.Key(): JobStateComplete,
+		})
+		So(receiveSubscriptionUpdate(oldSub, 150*time.Millisecond), ShouldBeNil)
+	})
+
 	Convey("A post-registration catch-up snapshot holds back a missed live RepGroup job", t, func() {
 		ctx := context.Background()
 		serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)


### PR DESCRIPTION
## Summary
- ensure explicitly re-added completed dependent jobs with `--rerun` are re-queued instead of skipped as duplicates
- keep rerun jobs waiting on currently incomplete dependencies
- preserve existing live dependency cascade behavior

Solves #326

## Tests
- go test -tags netgo --count 1 ./jobqueue -run TestRerunDependentJobWaitsOnIncompleteDependencies -v
- golangci-lint run --timeout=2m ./jobqueue/...