### PR TITLE
Modernize cmd error handling

### DIFF
--- a/cmd/manager.go
+++ b/cmd/manager.go
@@ -32,6 +32,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -966,7 +967,10 @@ func startJQ(postCreation, preDestroy []byte) {
 
 	if err != nil {
 		saddr := sAddr(server.ServerInfo)
-		jqerr, ok := err.(jobqueue.Error)
+
+		var jqerr jobqueue.Error
+
+		ok := errors.As(err, &jqerr)
 		switch {
 		case ok && jqerr.Err == jobqueue.ErrClosedTerm:
 			info("wr manager on %s gracefully stopped (received SIGTERM)", saddr)

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -28,6 +28,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/syslog"
 	"os"
@@ -261,7 +262,9 @@ complete.`,
 			numrun++
 			if err != nil {
 				warn("%s", err)
-				if jqerr, ok := err.(jobqueue.Error); ok {
+
+				var jqerr jobqueue.Error
+				if errors.As(err, &jqerr) {
 					if strings.Contains(jqerr.Err, jobqueue.FailReasonSignal) {
 						exitReason = "we received a signal to stop"
 						break

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -28,7 +28,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/syslog"
 	"os"
@@ -263,8 +262,8 @@ complete.`,
 			if err != nil {
 				warn("%s", err)
 
-				var jqerr jobqueue.Error
-				if errors.As(err, &jqerr) {
+				// Keep this as a direct assertion: wrapped jobqueue errors must not change runner control flow.
+				if jqerr, ok := err.(jobqueue.Error); ok {
 					if strings.Contains(jqerr.Err, jobqueue.FailReasonSignal) {
 						exitReason = "we received a signal to stop"
 						break


### PR DESCRIPTION
Solves #301

- Replace cmd jobqueue.Error type assertions with errors.As.
- Keep CLI messages and existing behavior unchanged.