### PR TITLE
Modernize queue and rp error handling

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -103,6 +103,20 @@ import (
 	"github.com/VertebrateResequencing/wr/clog"
 )
 
+// recallBreak is how long we wait before recalling readyAdded.
+const recallBreak = 500 * time.Millisecond
+
+// Queue has some typical errors.
+var (
+	ErrQueueClosed   = errors.New("queue closed")
+	ErrNothingReady  = errors.New("ready queue is empty")
+	ErrAlreadyExists = errors.New("already exists")
+	ErrNotFound      = errors.New("not found")
+	ErrNotReady      = errors.New("not ready")
+	ErrNotRunning    = errors.New("not running")
+	ErrNotBuried     = errors.New("not buried")
+)
+
 // SubQueue is how we name the sub-queues of a Queue.
 type SubQueue string
 
@@ -119,19 +133,11 @@ const (
 	SubQueueRemoved   SubQueue = "removed"
 )
 
-// recallBreak is how long we wait before recalling readyAdded.
-const recallBreak = 500 * time.Millisecond
-
-// queue has some typical errors
-var (
-	ErrQueueClosed   = errors.New("queue closed")
-	ErrNothingReady  = errors.New("ready queue is empty")
-	ErrAlreadyExists = errors.New("already exists")
-	ErrNotFound      = errors.New("not found")
-	ErrNotReady      = errors.New("not ready")
-	ErrNotRunning    = errors.New("not running")
-	ErrNotBuried     = errors.New("not buried")
-)
+// defaultTTRCallback is used if the user never calls SetTTRCallback() and
+// always moves the items to the ready sub-queue.
+func defaultTTRCallback(_ interface{}) SubQueue {
+	return SubQueueReady
+}
 
 // Error records an error and the operation, item and queue that caused it.
 type Error struct {
@@ -161,12 +167,6 @@ type ChangedCallback func(from, to SubQueue, data []interface{})
 // SubQueueBury. SubQueueRun can be used to avoid changing subqueue. Other
 // values will be treated as SubQueueReady).
 type TTRCallback func(data interface{}) SubQueue
-
-// defaultTTRCallback is used if the the user never calls SetTTRCallback() and
-// always moves the items to the ready sub-queue.
-var defaultTTRCallback = func(data interface{}) SubQueue {
-	return SubQueueReady
-}
 
 // Queue is a synchronized map of items that can shift to different sub-queues,
 // automatically depending on their delay or ttr expiring, or manually by
@@ -1385,4 +1385,9 @@ func (queue *Queue) ttrNotificationTrigger(item *Item) {
 	} else {
 		queue.mutex.RUnlock()
 	}
+}
+
+// Unwrap returns the underlying queue sentinel error.
+func (e Error) Unwrap() error {
+	return e.Err
 }

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -28,6 +28,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -249,9 +250,7 @@ func TestQueue(t *testing.T) {
 			item, err := queue.Get("key_fake")
 			So(err, ShouldNotBeNil)
 			So(item, ShouldBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNotFound)
+			shouldBeQueueError(err, ErrNotFound)
 		})
 
 		Convey("You can get all items back out", func() {
@@ -266,9 +265,7 @@ func TestQueue(t *testing.T) {
 
 		Convey("You can't add the same item again", func() {
 			item, err := queue.Add(ctx, "key_0", "", "data new", 0, 100*time.Millisecond, 100*time.Millisecond, "")
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrAlreadyExists)
+			shouldBeQueueError(err, ErrAlreadyExists)
 			So(err.Error(), ShouldEqual, "queue(myqueue) Add(key_0): already exists")
 			So(item.Data(), ShouldEqual, "data")
 			So(item.creation, ShouldHappenOnOrBefore, items["key_0"].creation)
@@ -321,9 +318,7 @@ func TestQueue(t *testing.T) {
 				item4, err := queue.Reserve("", 0)
 				So(err, ShouldNotBeNil)
 				So(item4, ShouldBeNil)
-				qerr, ok := err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNothingReady)
+				shouldBeQueueError(err, ErrNothingReady)
 
 				stats = queue.Stats()
 				So(stats.Items, ShouldEqual, 10)
@@ -425,34 +420,22 @@ func TestQueue(t *testing.T) {
 					Convey("Releasing, touching, burying, kicking and updating fail after removal", func() {
 						err := queue.Release(ctx, item2.Key)
 						So(err, ShouldNotBeNil)
-						qerr, ok := err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 						err = queue.Touch(item2.Key)
 						So(err, ShouldNotBeNil)
-						qerr, ok = err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 						err = queue.Bury(item2.Key)
 						So(err, ShouldNotBeNil)
-						qerr, ok = err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 						err = queue.Kick(ctx, item2.Key)
 						So(err, ShouldNotBeNil)
-						qerr, ok = err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 						err = queue.Update(ctx, item2.Key, "", item2.Data(), 0, 0*time.Second, 0*time.Second)
 						So(err, ShouldNotBeNil)
-						qerr, ok = err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 						err = queue.SetDelay(item2.Key, 0*time.Second)
 						So(err, ShouldNotBeNil)
-						qerr, ok = err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 					})
 				})
 
@@ -505,18 +488,14 @@ func TestQueue(t *testing.T) {
 
 						err = queue.Remove(ctx, "key_2")
 						So(err, ShouldNotBeNil)
-						qerr, ok := err.(Error)
-						So(ok, ShouldBeTrue)
-						So(qerr.Err, ShouldEqual, ErrNotFound)
+						shouldBeQueueError(err, ErrNotFound)
 					})
 				})
 
 				Convey("If not buried you can't kick them", func() {
 					err := queue.Kick(ctx, item3.Key)
 					So(err, ShouldNotBeNil)
-					qerr, ok := err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrNotBuried)
+					shouldBeQueueError(err, ErrNotBuried)
 					So(item3.State(), ShouldEqual, ItemStateRun)
 				})
 
@@ -618,9 +597,7 @@ func TestQueue(t *testing.T) {
 
 					err = queue.Touch("item_fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok := err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrNotFound)
+					shouldBeQueueError(err, ErrNotFound)
 				})
 
 				Convey("Touching doesn't mess with the correct queue order", func() {
@@ -668,89 +645,57 @@ func TestQueue(t *testing.T) {
 
 					_, err = queue.Add(ctx, "fake", "", "data", 0, 0*time.Second, 0*time.Second, "")
 					So(err, ShouldNotBeNil)
-					qerr, ok := err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					_, err = queue.Get("fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Update(ctx, "fake", "", "data", 0, 0*time.Second, 0*time.Second)
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					_, err = queue.Reserve("", 0)
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					_, err = queue.Reserve("", 0)
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Touch("fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Release(ctx, "fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Bury("fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Kick(ctx, "fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.Remove(ctx, "fake")
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 					err = queue.SetDelay("fake", 0*time.Second)
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 
 					err = queue.Destroy()
 					So(err, ShouldNotBeNil)
-					qerr, ok = err.(Error)
-					So(ok, ShouldBeTrue)
-					So(qerr.Err, ShouldEqual, ErrQueueClosed)
+					shouldBeQueueError(err, ErrQueueClosed)
 				})
 			})
 
 			Convey("If not reserved you can't release, touch, bury or kick them", func() {
 				err := queue.Release(ctx, "key_0")
 				So(err, ShouldNotBeNil)
-				qerr, ok := err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotRunning)
+				shouldBeQueueError(err, ErrNotRunning)
 				err = queue.Touch("key_0")
 				So(err, ShouldNotBeNil)
-				qerr, ok = err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotRunning)
+				shouldBeQueueError(err, ErrNotRunning)
 				err = queue.Bury("key_0")
 				So(err, ShouldNotBeNil)
-				qerr, ok = err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotRunning)
+				shouldBeQueueError(err, ErrNotRunning)
 				err = queue.Kick(ctx, "key_0")
 				So(err, ShouldNotBeNil)
-				qerr, ok = err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotBuried)
+				shouldBeQueueError(err, ErrNotBuried)
 			})
 
 			Convey("But you can remove them when ready", func() {
@@ -766,9 +711,7 @@ func TestQueue(t *testing.T) {
 
 				err = queue.Remove(ctx, "key_0")
 				So(err, ShouldNotBeNil)
-				qerr, ok := err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotFound)
+				shouldBeQueueError(err, ErrNotFound)
 			})
 		})
 
@@ -776,9 +719,7 @@ func TestQueue(t *testing.T) {
 			item, err := queue.Reserve("", 0)
 			So(err, ShouldNotBeNil)
 			So(item, ShouldBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNothingReady)
+			shouldBeQueueError(err, ErrNothingReady)
 		})
 
 		Convey("But you can remove them when not ready", func() {
@@ -794,9 +735,7 @@ func TestQueue(t *testing.T) {
 
 			err = queue.Remove(ctx, "key_0")
 			So(err, ShouldNotBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNotFound)
+			shouldBeQueueError(err, ErrNotFound)
 		})
 	})
 
@@ -821,9 +760,7 @@ func TestQueue(t *testing.T) {
 			Convey("Once removed it can't be updated", func() {
 				err = queue.Update(ctx, "item1", "", "data", 0, 75*time.Millisecond, 50*time.Millisecond)
 				So(err, ShouldNotBeNil)
-				qerr, ok := err.(Error)
-				So(ok, ShouldBeTrue)
-				So(qerr.Err, ShouldEqual, ErrNotFound)
+				shouldBeQueueError(err, ErrNotFound)
 			})
 		})
 
@@ -1092,9 +1029,7 @@ func TestQueue(t *testing.T) {
 			item, err := queue.Reserve("1001", 0)
 			So(err, ShouldNotBeNil)
 			So(item, ShouldBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNothingReady)
+			shouldBeQueueError(err, ErrNothingReady)
 
 			sort.Ints(dataids)
 			for _, dataid := range dataids {
@@ -1169,9 +1104,7 @@ func TestQueue(t *testing.T) {
 		item, err := q.Reserve("", 0)
 		So(err, ShouldNotBeNil)
 		So(item, ShouldBeNil)
-		qerr, ok := err.(Error)
-		So(ok, ShouldBeTrue)
-		So(qerr.Err, ShouldEqual, ErrNothingReady)
+		shouldBeQueueError(err, ErrNothingReady)
 
 		var itemdefs []*ItemDef
 		for i := 0; i < 10; i++ {
@@ -1226,9 +1159,7 @@ func TestQueue(t *testing.T) {
 			So(err, ShouldBeNil)
 			_, _, err = q.AddMany(ctx, itemdefs)
 			So(err, ShouldNotBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrQueueClosed)
+			shouldBeQueueError(err, ErrQueueClosed)
 		})
 	})
 
@@ -1467,21 +1398,15 @@ func TestQueue(t *testing.T) {
 
 			err = queue.ChangeKey("foo", "bar")
 			So(err, ShouldNotBeNil)
-			qerr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNotFound)
+			shouldBeQueueError(err, ErrNotFound)
 
 			err = queue.ChangeKey("key_1", "changed_3")
 			So(err, ShouldNotBeNil)
-			qerr, ok = err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrAlreadyExists)
+			shouldBeQueueError(err, ErrAlreadyExists)
 
 			_, err = queue.Get("key_3")
 			So(err, ShouldNotBeNil)
-			qerr, ok = err.(Error)
-			So(ok, ShouldBeTrue)
-			So(qerr.Err, ShouldEqual, ErrNotFound)
+			shouldBeQueueError(err, ErrNotFound)
 
 			item, err := queue.Get("changed_3")
 			So(err, ShouldBeNil)
@@ -1810,6 +1735,12 @@ func TestQueue(t *testing.T) {
 	})
 }
 
+func shouldBeQueueError(err error, target error) {
+	var qerr Error
+	So(errors.As(err, &qerr), ShouldBeTrue)
+	So(errors.Is(err, target), ShouldBeTrue)
+}
+
 func depTestFunc(ctx context.Context, queue *Queue, changed bool) {
 	key3 := "key_3"
 	key6 := "key_6"
@@ -1917,7 +1848,7 @@ func depTestFunc(ctx context.Context, queue *Queue, changed bool) {
 func qdestroy(q *Queue) {
 	err := q.Destroy()
 	if err != nil {
-		if qerr, ok := err.(Error); ok && qerr.Err == ErrQueueClosed {
+		if errors.Is(err, ErrQueueClosed) {
 			return
 		}
 		fmt.Printf("queue.Destroy failed: %s\n", err)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1738,6 +1738,7 @@ func TestQueue(t *testing.T) {
 func shouldBeQueueError(err error, target error) {
 	var qerr Error
 	So(errors.As(err, &qerr), ShouldBeTrue)
+	So(qerr.Err, ShouldEqual, target)
 	So(errors.Is(err, target), ShouldBeTrue)
 }
 

--- a/rp/rp_test.go
+++ b/rp/rp_test.go
@@ -26,6 +26,7 @@
 package rp
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"testing/synctest"
@@ -179,9 +180,7 @@ func testRPBody(t *testing.T) {
 			r, err := rp.Request(maxSimultaneous + 1)
 			So(string(r), ShouldBeBlank)
 			So(err, ShouldNotBeNil)
-			rperr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(rperr.Err, ShouldEqual, ErrOverMaximumTokens)
+			shouldBeRPError(err, ErrOverMaximumTokens)
 		})
 
 		Convey("You can't do anything with an invalid receipt", func() {
@@ -213,9 +212,7 @@ func testRPBody(t *testing.T) {
 			r3, err := rp.Request(1)
 			So(string(r3), ShouldBeBlank)
 			So(err, ShouldNotBeNil)
-			rperr, ok := err.(Error)
-			So(ok, ShouldBeTrue)
-			So(rperr.Err, ShouldEqual, ErrShutDown)
+			shouldBeRPError(err, ErrShutDown)
 		})
 
 		Convey("WaitUntilGranted can time out and cancel the request", func() {
@@ -437,4 +434,10 @@ func testRPBody(t *testing.T) {
 			So(time.Now(), ShouldHappenOnOrBetween, begin.Add(time.Duration(delayInt*tooBusyFor)*time.Millisecond), begin.Add(time.Duration(delayInt*tooBusyFor)*time.Millisecond).Add(halfDelay))
 		})
 	})
+}
+
+func shouldBeRPError(err error, target string) {
+	var rperr Error
+	So(errors.As(err, &rperr), ShouldBeTrue)
+	So(rperr.Err, ShouldEqual, target)
 }


### PR DESCRIPTION
Solves #301

Summary:
- Add standard unwrapping for queue.Error so sentinel errors work with errors.Is.
- Update queue and rp error assertions to use errors.As/errors.Is instead of direct type assertions.
- Keep behavior unchanged while satisfying focused queue/rp lint checks.

Tests:
- timeout 180s env CGO_ENABLED=1 go test -tags netgo --count 1 ./queue ./rp -v
- timeout 180s golangci-lint run ./queue/... ./rp/...