### PR TITLE
Modernize internal and port error wrapping

### DIFF
--- a/internal/cert.go
+++ b/internal/cert.go
@@ -100,6 +100,11 @@ func (ce CertError) Error() string {
 	return msg
 }
 
+// Unwrap returns the underlying certificate error.
+func (ce CertError) Unwrap() error {
+	return ce.Err
+}
+
 // NumberError records a number related error.
 type NumberError struct {
 	Err error
@@ -108,6 +113,15 @@ type NumberError struct {
 // Error returns a number related error.
 func (n *NumberError) Error() string {
 	return fmt.Sprintf("failed to generate serial number: %s", n.Err)
+}
+
+// Unwrap returns the underlying number generation error.
+func (n *NumberError) Unwrap() error {
+	if n == nil {
+		return nil
+	}
+
+	return n.Err
 }
 
 // GenerateCerts creates a CA certificate which is used to sign a created server

--- a/internal/cert_test.go
+++ b/internal/cert_test.go
@@ -32,6 +32,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -68,6 +69,7 @@ func TestCert(t *testing.T) {
 			errCertTmplt, err := certTemplate(certDomain, r)
 			So(err, ShouldNotBeNil)
 			So(errCertTmplt, ShouldBeNil)
+			So(wrappedErrIs(err), ShouldBeTrue)
 
 			certTmplt, err := certTemplate(certDomain, crand.Reader)
 			So(err, ShouldBeNil)
@@ -109,6 +111,7 @@ func TestCert(t *testing.T) {
 							errCert, err := parseCertAndSavePEM(empByte, caFile, certFileFlags)
 							So(errCert, ShouldBeNil)
 							So(err, ShouldNotBeNil)
+							So(wrappedErrIs(err), ShouldBeTrue)
 						})
 
 						Convey("and not when file cannot be written", func() {
@@ -241,4 +244,18 @@ func TestCert(t *testing.T) {
 			})
 		})
 	})
+}
+
+func wrappedErrIs(err error) bool {
+	var certErr *CertError
+	if errors.As(err, &certErr) && certErr.Err != nil {
+		return errors.Is(err, certErr.Err)
+	}
+
+	var numberErr *NumberError
+	if errors.As(err, &numberErr) && numberErr.Err != nil {
+		return errors.Is(err, numberErr.Err)
+	}
+
+	return false
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -248,6 +248,15 @@ func ConfigLoadFromParentDir(ctx context.Context, deployment string) *Config {
 	return mergeAllConfigs(ctx, uid, deployment, pwd)
 }
 
+// Unwrap returns the underlying file existence error.
+func (f *FileExistsError) Unwrap() error {
+	if f == nil {
+		return nil
+	}
+
+	return f.Err
+}
+
 // getPWDAndUID returns present working directory and user id.
 func getPWDAndUID(ctx context.Context) (string, int) {
 	pwd := fsd.GetPWD(ctx)

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -29,6 +29,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -147,6 +148,12 @@ func TestConfig(t *testing.T) {
 	Convey("Given a path", t, func() {
 		pathS3 := "s3://test1"
 		pathNotS3 := "/tmp/test2"
+
+		Convey("file exists errors can be matched against their cause", func() {
+			err := &FileExistsError{Path: pathNotS3, Err: os.ErrExist}
+
+			So(errors.Is(err, os.ErrExist), ShouldBeTrue)
+		})
 
 		Convey("we can see if it's in an S3 bucket", func() {
 			So(InS3(pathS3), ShouldEqual, true)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -215,7 +215,7 @@ func ProcMeminfoMBs() (int, error) {
 // args are passed as additional context for the logger.
 func LogClose(ctx context.Context, obj io.Closer, msg string, extra ...interface{}) {
 	err := obj.Close()
-	if err != nil && !errors.Is(err, io.EOF) {
+	if err != nil && err.Error() != "EOF" && !errors.Is(err, io.EOF) {
 		extra = append(extra, "err", err)
 		clog.Warn(ctx, "failed to close "+msg, extra...)
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"crypto/md5" // #nosec not used for security purposes
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -214,7 +215,7 @@ func ProcMeminfoMBs() (int, error) {
 // args are passed as additional context for the logger.
 func LogClose(ctx context.Context, obj io.Closer, msg string, extra ...interface{}) {
 	err := obj.Close()
-	if err != nil && err.Error() != "EOF" {
+	if err != nil && !errors.Is(err, io.EOF) {
 		extra = append(extra, "err", err)
 		clog.Warn(ctx, "failed to close "+msg, extra...)
 	}
@@ -335,7 +336,7 @@ func InfobloxSetDomainIP(domain, ip string) error {
 	// check if it's already set
 	objs, err := ib.FindRecordA(domain)
 	if err != nil {
-		return fmt.Errorf("finding A records failed: %s", err)
+		return fmt.Errorf("finding A records failed: %w", err)
 	}
 
 	if len(objs) == 1 {
@@ -348,7 +349,7 @@ func InfobloxSetDomainIP(domain, ip string) error {
 	for _, obj := range objs {
 		err = ib.NetworkObject(obj.Ref).Delete(nil)
 		if err != nil {
-			return fmt.Errorf("delete of A record failed: %s", err)
+			return fmt.Errorf("delete of A record failed: %w", err)
 		}
 	}
 
@@ -358,7 +359,7 @@ func InfobloxSetDomainIP(domain, ip string) error {
 	d.Set("name", domain)
 	_, err = ib.RecordA().Create(d, nil, nil)
 	if err != nil {
-		return fmt.Errorf("create of A record failed: %s", err)
+		return fmt.Errorf("create of A record failed: %w", err)
 	}
 
 	// wait a while for things to "really" work
@@ -503,7 +504,7 @@ func PathToContent(path string) (string, error) {
 	absPath := TildaToHome(path)
 	contents, err := os.ReadFile(absPath)
 	if err != nil {
-		return "", fmt.Errorf("path [%s] could not be read: %s", absPath, err)
+		return "", fmt.Errorf("path [%s] could not be read: %w", absPath, err)
 	}
 	return string(contents), nil
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/clog"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type wrappedEOFCloser struct{}
+
+func (wrappedEOFCloser) Close() error {
+	return fmt.Errorf("wrapped close: %w", io.EOF)
+}
+
+func TestUtilsErrorWrapping(t *testing.T) {
+	Convey("Given utility errors with context", t, func() {
+		Convey("PathToContent preserves the read failure cause", func() {
+			_, err := PathToContent(filepath.Join(t.TempDir(), "missing"))
+
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, os.ErrNotExist), ShouldBeTrue)
+		})
+
+		Convey("LogClose ignores wrapped EOF close errors", func() {
+			buff := clog.ToBufferAtLevel("warn")
+
+			defer clog.ToDefault()
+
+			LogClose(context.Background(), wrappedEOFCloser{}, "wrapped eof")
+
+			So(buff.String(), ShouldEqual, "")
+		})
+	})
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -38,6 +38,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+var errLegacyEOF = errors.New("EOF") // Regression sentinel for legacy close behaviour.
+
 type wrappedEOFCloser struct{}
 
 func (wrappedEOFCloser) Close() error {
@@ -62,5 +64,21 @@ func TestUtilsErrorWrapping(t *testing.T) {
 
 			So(buff.String(), ShouldEqual, "")
 		})
+
+		Convey("LogClose still ignores legacy EOF string close errors", func() {
+			buff := clog.ToBufferAtLevel("warn")
+
+			defer clog.ToDefault()
+
+			LogClose(context.Background(), legacyEOFCloser{}, "legacy eof")
+
+			So(buff.String(), ShouldEqual, "")
+		})
 	})
+}
+
+type legacyEOFCloser struct{}
+
+func (legacyEOFCloser) Close() error {
+	return errLegacyEOF
 }

--- a/network/port/port.go
+++ b/network/port/port.go
@@ -172,9 +172,17 @@ func (c *Checker) portsBefore(start int) []int {
 func (c *Checker) release(err error) error {
 	for _, l := range c.listeners {
 		errl := l.Close()
-		if errl != nil {
-			err = fmt.Errorf("%w; %s", err, errl.Error())
+		if errl == nil {
+			continue
 		}
+
+		if err == nil {
+			err = errl
+
+			continue
+		}
+
+		err = fmt.Errorf("%w; %w", err, errl)
 	}
 
 	c.listeners = nil

--- a/network/port/port_test.go
+++ b/network/port/port_test.go
@@ -26,6 +26,7 @@
 package port
 
 import (
+	"errors"
 	"net"
 	"syscall"
 	"testing"
@@ -67,6 +68,7 @@ func TestPort(t *testing.T) {
 				checker.listeners[0] = &mockListener{tcpListener}
 				err = checker.release(err)
 				So(err, ShouldNotBeNil)
+				So(errors.Is(err, syscall.EINVAL), ShouldBeTrue)
 			})
 		})
 


### PR DESCRIPTION
Summary:
- Wrap internal utility errors with %w and use errors.Is for EOF close handling.
- Add Unwrap support for internal custom error types.
- Preserve port release close errors for errors.Is matching.

Tests:
- timeout 180s env CGO_ENABLED=1 go test -tags netgo --count 1 ./internal/... ./network/port -v
- timeout 180s golangci-lint run ./internal/... ./network/port/...

Solves #301