### PR TITLE
Trim lifecycle client payloads

### DIFF
--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -131,6 +131,16 @@ const (
 	RepGroupMatchSuffix RepGroupMatch = "suffix"
 )
 
+func touchEndState(job *Job) *JobEndState {
+	return &JobEndState{
+		PeakRAM:  job.PeakRAM,
+		PeakDisk: job.PeakDisk,
+		CPUtime:  job.CPUtime,
+		Stdout:   job.StdOutC,
+		Stderr:   job.StdErrC,
+	}
+}
+
 // clientRequest is the struct that clients send to the server over the network
 // to request it do something. (The properties are only exported so the
 // encoder doesn't ignore them.)
@@ -148,6 +158,7 @@ type clientRequest struct {
 	State                   JobState
 	Path                    string // desired path File should be stored at, can be blank
 	CloudServerID           string
+	FailReason              string
 	Job                     *Job
 	JobEndState             *JobEndState
 	Modifier                *JobModifier
@@ -183,6 +194,26 @@ func RepGroupMatches(jobRepGroup, repgroup string, match RepGroupMatch) bool {
 	default:
 		return jobRepGroup == repgroup
 	}
+}
+
+func (cr *clientRequest) key() string {
+	if len(cr.Keys) > 0 {
+		return cr.Keys[0]
+	}
+
+	if cr.Job != nil {
+		return cr.Job.Key()
+	}
+
+	return ""
+}
+
+func (cr *clientRequest) failReason() string {
+	if cr.FailReason != "" || cr.Job == nil {
+		return cr.FailReason
+	}
+
+	return cr.Job.FailReason
 }
 
 // Client represents the client side of the socket that the jobqueue server is
@@ -1694,7 +1725,12 @@ func (c *Client) Touch(job *Job) (bool, error) {
 	defer c.teMutex.Unlock()
 	job.RLock()
 	defer job.RUnlock()
-	resp, err := c.request(&clientRequest{Method: "jtouch", Job: job})
+
+	resp, err := c.request(&clientRequest{
+		Method:      "jtouch",
+		Keys:        []string{job.Key()},
+		JobEndState: touchEndState(job),
+	})
 	if err != nil {
 		return false, err
 	}
@@ -1755,7 +1791,7 @@ func (c *Client) Archive(job *Job, jes *JobEndState) error {
 	job.RLock()
 	defer job.RUnlock()
 
-	_, err := c.request(&clientRequest{Method: "jarchive", Job: job, JobEndState: jes})
+	_, err := c.request(&clientRequest{Method: "jarchive", Keys: []string{job.Key()}, JobEndState: jes})
 	if err != nil {
 		return err
 	}
@@ -1782,7 +1818,12 @@ func (c *Client) Release(job *Job, jes *JobEndState, failreason string) error {
 
 	job.FailReason = failreason
 
-	_, err := c.request(&clientRequest{Method: "jrelease", Job: job, JobEndState: jes})
+	_, err := c.request(&clientRequest{
+		Method:      "jrelease",
+		Keys:        []string{job.Key()},
+		JobEndState: jes,
+		FailReason:  failreason,
+	})
 	if err != nil {
 		return err
 	}
@@ -1824,7 +1865,12 @@ func (c *Client) Bury(job *Job, jes *JobEndState, failreason string, stderr ...e
 		jes.Stderr = compressStd([]byte(stderr[0].Error()))
 	}
 
-	_, err := c.request(&clientRequest{Method: "jbury", Job: job, JobEndState: jes})
+	_, err := c.request(&clientRequest{
+		Method:      "jbury",
+		Keys:        []string{job.Key()},
+		JobEndState: jes,
+		FailReason:  failreason,
+	})
 	if err != nil {
 		return err
 	}
@@ -2145,11 +2191,7 @@ func (c *Client) request(cr *clientRequest) (*serverResponse, error) {
 
 	// pull the error out of sr
 	if sr.Err != "" {
-		key := ""
-		if cr.Job != nil {
-			key = cr.Job.Key()
-		}
-		return sr, Error{cr.Method, key, sr.Err}
+		return sr, Error{cr.Method, cr.key(), sr.Err}
 	}
 	return sr, err
 }

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -119,6 +119,7 @@ var (
 )
 
 const (
+	requestMethodStart          = "jstart"
 	requestMethodSubscribe      = "subscribe"
 	requestMethodUnsubscribe    = "unsubscribe"
 	requestMethodWaitForUpdates = "waitForUpdates"
@@ -1712,7 +1713,7 @@ func (c *Client) Started(job *Job, pid int) error {
 	job.Pid = pid
 	job.Attempts++             // not considered by server, which does this itself - just for benefit of this process
 	job.StartTime = time.Now() // ditto
-	_, err = c.request(&clientRequest{Method: "jstart", Job: job})
+	_, err = c.request(&clientRequest{Method: requestMethodStart, Job: job})
 	return err
 }
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1731,7 +1731,7 @@ func keyOnlyJob(job *Job) *Job {
 		Cmd:             job.Cmd,
 		Cwd:             job.Cwd,
 		CwdMatters:      job.CwdMatters,
-		MountConfigs:    slices.Clone(job.MountConfigs),
+		MountConfigs:    cloneMountConfigs(job.MountConfigs),
 		WithDocker:      job.WithDocker,
 		WithSingularity: job.WithSingularity,
 		ContainerMounts: job.ContainerMounts,
@@ -2247,4 +2247,13 @@ func (c *Client) CompressEnv(envars []string) ([]byte, error) {
 		return nil, err
 	}
 	return compress(encoded)
+}
+
+func cloneMountConfigs(mountConfigs MountConfigs) MountConfigs {
+	clone := slices.Clone(mountConfigs)
+	for i := range clone {
+		clone[i].Targets = slices.Clone(clone[i].Targets)
+	}
+
+	return clone
 }

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1746,10 +1746,10 @@ func (c *Client) Touch(job *Job) (bool, error) {
 	c.teMutex.Lock()
 	defer c.teMutex.Unlock()
 
-	job.RLock()
-	key := jobKeySnapshot(job)
+	job.Lock()
+	key := job.Key()
 	endState := touchEndState(job)
-	job.RUnlock()
+	job.Unlock()
 
 	resp, err := c.request(&clientRequest{
 		Method:      "jtouch",
@@ -1779,10 +1779,6 @@ type JobEndState struct {
 	Stdout   []byte
 	Stderr   []byte
 	Exited   bool
-}
-
-func jobKeySnapshot(job *Job) string {
-	return keyOnlyJob(job).Key()
 }
 
 // ended updates a Job for the benefit of the client only: this has no effect on
@@ -1817,9 +1813,9 @@ func (c *Client) Archive(job *Job, jes *JobEndState) error {
 	c.teMutex.Lock()
 	defer c.teMutex.Unlock()
 
-	job.RLock()
-	key := jobKeySnapshot(job)
-	job.RUnlock()
+	job.Lock()
+	key := job.Key()
+	job.Unlock()
 
 	_, err := c.request(&clientRequest{Method: "jarchive", Keys: []string{key}, JobEndState: jes})
 	if err != nil {
@@ -1848,7 +1844,7 @@ func (c *Client) Release(job *Job, jes *JobEndState, failreason string) error {
 
 	job.Lock()
 	job.FailReason = failreason
-	key := jobKeySnapshot(job)
+	key := job.Key()
 	job.Unlock()
 
 	_, err := c.request(&clientRequest{
@@ -1898,7 +1894,7 @@ func (c *Client) Bury(job *Job, jes *JobEndState, failreason string, stderr ...e
 
 	job.Lock()
 	job.FailReason = failreason
-	key := jobKeySnapshot(job)
+	key := job.Key()
 	job.Unlock()
 
 	_, err := c.request(&clientRequest{

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -45,6 +45,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -137,8 +138,8 @@ func touchEndState(job *Job) *JobEndState {
 		PeakRAM:  job.PeakRAM,
 		PeakDisk: job.PeakDisk,
 		CPUtime:  job.CPUtime,
-		Stdout:   job.StdOutC,
-		Stderr:   job.StdErrC,
+		Stdout:   slices.Clone(job.StdOutC),
+		Stderr:   slices.Clone(job.StdErrC),
 	}
 }
 
@@ -1703,18 +1704,38 @@ func (c *Client) Started(job *Job, pid int) error {
 	if err != nil {
 		host = localhost
 	}
-	job.Lock()
-	defer job.Unlock()
-	job.Host = host
-	job.HostIP, err = internal.CurrentIP("")
+
+	hostIP, err := internal.CurrentIP("")
 	if err != nil {
 		return err
 	}
+
+	job.Lock()
+	job.Host = host
+	job.HostIP = hostIP
 	job.Pid = pid
 	job.Attempts++             // not considered by server, which does this itself - just for benefit of this process
 	job.StartTime = time.Now() // ditto
-	_, err = c.request(&clientRequest{Method: requestMethodStart, Job: job})
+	requestJob := keyOnlyJob(job)
+	requestJob.Host = job.Host
+	requestJob.HostIP = job.HostIP
+	requestJob.Pid = job.Pid
+	job.Unlock()
+
+	_, err = c.request(&clientRequest{Method: requestMethodStart, Job: requestJob})
 	return err
+}
+
+func keyOnlyJob(job *Job) *Job {
+	return &Job{
+		Cmd:             job.Cmd,
+		Cwd:             job.Cwd,
+		CwdMatters:      job.CwdMatters,
+		MountConfigs:    slices.Clone(job.MountConfigs),
+		WithDocker:      job.WithDocker,
+		WithSingularity: job.WithSingularity,
+		ContainerMounts: job.ContainerMounts,
+	}
 }
 
 // Touch adds to a job's ttr, allowing you more time to work on it. Note that
@@ -1724,13 +1745,16 @@ func (c *Client) Started(job *Job, pid int) error {
 func (c *Client) Touch(job *Job) (bool, error) {
 	c.teMutex.Lock()
 	defer c.teMutex.Unlock()
+
 	job.RLock()
-	defer job.RUnlock()
+	key := jobKeySnapshot(job)
+	endState := touchEndState(job)
+	job.RUnlock()
 
 	resp, err := c.request(&clientRequest{
 		Method:      "jtouch",
-		Keys:        []string{job.Key()},
-		JobEndState: touchEndState(job),
+		Keys:        []string{key},
+		JobEndState: endState,
 	})
 	if err != nil {
 		return false, err
@@ -1755,6 +1779,10 @@ type JobEndState struct {
 	Stdout   []byte
 	Stderr   []byte
 	Exited   bool
+}
+
+func jobKeySnapshot(job *Job) string {
+	return keyOnlyJob(job).Key()
 }
 
 // ended updates a Job for the benefit of the client only: this has no effect on
@@ -1790,17 +1818,21 @@ func (c *Client) Archive(job *Job, jes *JobEndState) error {
 	defer c.teMutex.Unlock()
 
 	job.RLock()
-	defer job.RUnlock()
+	key := jobKeySnapshot(job)
+	job.RUnlock()
 
-	_, err := c.request(&clientRequest{Method: "jarchive", Keys: []string{job.Key()}, JobEndState: jes})
+	_, err := c.request(&clientRequest{Method: "jarchive", Keys: []string{key}, JobEndState: jes})
 	if err != nil {
 		return err
 	}
 
+	job.Lock()
+	defer job.Unlock()
+
 	c.ended(job, jes)
 	job.State = JobStateComplete
 
-	return err
+	return nil
 }
 
 // Release places a job back on the jobqueue, for use when you can't handle the
@@ -1815,19 +1847,22 @@ func (c *Client) Release(job *Job, jes *JobEndState, failreason string) error {
 	defer c.teMutex.Unlock()
 
 	job.Lock()
-	defer job.Unlock()
-
 	job.FailReason = failreason
+	key := jobKeySnapshot(job)
+	job.Unlock()
 
 	_, err := c.request(&clientRequest{
 		Method:      "jrelease",
-		Keys:        []string{job.Key()},
+		Keys:        []string{key},
 		JobEndState: jes,
 		FailReason:  failreason,
 	})
 	if err != nil {
 		return err
 	}
+
+	job.Lock()
+	defer job.Unlock()
 
 	c.ended(job, jes)
 
@@ -1853,11 +1888,6 @@ func (c *Client) Bury(job *Job, jes *JobEndState, failreason string, stderr ...e
 	c.teMutex.Lock()
 	defer c.teMutex.Unlock()
 
-	job.Lock()
-	defer job.Unlock()
-
-	job.FailReason = failreason
-
 	if len(stderr) == 1 && stderr[0] != nil {
 		if jes == nil {
 			jes = &JobEndState{}
@@ -1866,15 +1896,23 @@ func (c *Client) Bury(job *Job, jes *JobEndState, failreason string, stderr ...e
 		jes.Stderr = compressStd([]byte(stderr[0].Error()))
 	}
 
+	job.Lock()
+	job.FailReason = failreason
+	key := jobKeySnapshot(job)
+	job.Unlock()
+
 	_, err := c.request(&clientRequest{
 		Method:      "jbury",
-		Keys:        []string{job.Key()},
+		Keys:        []string{key},
 		JobEndState: jes,
 		FailReason:  failreason,
 	})
 	if err != nil {
 		return err
 	}
+
+	job.Lock()
+	defer job.Unlock()
 
 	c.ended(job, jes)
 	job.State = JobStateBuried

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -75,8 +75,9 @@ func (s *captureSocket) Recv() ([]byte, error) {
 	var encoded []byte
 
 	enc := codec.NewEncoderBytes(&encoded, s.ch)
+	err := enc.Encode(&serverResponse{})
 
-	return encoded, enc.Encode(&serverResponse{})
+	return encoded, err
 }
 
 func (s *captureSocket) SendMsg(msg *mangos.Message) error {

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -26,11 +26,14 @@
 package jobqueue
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/gofrs/uuid/v5"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/ugorji/go/codec"
@@ -40,8 +43,9 @@ import (
 var errCaptureSocketUnsupported = errors.New("unsupported capture socket operation")
 
 type captureSocket struct {
-	ch   codec.Handle
-	sent []byte
+	ch      codec.Handle
+	sent    []byte
+	sentMsg []byte
 }
 
 func newCaptureClient() (*Client, *captureSocket) {
@@ -75,8 +79,10 @@ func (s *captureSocket) Recv() ([]byte, error) {
 	return encoded, enc.Encode(&serverResponse{})
 }
 
-func (s *captureSocket) SendMsg(_ *mangos.Message) error {
-	return errCaptureSocketUnsupported
+func (s *captureSocket) SendMsg(msg *mangos.Message) error {
+	s.sentMsg = append([]byte(nil), msg.Body...)
+
+	return nil
 }
 
 func (s *captureSocket) RecvMsg() (*mangos.Message, error) {
@@ -132,6 +138,15 @@ func (s *captureSocket) request() *clientRequest {
 	return req
 }
 
+func (s *captureSocket) response() *serverResponse {
+	resp := &serverResponse{}
+	dec := codec.NewDecoderBytes(s.sentMsg, s.ch)
+	err := dec.Decode(resp)
+	So(err, ShouldBeNil)
+
+	return resp
+}
+
 func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
 	Convey("Lifecycle methods send only keys and required state, not whole jobs", t, func() {
 		client, sock := newCaptureClient()
@@ -168,6 +183,47 @@ func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(killCalled, ShouldBeFalse)
 		assertTrimmedLifecycleRequest(sock.request(), "jtouch", job.Key(), "", touchEndState(job))
+	})
+}
+
+func TestServerRejectsKeyOnlyStartedRequest(t *testing.T) {
+	Convey("A malformed key-only jstart request is rejected instead of panicking", t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ch := new(codec.BincHandle)
+		token := bytes.Repeat([]byte("x"), tokenLength)
+		sock := &captureSocket{ch: ch}
+		server := &Server{
+			ch:    ch,
+			sock:  sock,
+			token: token,
+			q:     queue.New(ctx, "payload-trim-start"),
+			up:    true,
+		}
+		clientID, err := uuid.NewV4()
+		So(err, ShouldBeNil)
+
+		job := &Job{Cmd: "echo key-only-start", ReservedBy: clientID}
+		key := job.Key()
+		_, err = server.q.Add(ctx, key, "", job, 0, 0, time.Minute, queue.SubQueueRun)
+		So(err, ShouldBeNil)
+
+		var encoded []byte
+
+		enc := codec.NewEncoderBytes(&encoded, ch)
+		err = enc.Encode(&clientRequest{
+			Method:   requestMethodStart,
+			Token:    token,
+			ClientID: clientID,
+			Keys:     []string{key},
+		})
+		So(err, ShouldBeNil)
+
+		err = server.handleRequest(ctx, &mangos.Message{Body: encoded})
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, ErrBadRequest)
+		So(sock.response().Err, ShouldEqual, ErrBadRequest)
 	})
 }
 

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ugorji/go/codec"
+	"go.nanomsg.org/mangos/v3"
+)
+
+var errCaptureSocketUnsupported = errors.New("unsupported capture socket operation")
+
+type captureSocket struct {
+	ch   codec.Handle
+	sent []byte
+}
+
+func newCaptureClient() (*Client, *captureSocket) {
+	ch := new(codec.BincHandle)
+	sock := &captureSocket{ch: ch}
+	id, err := uuid.NewV4()
+	So(err, ShouldBeNil)
+
+	return &Client{ch: ch, clientid: id, sock: sock}, sock
+}
+
+func (s *captureSocket) Info() mangos.ProtocolInfo {
+	return mangos.ProtocolInfo{}
+}
+
+func (s *captureSocket) Close() error {
+	return nil
+}
+
+func (s *captureSocket) Send(msg []byte) error {
+	s.sent = append([]byte(nil), msg...)
+
+	return nil
+}
+
+func (s *captureSocket) Recv() ([]byte, error) {
+	var encoded []byte
+
+	enc := codec.NewEncoderBytes(&encoded, s.ch)
+
+	return encoded, enc.Encode(&serverResponse{})
+}
+
+func (s *captureSocket) SendMsg(_ *mangos.Message) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) RecvMsg() (*mangos.Message, error) {
+	return nil, errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) Dial(_ string) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) DialOptions(_ string, _ map[string]interface{}) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) NewDialer(_ string, _ map[string]interface{}) (mangos.Dialer, error) {
+	return nil, errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) Listen(_ string) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) ListenOptions(_ string, _ map[string]interface{}) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) NewListener(_ string, _ map[string]interface{}) (mangos.Listener, error) {
+	return nil, errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) GetOption(_ string) (interface{}, error) {
+	return nil, errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) SetOption(_ string, _ interface{}) error {
+	return errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) OpenContext() (mangos.Context, error) {
+	return nil, errCaptureSocketUnsupported
+}
+
+func (s *captureSocket) SetPipeEventHook(_ mangos.PipeEventHook) mangos.PipeEventHook {
+	return nil
+}
+
+func (s *captureSocket) request() *clientRequest {
+	req := &clientRequest{}
+	dec := codec.NewDecoderBytes(s.sent, s.ch)
+	err := dec.Decode(req)
+	So(err, ShouldBeNil)
+
+	return req
+}
+
+func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
+	Convey("Lifecycle methods send only keys and required state, not whole jobs", t, func() {
+		client, sock := newCaptureClient()
+		job := newLargePayloadJob(client.clientid)
+		key := job.Key()
+		endState := &JobEndState{
+			Cwd:      "/work/actual",
+			Exitcode: 0,
+			PeakRAM:  123,
+			PeakDisk: 456,
+			CPUtime:  7 * time.Second,
+			EndTime:  time.Now(),
+			Stdout:   []byte("stdout"),
+			Stderr:   []byte("stderr"),
+			Exited:   true,
+		}
+
+		So(client.Archive(job, endState), ShouldBeNil)
+		assertTrimmedLifecycleRequest(sock.request(), "jarchive", key, "", endState)
+
+		client, sock = newCaptureClient()
+		job = newLargePayloadJob(client.clientid)
+		So(client.Release(job, endState, "temporary"), ShouldBeNil)
+		assertTrimmedLifecycleRequest(sock.request(), "jrelease", job.Key(), "temporary", endState)
+
+		client, sock = newCaptureClient()
+		job = newLargePayloadJob(client.clientid)
+		So(client.Bury(job, endState, "permanent"), ShouldBeNil)
+		assertTrimmedLifecycleRequest(sock.request(), "jbury", job.Key(), "permanent", endState)
+
+		client, sock = newCaptureClient()
+		job = newLargePayloadJob(client.clientid)
+		killCalled, err := client.Touch(job)
+		So(err, ShouldBeNil)
+		So(killCalled, ShouldBeFalse)
+		assertTrimmedLifecycleRequest(sock.request(), "jtouch", job.Key(), "", touchEndState(job))
+	})
+}
+
+func newLargePayloadJob(clientID uuid.UUID) *Job {
+	return &Job{
+		Cmd:         strings.Repeat("echo payload ", 100),
+		Cwd:         "/work",
+		RepGroup:    "payload-trim",
+		Behaviours:  Behaviours{{When: OnSuccess, Do: Run, Arg: strings.Repeat("touch marker ", 100)}},
+		EnvC:        []byte(strings.Repeat("ENV=value", 100)),
+		StdOutC:     []byte(strings.Repeat("stdout", 100)),
+		StdErrC:     []byte(strings.Repeat("stderr", 100)),
+		PeakRAM:     11,
+		PeakDisk:    22,
+		CPUtime:     33 * time.Second,
+		UntilBuried: 2,
+		ReservedBy:  clientID,
+	}
+}
+
+func assertTrimmedLifecycleRequest(req *clientRequest, method, key, failReason string, endState *JobEndState) {
+	So(req.Method, ShouldEqual, method)
+	So(req.Keys, ShouldResemble, []string{key})
+	So(req.Job, ShouldBeNil)
+	So(req.FailReason, ShouldEqual, failReason)
+
+	if endState == nil {
+		So(req.JobEndState, ShouldBeNil)
+
+		return
+	}
+
+	So(req.JobEndState, ShouldNotBeNil)
+	So(req.JobEndState.PeakRAM, ShouldEqual, endState.PeakRAM)
+	So(req.JobEndState.PeakDisk, ShouldEqual, endState.PeakDisk)
+	So(req.JobEndState.CPUtime, ShouldEqual, endState.CPUtime)
+	So(req.JobEndState.Stdout, ShouldResemble, endState.Stdout)
+	So(req.JobEndState.Stderr, ShouldResemble, endState.Stderr)
+}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -552,8 +552,14 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 					clog.Debug(ctx, "reserved job", "cmd", job.Cmd, "schedGrp", sgroup)
 				}
 			} // else we'll return nothing, as if there were no jobs in the queue
-		case "jstart":
+		case requestMethodStart:
 			// update the job's cmd-started-related properties
+			if cr.Job == nil {
+				srerr = ErrBadRequest
+
+				break
+			}
+
 			var job *Job
 			_, job, srerr = s.getij(cr, true)
 			if srerr == "" {

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -683,7 +683,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 				if cr.JobEndState == nil {
 					cr.JobEndState = &JobEndState{}
 				}
-				errq := s.releaseJob(ctx, job, cr.JobEndState, cr.Job.FailReason, true, false)
+
+				errq := s.releaseJob(ctx, job, cr.JobEndState, cr.failReason(), true, false)
 				if errq != nil {
 					srerr = ErrInternalError
 
@@ -700,7 +701,7 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 					cr.JobEndState = &JobEndState{}
 				}
 
-				errq := s.releaseJob(ctx, job, cr.JobEndState, cr.Job.FailReason, true, true)
+				errq := s.releaseJob(ctx, job, cr.JobEndState, cr.failReason(), true, true)
 				if errq != nil {
 					srerr = ErrInternalError
 
@@ -1044,11 +1045,8 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 		if qerr == "" {
 			qerr = srerr
 		}
-		key := ""
-		if cr.Job != nil {
-			key = cr.Job.Key()
-		}
-		return Error{cr.Method, key, qerr}
+
+		return Error{cr.Method, cr.key(), qerr}
 	}
 
 	// some commands don't return anything to the client
@@ -1063,12 +1061,12 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 // for the many j* methods in handleRequest, we do this common stuff to get
 // the desired item and job. The returned string is one of our Err* constants.
 func (s *Server) getij(cr *clientRequest, checkRunning bool) (*queue.Item, *Job, string) {
-	// clientRequest must have a Job
-	if cr.Job == nil {
+	key := cr.key()
+	if key == "" {
 		return nil, nil, ErrBadRequest
 	}
 
-	item, err := s.q.Get(cr.Job.Key())
+	item, err := s.q.Get(key)
 	if err != nil || (checkRunning && item.Stats().State != queue.ItemStateRun) {
 		return item, nil, ErrBadJob
 	}


### PR DESCRIPTION
## Summary
- send lifecycle job keys instead of whole jobs for Archive/Release/Bury/Touch
- keep public client APIs unchanged while preserving fail reasons and end state
- keep Touch payload to key plus #98 live-introspection fields

Solves #290

## Tests
- timeout 5m env CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run TestClientLifecycleRequestsTrimJobPayload
- timeout 5m env CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run TestJobqueueBasics
- timeout 5m golangci-lint run --fix
- git diff --check
