### PR TITLE
Fix memory kill attribution

### DIFF
--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1056,11 +1056,9 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	var oomMonitor *cgroupOOMMonitor
 
-	if c.ServerInfo != nil && !schedulerNeedsSigkillMemoryFallback(c.ServerInfo.Scheduler) {
-		monitor, errm := newCgroupOOMMonitor(cmd.Process.Pid, procRoot, cgroupRoot)
-		if errm == nil {
-			oomMonitor = monitor
-		}
+	monitor, errm := newCgroupOOMMonitor(cmd.Process.Pid, procRoot, cgroupRoot)
+	if errm == nil {
+		oomMonitor = monitor
 	}
 
 	// update the server that we've started the job
@@ -1293,7 +1291,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					if commandExceededMemoryEstimate(peakmem, job.Requirements.RAM) {
 						exceededMemEstimate = true
 
-						// ... it both uses more than exepected and more than
+						// ... it both uses more than expected and more than
 						// 90% of physical memory, since we could screw up the
 						// machine we're running on
 						if machineRAM == 0 {

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -225,6 +225,18 @@ func (cr *clientRequest) failReason() string {
 	return cr.Job.FailReason
 }
 
+type serverContactState struct {
+	lost atomic.Bool
+}
+
+func (state *serverContactState) recordTouchResult(err error) {
+	state.lost.Store(err != nil)
+}
+
+func (state *serverContactState) schedulerMemoryFallbackAllowed() bool {
+	return !state.lost.Load()
+}
+
 // Client represents the client side of the socket that the jobqueue server is
 // Serve()ing, specific to a particular queue.
 type Client struct {
@@ -749,7 +761,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	var wkbsMutex sync.RWMutex
 
-	var serverContactLost atomic.Bool
+	serverContact := &serverContactState{}
 	killDoneCh := make(chan bool, 1)
 	whenKilledByServer := func() {
 		killDoneCh <- true
@@ -773,10 +785,12 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if errf != nil {
 					// we may have lost contact with the manager; this is OK. We
 					// will keep trying to touch until it works
-					serverContactLost.Store(true)
+					serverContact.recordTouchResult(errf)
 					clog.Warn(ctx, "could not touch", "err", errf)
 					continue
 				}
+
+				serverContact.recordTouchResult(nil)
 			case <-stopTouching:
 				touchTicker.Stop()
 				return
@@ -1493,7 +1507,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					schedulerName = c.ServerInfo.Scheduler
 				}
 
-				allowSchedulerMemoryFallback := !serverContactLost.Load()
+				allowSchedulerMemoryFallback := serverContact.schedulerMemoryFallbackAllowed()
 
 				switch exitcode {
 				case exitCodeCommandPermission:

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1551,7 +1551,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					):
 						failreason = FailReasonRAM
 						myerr = Error{"Execute", job.Key(), FailReasonRAM}
-					case waitStatus.Signaled(): //nolint:misspell
+					case waitStatus.Signaled(): //nolint:misspell // Signaled is syscall's method name.
 						failreason = FailReasonSignal
 						shellExitCode := shellSignalExitCodeOffset + int(waitStatus.Signal())
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1050,6 +1050,15 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	clog.Info(ctx, "started executing", "cmd", job.Cmd, "pid", cmd.Process.Pid)
 
+	var oomMonitor *cgroupOOMMonitor
+
+	if c.ServerInfo != nil && !schedulerNeedsSigkillMemoryFallback(c.ServerInfo.Scheduler) {
+		monitor, errm := newCgroupOOMMonitor(cmd.Process.Pid, procRoot, cgroupRoot)
+		if errm == nil {
+			oomMonitor = monitor
+		}
+	}
+
 	// update the server that we've started the job
 	err = c.Started(job, cmd.Process.Pid)
 	if err != nil {
@@ -1069,15 +1078,6 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			extra += fmt.Sprintf(" (and unmounting the job failed: %s)", erru)
 		}
 		return fmt.Errorf("command [%s] started running, but I killed it due to a jobqueue server error: %w%s", job.Cmd, err, extra)
-	}
-
-	var oomMonitor *cgroupOOMMonitor
-
-	if c.ServerInfo != nil && !schedulerNeedsSigkillMemoryFallback(c.ServerInfo.Scheduler) {
-		monitor, errm := newCgroupOOMMonitor(cmd.Process.Pid, procRoot, cgroupRoot)
-		if errm == nil {
-			oomMonitor = monitor
-		}
 	}
 
 	// update peak mem and disk used by command, and check if we use too much
@@ -1521,7 +1521,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					dorelease = true
 
 					switch {
-					case attributedMemoryDeath(killedForMem, cgroupOOM, waitStatus, peakmem, job.Requirements.RAM, schedulerName):
+					case killedForMem:
 						failreason = FailReasonRAM
 						myerr = Error{"Execute", job.Key(), FailReasonRAM}
 					case ranoutDisk:
@@ -1535,13 +1535,16 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 							failreason = FailReasonSignal
 							myerr = Error{"Execute", job.Key(), FailReasonSignal}
 						}
-					case waitStatus.Signaled(): //nolint:misspell
-						failreason = FailReasonSignal
-						myerr = Error{"Execute", job.Key(), FailReasonSignal}
 					case killCalled:
 						dobury = true
 						failreason = FailReasonKilled
 						myerr = Error{"Execute", job.Key(), FailReasonKilled}
+					case attributedMemoryDeath(false, cgroupOOM, waitStatus, peakmem, job.Requirements.RAM, schedulerName):
+						failreason = FailReasonRAM
+						myerr = Error{"Execute", job.Key(), FailReasonRAM}
+					case waitStatus.Signaled(): //nolint:misspell
+						failreason = FailReasonSignal
+						myerr = Error{"Execute", job.Key(), FailReasonSignal}
 					case job.UntilBuried > 1 && job.NoRetriesOverWalltime > 0 && job.WallTime() > job.NoRetriesOverWalltime:
 						dobury = true
 						failreason = FailReasonExit

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1553,10 +1553,12 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 						myerr = Error{"Execute", job.Key(), FailReasonRAM}
 					case waitStatus.Signaled(): //nolint:misspell
 						failreason = FailReasonSignal
+						shellExitCode := shellSignalExitCodeOffset + int(waitStatus.Signal())
+
 						//nolint:err113
 						myerr = fmt.Errorf(
-							"command [%s] exited with code %d after receiving signal %s%s%s",
-							job.Cmd, exitcode, waitStatus.Signal(), mayBeTemp, cmdOut,
+							"command [%s] terminated by signal %s (shell exit code %d)%s%s",
+							job.Cmd, waitStatus.Signal(), shellExitCode, mayBeTemp, cmdOut,
 						)
 					case job.UntilBuried > 1 && job.NoRetriesOverWalltime > 0 && job.WallTime() > job.NoRetriesOverWalltime:
 						dobury = true

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -48,6 +48,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -747,6 +748,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	touchTicker := time.NewTicker(c.touchInterval) // server-provided default (< its ItemTTR), overridable per client
 
 	var wkbsMutex sync.RWMutex
+
+	var serverContactLost atomic.Bool
 	killDoneCh := make(chan bool, 1)
 	whenKilledByServer := func() {
 		killDoneCh <- true
@@ -770,6 +773,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if errf != nil {
 					// we may have lost contact with the manager; this is OK. We
 					// will keep trying to touch until it works
+					serverContactLost.Store(true)
 					clog.Warn(ctx, "could not touch", "err", errf)
 					continue
 				}
@@ -1491,6 +1495,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					schedulerName = c.ServerInfo.Scheduler
 				}
 
+				allowSchedulerMemoryFallback := !serverContactLost.Load()
+
 				switch exitcode {
 				case exitCodeCommandPermission:
 					dobury = true
@@ -1521,9 +1527,6 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					dorelease = true
 
 					switch {
-					case killedForMem:
-						failreason = FailReasonRAM
-						myerr = Error{"Execute", job.Key(), FailReasonRAM}
 					case ranoutDisk:
 						failreason = FailReasonDisk
 						myerr = Error{"Execute", job.Key(), FailReasonDisk}
@@ -1539,7 +1542,15 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 						dobury = true
 						failreason = FailReasonKilled
 						myerr = Error{"Execute", job.Key(), FailReasonKilled}
-					case attributedMemoryDeath(false, cgroupOOM, waitStatus, peakmem, job.Requirements.RAM, schedulerName):
+					case attributedMemoryDeath(
+						killedForMem,
+						cgroupOOM,
+						waitStatus,
+						peakmem,
+						job.Requirements.RAM,
+						schedulerName,
+						allowSchedulerMemoryFallback,
+					):
 						failreason = FailReasonRAM
 						myerr = Error{"Execute", job.Key(), FailReasonRAM}
 					case waitStatus.Signaled(): //nolint:misspell

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -127,6 +127,12 @@ const (
 )
 
 const (
+	exitCodeCommandPermission = 126
+	exitCodeCommandNotFound   = 127
+	exitCodeCommandInvalid    = 128
+)
+
+const (
 	RepGroupMatchExact  RepGroupMatch = "exact"
 	RepGroupMatchSubStr RepGroupMatch = "substr"
 	RepGroupMatchPrefix RepGroupMatch = "prefix"
@@ -1065,6 +1071,15 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return fmt.Errorf("command [%s] started running, but I killed it due to a jobqueue server error: %w%s", job.Cmd, err, extra)
 	}
 
+	var oomMonitor *cgroupOOMMonitor
+
+	if c.ServerInfo != nil && !schedulerNeedsSigkillMemoryFallback(c.ServerInfo.Scheduler) {
+		monitor, errm := newCgroupOOMMonitor(cmd.Process.Pid, procRoot, cgroupRoot)
+		if errm == nil {
+			oomMonitor = monitor
+		}
+	}
+
 	// update peak mem and disk used by command, and check if we use too much
 	// resources, every second. Also check for signals
 	peakmem := 0
@@ -1072,7 +1087,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	dockerCPU := 0
 	resourceTicker := time.NewTicker(1 * time.Second)
 	machineRAM := 0
-	ranoutMem := false
+	exceededMemEstimate := false
+	killedForMem := false
 	ranoutTime := false
 	ranoutDisk := false
 	signalled := false
@@ -1270,10 +1286,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if errf == nil && mem > peakmem {
 					peakmem = mem
 
-					if peakmem > job.Requirements.RAM {
-						// if we later fail we'll assume it's because we used
-						// too much memory, but won't kill the cmd unless...
-						ranoutMem = true
+					if commandExceededMemoryEstimate(peakmem, job.Requirements.RAM) {
+						exceededMemEstimate = true
 
 						// ... it both uses more than exepected and more than
 						// 90% of physical memory, since we could screw up the
@@ -1287,6 +1301,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 						if machineRAM > 0 && peakmem >= ((machineRAM/100)*c.percentMemoryKill) { //nolint:mnd
 							killErr = killCmd()
+							killedForMem = true
 							stateMutex.Unlock()
 							break CHECKING
 						}
@@ -1355,6 +1370,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	if errd == nil && finalDisk > peakdisk {
 		peakdisk = finalDisk
 	}
+
+	exceededMemEstimate = commandExceededMemoryEstimate(peakmem, job.Requirements.RAM)
 
 	// get the exit code and figure out what to do with the Job
 	var exitcode int
@@ -1459,48 +1476,89 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			exitcode = exitError.Sys().(syscall.WaitStatus).ExitStatus()
-			switch exitcode {
-			case 126:
-				dobury = true
-				failreason = FailReasonCPerm
-				myerr = fmt.Errorf("command [%s] exited with code %d (permission problem, or command is not executable), which seems permanent, so it has been buried%s", job.Cmd, exitcode, cmdOut)
-			case 127:
-				dobury = true
-				failreason = FailReasonCFound
-				myerr = fmt.Errorf("command [%s] exited with code %d (command not found), which seems permanent, so it has been buried%s", job.Cmd, exitcode, cmdOut)
-			case 128:
-				dobury = true
-				failreason = FailReasonCExit
-				myerr = fmt.Errorf("command [%s] exited with code %d (invalid exit code), which seems permanent, so it has been buried%s", job.Cmd, exitcode, cmdOut)
-			default:
+			waitStatus, ok := exitError.Sys().(syscall.WaitStatus)
+			if !ok {
+				exitcode = 255
 				dorelease = true
-				switch {
-				case ranoutMem:
-					failreason = FailReasonRAM
-					myerr = Error{"Execute", job.Key(), FailReasonRAM}
-				case ranoutDisk:
-					failreason = FailReasonDisk
-					myerr = Error{"Execute", job.Key(), FailReasonDisk}
-				case signalled:
-					if ranoutTime {
-						failreason = FailReasonTime
-						myerr = Error{"Execute", job.Key(), FailReasonTime}
-					} else {
+				failreason = FailReasonAbnormal
+				myerr = fmt.Errorf("command [%s] failed to complete normally (%w)%s%s", job.Cmd, err, mayBeTemp, cmdOut)
+			} else {
+				exitcode = waitStatus.ExitStatus()
+				cgroupOOM := oomMonitor.oomKillIncreased()
+
+				schedulerName := ""
+				if c.ServerInfo != nil {
+					schedulerName = c.ServerInfo.Scheduler
+				}
+
+				switch exitcode {
+				case exitCodeCommandPermission:
+					dobury = true
+					failreason = FailReasonCPerm
+					//nolint:err113
+					myerr = fmt.Errorf(
+						"command [%s] exited with code %d (permission problem, or command is not executable), "+
+							"which seems permanent, so it has been buried%s",
+						job.Cmd, exitcode, cmdOut,
+					)
+				case exitCodeCommandNotFound:
+					dobury = true
+					failreason = FailReasonCFound
+					//nolint:err113
+					myerr = fmt.Errorf(
+						"command [%s] exited with code %d (command not found), which seems permanent, so it has been buried%s",
+						job.Cmd, exitcode, cmdOut,
+					)
+				case exitCodeCommandInvalid:
+					dobury = true
+					failreason = FailReasonCExit
+					//nolint:err113
+					myerr = fmt.Errorf(
+						"command [%s] exited with code %d (invalid exit code), which seems permanent, so it has been buried%s",
+						job.Cmd, exitcode, cmdOut,
+					)
+				default:
+					dorelease = true
+
+					switch {
+					case attributedMemoryDeath(killedForMem, cgroupOOM, waitStatus, peakmem, job.Requirements.RAM, schedulerName):
+						failreason = FailReasonRAM
+						myerr = Error{"Execute", job.Key(), FailReasonRAM}
+					case ranoutDisk:
+						failreason = FailReasonDisk
+						myerr = Error{"Execute", job.Key(), FailReasonDisk}
+					case signalled:
+						if ranoutTime {
+							failreason = FailReasonTime
+							myerr = Error{"Execute", job.Key(), FailReasonTime}
+						} else {
+							failreason = FailReasonSignal
+							myerr = Error{"Execute", job.Key(), FailReasonSignal}
+						}
+					case waitStatus.Signaled(): //nolint:misspell
 						failreason = FailReasonSignal
 						myerr = Error{"Execute", job.Key(), FailReasonSignal}
+					case killCalled:
+						dobury = true
+						failreason = FailReasonKilled
+						myerr = Error{"Execute", job.Key(), FailReasonKilled}
+					case job.UntilBuried > 1 && job.NoRetriesOverWalltime > 0 && job.WallTime() > job.NoRetriesOverWalltime:
+						dobury = true
+						failreason = FailReasonExit
+						//nolint:err113
+						myerr = fmt.Errorf(
+							"command [%s] exited with code %d%s%s",
+							job.Cmd, exitcode, ", after the noretries time, so will not be tried again", cmdOut,
+						)
+					default:
+						failreason = FailReasonExit
+						//nolint:err113
+						myerr = fmt.Errorf("command [%s] exited with code %d%s%s", job.Cmd, exitcode, mayBeTemp, cmdOut)
 					}
-				case killCalled:
-					dobury = true
-					failreason = FailReasonKilled
-					myerr = Error{"Execute", job.Key(), FailReasonKilled}
-				case job.UntilBuried > 1 && job.NoRetriesOverWalltime > 0 && job.WallTime() > job.NoRetriesOverWalltime:
-					dobury = true
-					failreason = FailReasonExit
-					myerr = fmt.Errorf("command [%s] exited with code %d%s%s", job.Cmd, exitcode, ", after the noretries time, so will not be be tried again", cmdOut)
-				default:
-					failreason = FailReasonExit
-					myerr = fmt.Errorf("command [%s] exited with code %d%s%s", job.Cmd, exitcode, mayBeTemp, cmdOut)
+
+					if failreason != FailReasonRAM && exceededMemEstimate {
+						myerr = appendHighMemoryNote(myerr, peakmem, job.Requirements.RAM)
+					}
 				}
 			}
 		} else {

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1544,7 +1544,11 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 						myerr = Error{"Execute", job.Key(), FailReasonRAM}
 					case waitStatus.Signaled(): //nolint:misspell
 						failreason = FailReasonSignal
-						myerr = Error{"Execute", job.Key(), FailReasonSignal}
+						//nolint:err113
+						myerr = fmt.Errorf(
+							"command [%s] exited with code %d after receiving signal %s%s%s",
+							job.Cmd, exitcode, waitStatus.Signal(), mayBeTemp, cmdOut,
+						)
 					case job.UntilBuried > 1 && job.NoRetriesOverWalltime > 0 && job.WallTime() > job.NoRetriesOverWalltime:
 						dobury = true
 						failreason = FailReasonExit

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -1487,7 +1487,7 @@ func TestJobqueueSignal(t *testing.T) {
 						return
 					}
 
-					t.Logf("job2 had err %s, expected %q", erre, expectedSignalErr)
+					t.Logf("job2 had err %v, expected %q", erre, expectedSignalErr)
 					j2worked <- false
 					return
 				case <-giveUp2:

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -1477,11 +1477,17 @@ func TestJobqueueSignal(t *testing.T) {
 				}()
 				select {
 				case erre := <-errch:
-					if erre != nil && strings.Contains(erre.Error(), "exited with code -1") {
+					expectedSignalErr := fmt.Sprintf(
+						"terminated by signal %s (shell exit code %d)",
+						syscall.SIGKILL,
+						shellSignalExitCodeOffset+int(syscall.SIGKILL),
+					)
+					if erre != nil && strings.Contains(erre.Error(), expectedSignalErr) {
 						j2worked <- true
 						return
 					}
-					fmt.Printf("\njob2 had err %s\n", erre)
+
+					t.Logf("job2 had err %s, expected %q", erre, expectedSignalErr)
 					j2worked <- false
 					return
 				case <-giveUp2:
@@ -4925,8 +4931,14 @@ func TestJobqueueModify(t *testing.T) {
 				return
 			}
 
-			addJobs = append(addJobs, &Job{Cmd: "echo a && false", Cwd: tmp, ReqGroup: "rgroup", Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "a"})
-			addJobs = append(addJobs, &Job{Cmd: "echo b && false", Cwd: tmp, ReqGroup: "rgroup", Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "b"})
+			addJobs = append(addJobs, &Job{
+				Cmd: "echo a && false", Cwd: tmp, ReqGroup: "rgroup",
+				Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "a",
+			})
+			addJobs = append(addJobs, &Job{
+				Cmd: "echo b && false", Cwd: tmp, ReqGroup: "rgroup",
+				Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "b",
+			})
 			add(2)
 
 			jm.SetCmd("echo b && false")

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -2640,11 +2640,21 @@ func TestJobqueueMedium(t *testing.T) {
 
 				err = jq.Execute(ctx, job, config.RunnerExecShell)
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "command [sleep 0.1 && false] exited with code 1, which may be a temporary issue, so it will be tried again")
+
+				expectedErrPrefix := "command [sleep 0.1 && false] exited with code 1, " +
+					"which may be a temporary issue, so it will be tried again"
+				So(err.Error(), ShouldStartWith, expectedErrPrefix)
 				So(job.State, ShouldEqual, JobStateDelayed)
 				So(job.Exited, ShouldBeTrue)
 				So(job.Exitcode, ShouldEqual, 1)
+				So(job.FailReason, ShouldEqual, FailReasonExit)
 				So(job.PeakRAM, ShouldBeGreaterThan, 0)
+
+				if job.PeakRAM > job.Requirements.RAM {
+					So(err.Error(), ShouldContainSubstring, FailReasonRAM)
+				} else {
+					So(err.Error(), ShouldNotContainSubstring, FailReasonRAM)
+				}
 				So(job.Pid, ShouldBeGreaterThan, 0)
 				So(job.Host, ShouldEqual, host)
 				So(job.WallTime(), ShouldBeGreaterThanOrEqualTo, 1*time.Millisecond)
@@ -2859,9 +2869,19 @@ func TestJobqueueMedium(t *testing.T) {
 
 					err = jq.Execute(ctx, job, config.RunnerExecShell)
 					So(err, ShouldNotBeNil)
-					So(err.Error(), ShouldEqual, "command [sleep 0.5 && false] exited with code 1, after the noretries time, so will not be be tried again")
+
+					expectedErrPrefix := "command [sleep 0.5 && false] exited with code 1, " +
+						"after the noretries time, so will not be tried again"
+					So(err.Error(), ShouldStartWith, expectedErrPrefix)
 					So(job.State, ShouldEqual, JobStateBuried)
 					So(job.Exited, ShouldBeTrue)
+					So(job.FailReason, ShouldEqual, FailReasonExit)
+
+					if job.PeakRAM > job.Requirements.RAM {
+						So(err.Error(), ShouldContainSubstring, FailReasonRAM)
+					} else {
+						So(err.Error(), ShouldNotContainSubstring, FailReasonRAM)
+					}
 				})
 			})
 
@@ -2915,11 +2935,20 @@ func TestJobqueueMedium(t *testing.T) {
 
 					err = jq.Execute(ctx, job, config.RunnerExecShell)
 					So(err, ShouldNotBeNil)
-					So(err.Error(), ShouldEqual, "command [sleep 0.1 && true | false | true] exited with code 1, which may be a temporary issue, so it will be tried again") //*** can fail with a receive time out; why?!
+
+					expectedErrPrefix := "command [sleep 0.1 && true | false | true] exited with code 1, " +
+						"which may be a temporary issue, so it will be tried again"
+					So(err.Error(), ShouldStartWith, expectedErrPrefix) // *** can fail with a receive time out; why?!
 					So(job.State, ShouldEqual, JobStateDelayed)
 					So(job.Exited, ShouldBeTrue)
 					So(job.Exitcode, ShouldEqual, 1)
 					So(job.FailReason, ShouldEqual, FailReasonExit)
+
+					if job.PeakRAM > job.Requirements.RAM {
+						So(err.Error(), ShouldContainSubstring, FailReasonRAM)
+					} else {
+						So(err.Error(), ShouldNotContainSubstring, FailReasonRAM)
+					}
 				})
 
 				Convey("Invalid commands are immediately buried", func() {
@@ -4665,6 +4694,7 @@ func TestJobqueueModify(t *testing.T) {
 	learnedRAMNormal := 100
 	learnedRAMExtraRange := []int{200, 500}
 	tmp := "/tmp"
+	echoACmd := "echo a"
 
 	Convey("Once a new jobqueue server is up and client is connected", t, func() {
 		serverConfig.Timings.ItemTTR = 5 * time.Second
@@ -4955,7 +4985,7 @@ func TestJobqueueModify(t *testing.T) {
 				return
 			}
 
-			cmd := "echo a"
+			cmd := echoACmd
 			addJobs = append(addJobs, &Job{Cmd: cmd, Cwd: tmp, ReqGroup: "initial", Requirements: standardReqs, Override: uint8(0), Retries: uint8(0), RepGroup: "a"})
 			add(1)
 
@@ -4988,7 +5018,7 @@ func TestJobqueueModify(t *testing.T) {
 			// not actually using a scheduler to determine when and if jobs are
 			// allowed to run, so we're just doing a basic test that the reqs
 			// of the job change appropriately
-			cmd := "echo a"
+			cmd := echoACmd
 			addJobs = append(addJobs, &Job{Cmd: cmd, Cwd: tmp, ReqGroup: "rgroup", Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "a"})
 			add(1)
 
@@ -5099,12 +5129,15 @@ func TestJobqueueModify(t *testing.T) {
 				return
 			}
 
-			addJobs = append(addJobs, &Job{Cmd: "echo a", Cwd: tmp, ReqGroup: "rgroup", Requirements: standardReqs, Override: uint8(2), Retries: uint8(0), RepGroup: "a", DepGroups: []string{"a"}})
+			addJobs = append(addJobs, &Job{
+				Cmd: echoACmd, Cwd: tmp, ReqGroup: "rgroup", Requirements: standardReqs,
+				Override: uint8(2), Retries: uint8(0), RepGroup: "a", DepGroups: []string{"a"},
+			})
 			addJobs = append(addJobs, &Job{Cmd: "echo b", Cwd: tmp, ReqGroup: "rgroup", Requirements: &jqs.Requirements{RAM: 400, Time: 10 * time.Second, Cores: 1, Disk: 0, Other: make(map[string]string)}, Override: uint8(2), Retries: uint8(0), RepGroup: "b", DepGroups: []string{"b"}})
 			addJobs = append(addJobs, &Job{Cmd: "echo c", Cwd: tmp, ReqGroup: "rgroup", Requirements: &jqs.Requirements{RAM: 800, Time: 10 * time.Second, Cores: 1, Disk: 0, Other: make(map[string]string)}, Override: uint8(2), Retries: uint8(0), RepGroup: "c", Dependencies: groupsToDeps("a,b")})
 			add(3)
 
-			jobA := reserve(rgroup, "echo a")
+			jobA := reserve(rgroup, echoACmd)
 			reserve("500:30:1:0", "echo b")
 
 			jobC, err := jq.ReserveScheduled(rtime, "900:30:1:0")

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -207,7 +207,6 @@ func schedulerNeedsSigkillMemoryFallback(scheduler string) bool {
 }
 
 func sigkillMemoryFallback(status syscall.WaitStatus, peakRAM, requiredRAM int) bool {
-	return status.Signaled() && //nolint:misspell
-		status.Signal() == syscall.SIGKILL &&
+	return oomCompatibleExitStatus(status) &&
 		peakRAM >= requiredRAM
 }

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -48,6 +48,8 @@ const (
 
 var errCgroupOOMKillCountMissing = errors.New("cgroup OOM kill count missing")
 
+const shellSignalExitCodeOffset = 128
+
 type cgroupOOMCounter struct {
 	path    string
 	key     string
@@ -179,7 +181,7 @@ func attributedMemoryDeath(
 	allowSchedulerFallback bool,
 ) bool {
 	if cgroupOOM {
-		return true
+		return oomCompatibleExitStatus(status)
 	}
 
 	if wrKilledForMemory {
@@ -189,6 +191,15 @@ func attributedMemoryDeath(
 	return allowSchedulerFallback &&
 		schedulerNeedsSigkillMemoryFallback(scheduler) &&
 		sigkillMemoryFallback(status, peakRAM, requiredRAM)
+}
+
+func oomCompatibleExitStatus(status syscall.WaitStatus) bool {
+	if status.Signaled() && status.Signal() == syscall.SIGKILL { //nolint:misspell
+		return true
+	}
+
+	return status.Exited() &&
+		status.ExitStatus() == shellSignalExitCodeOffset+int(syscall.SIGKILL)
 }
 
 func schedulerNeedsSigkillMemoryFallback(scheduler string) bool {

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	cgroupV2OOMKillKey = "oom_kill"
-	cgroupV1OOMKillKey = "oom_kill"
+	cgroupOOMKillKey   = "oom_kill"
+	cgroupV2OOMKillKey = cgroupOOMKillKey
+	cgroupV1OOMKillKey = cgroupOOMKillKey
 	cgroupLineParts    = 3
 )
 

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -26,7 +26,6 @@
 package jobqueue
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,14 +39,13 @@ const (
 	cgroupV2OOMKillKey = cgroupOOMKillKey
 	cgroupV1OOMKillKey = cgroupOOMKillKey
 	cgroupLineParts    = 3
+	cgroupOOMMissing   = "cgroup OOM kill count missing"
 )
 
 const (
 	procRoot   = "/proc"
 	cgroupRoot = "/sys/fs/cgroup"
 )
-
-var errCgroupOOMKillCountMissing = errors.New("cgroup OOM kill count missing")
 
 const shellSignalExitCodeOffset = 128
 
@@ -82,6 +80,15 @@ func cgroupOOMCounterFromLine(line, root string) (cgroupOOMCounter, bool) {
 	}
 
 	return cgroupOOMCounter{}, false
+}
+
+type cgroupOOMKillCountMissingError struct {
+	key  string
+	path string
+}
+
+func (err cgroupOOMKillCountMissingError) Error() string {
+	return fmt.Sprintf("%s: %s in %s", cgroupOOMMissing, err.key, err.path)
 }
 
 type cgroupOOMMonitor struct {
@@ -157,7 +164,7 @@ func readCgroupOOMKillCount(path, key string) (uint64, error) {
 		return count, nil
 	}
 
-	return 0, fmt.Errorf("%w: %s in %s", errCgroupOOMKillCountMissing, key, path)
+	return 0, cgroupOOMKillCountMissingError{key: key, path: path}
 }
 
 func appendHighMemoryNote(err error, peakRAM, requiredRAM int) error {

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -176,6 +176,7 @@ func attributedMemoryDeath(
 	peakRAM int,
 	requiredRAM int,
 	scheduler string,
+	allowSchedulerFallback bool,
 ) bool {
 	if cgroupOOM {
 		return true
@@ -185,7 +186,8 @@ func attributedMemoryDeath(
 		return sigkillMemoryFallback(status, peakRAM, requiredRAM)
 	}
 
-	return schedulerNeedsSigkillMemoryFallback(scheduler) &&
+	return allowSchedulerFallback &&
+		schedulerNeedsSigkillMemoryFallback(scheduler) &&
 		sigkillMemoryFallback(status, peakRAM, requiredRAM)
 }
 

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	cgroupV2OOMKillKey = "oom_kill"
+	cgroupV1OOMKillKey = "oom_kill"
+	cgroupLineParts    = 3
+)
+
+const (
+	procRoot   = "/proc"
+	cgroupRoot = "/sys/fs/cgroup"
+)
+
+var errCgroupOOMKillCountMissing = errors.New("cgroup OOM kill count missing")
+
+type cgroupOOMCounter struct {
+	path    string
+	key     string
+	initial uint64
+}
+
+func cgroupOOMCounterFromLine(line, root string) (cgroupOOMCounter, bool) {
+	parts := strings.Split(line, ":")
+	if len(parts) != cgroupLineParts {
+		return cgroupOOMCounter{}, false
+	}
+
+	cgroupPath := strings.TrimPrefix(parts[2], "/")
+	if parts[0] == "0" && parts[1] == "" {
+		return cgroupOOMCounter{
+			path: filepath.Join(root, cgroupPath, "memory.events"),
+			key:  cgroupV2OOMKillKey,
+		}, true
+	}
+
+	controllers := strings.Split(parts[1], ",")
+	for _, controller := range controllers {
+		if controller == "memory" {
+			return cgroupOOMCounter{
+				path: filepath.Join(root, "memory", cgroupPath, "memory.oom_control"),
+				key:  cgroupV1OOMKillKey,
+			}, true
+		}
+	}
+
+	return cgroupOOMCounter{}, false
+}
+
+type cgroupOOMMonitor struct {
+	counters []cgroupOOMCounter
+}
+
+func newCgroupOOMMonitor(pid int, proc, cgroup string) (*cgroupOOMMonitor, error) {
+	data, err := os.ReadFile(filepath.Join(proc, strconv.Itoa(pid), "cgroup"))
+	if err != nil {
+		return nil, err
+	}
+
+	var counters []cgroupOOMCounter
+
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		counter, ok := cgroupOOMCounterFromLine(line, cgroup)
+		if !ok {
+			continue
+		}
+
+		count, errc := readCgroupOOMKillCount(counter.path, counter.key)
+		if errc != nil {
+			continue
+		}
+
+		counter.initial = count
+		counters = append(counters, counter)
+	}
+
+	if len(counters) == 0 {
+		return nil, os.ErrNotExist
+	}
+
+	return &cgroupOOMMonitor{counters: counters}, nil
+}
+
+func (m *cgroupOOMMonitor) oomKillIncreased() bool {
+	if m == nil {
+		return false
+	}
+
+	for _, counter := range m.counters {
+		current, err := readCgroupOOMKillCount(counter.path, counter.key)
+		if err != nil {
+			continue
+		}
+
+		if current > counter.initial {
+			return true
+		}
+	}
+
+	return false
+}
+
+func readCgroupOOMKillCount(path, key string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != key {
+			continue
+		}
+
+		count, errp := strconv.ParseUint(fields[1], 10, 64)
+		if errp != nil {
+			return 0, errp
+		}
+
+		return count, nil
+	}
+
+	return 0, fmt.Errorf("%w: %s in %s", errCgroupOOMKillCountMissing, key, path)
+}
+
+func appendHighMemoryNote(err error, peakRAM, requiredRAM int) error {
+	if err == nil || !commandExceededMemoryEstimate(peakRAM, requiredRAM) {
+		return err
+	}
+
+	return fmt.Errorf("%w; %s", err, FailReasonRAM)
+}
+
+func commandExceededMemoryEstimate(peakRAM, requiredRAM int) bool {
+	return peakRAM > requiredRAM
+}
+
+func attributedMemoryDeath(
+	wrKilledForMemory bool,
+	cgroupOOM bool,
+	status syscall.WaitStatus,
+	peakRAM int,
+	requiredRAM int,
+	scheduler string,
+) bool {
+	if wrKilledForMemory || cgroupOOM {
+		return true
+	}
+
+	return schedulerNeedsSigkillMemoryFallback(scheduler) &&
+		sigkillMemoryFallback(status, peakRAM, requiredRAM)
+}
+
+func schedulerNeedsSigkillMemoryFallback(scheduler string) bool {
+	return scheduler == "" || scheduler == "local" || scheduler == "openstack"
+}
+
+func sigkillMemoryFallback(status syscall.WaitStatus, peakRAM, requiredRAM int) bool {
+	return status.Signaled() && //nolint:misspell
+		status.Signal() == syscall.SIGKILL &&
+		peakRAM >= requiredRAM
+}

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -162,7 +162,7 @@ func appendHighMemoryNote(err error, peakRAM, requiredRAM int) error {
 		return err
 	}
 
-	return fmt.Errorf("%w; %s", err, FailReasonRAM)
+	return fmt.Errorf("%w; note: %s", err, FailReasonRAM)
 }
 
 func commandExceededMemoryEstimate(peakRAM, requiredRAM int) bool {
@@ -177,8 +177,12 @@ func attributedMemoryDeath(
 	requiredRAM int,
 	scheduler string,
 ) bool {
-	if wrKilledForMemory || cgroupOOM {
+	if cgroupOOM {
 		return true
+	}
+
+	if wrKilledForMemory {
+		return sigkillMemoryFallback(status, peakRAM, requiredRAM)
 	}
 
 	return schedulerNeedsSigkillMemoryFallback(scheduler) &&

--- a/jobqueue/memory_attribution.go
+++ b/jobqueue/memory_attribution.go
@@ -194,7 +194,7 @@ func attributedMemoryDeath(
 }
 
 func oomCompatibleExitStatus(status syscall.WaitStatus) bool {
-	if status.Signaled() && status.Signal() == syscall.SIGKILL { //nolint:misspell
+	if status.Signaled() && status.Signal() == syscall.SIGKILL { //nolint:misspell // Signaled is syscall's method name.
 		return true
 	}
 

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -143,6 +143,25 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		So(attributedMemoryDeath(false, true, status, 50, 100, "local", false), ShouldBeTrue)
 	})
 
+	Convey("Scheduler SIGKILL fallback is restored after a successful touch", t, func() {
+		status := syscall.WaitStatus(syscall.SIGKILL)
+		contact := &serverContactState{}
+
+		So(contact.schedulerMemoryFallbackAllowed(), ShouldBeTrue)
+
+		contact.recordTouchResult(os.ErrClosed)
+		So(contact.schedulerMemoryFallbackAllowed(), ShouldBeFalse)
+		attributed := attributedMemoryDeath(false, false, status, 200, 100, "local",
+			contact.schedulerMemoryFallbackAllowed())
+		So(attributed, ShouldBeFalse)
+
+		contact.recordTouchResult(nil)
+		So(contact.schedulerMemoryFallbackAllowed(), ShouldBeTrue)
+		attributed = attributedMemoryDeath(false, false, status, 200, 100, "local",
+			contact.schedulerMemoryFallbackAllowed())
+		So(attributed, ShouldBeTrue)
+	})
+
 	Convey("A non-SIGKILL signal with high peak is not attributed to RAM", t, func() {
 		status := syscall.WaitStatus(syscall.SIGTERM)
 

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -123,18 +123,23 @@ func TestMemoryFailureAttribution(t *testing.T) {
 
 	Convey("Local and cloud schedulers use SIGKILL plus high peak as the memory fallback", t, func() {
 		status := syscall.WaitStatus(syscall.SIGKILL)
+		shellSIGKILL := syscall.WaitStatus((shellSignalExitCodeOffset + int(syscall.SIGKILL)) << 8)
 
 		So(attributedMemoryDeath(false, false, status, 200, 100, "local", true), ShouldBeTrue)
 		So(attributedMemoryDeath(false, false, status, 200, 100, "openstack", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, shellSIGKILL, 200, 100, "local", true), ShouldBeTrue)
 		So(attributedMemoryDeath(false, false, status, 100, 100, "local", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, shellSIGKILL, 50, 100, "local", true), ShouldBeFalse)
 		So(attributedMemoryDeath(false, false, status, 50, 100, "local", true), ShouldBeFalse)
 		So(attributedMemoryDeath(false, false, status, 200, 100, "lsf", true), ShouldBeFalse)
 	})
 
 	Convey("Scheduler SIGKILL fallback is suppressed after server contact is lost", t, func() {
 		status := syscall.WaitStatus(syscall.SIGKILL)
+		shellSIGKILL := syscall.WaitStatus((shellSignalExitCodeOffset + int(syscall.SIGKILL)) << 8)
 
 		So(attributedMemoryDeath(false, false, status, 200, 100, "local", false), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, shellSIGKILL, 200, 100, "local", false), ShouldBeFalse)
 		So(attributedMemoryDeath(false, true, status, 50, 100, "local", false), ShouldBeTrue)
 	})
 
@@ -168,10 +173,13 @@ func TestMemoryFailureAttribution(t *testing.T) {
 	Convey("wr's own memory kill still requires SIGKILL plus high peak", t, func() {
 		normalExit := syscall.WaitStatus(1 << 8)
 		sigkill := syscall.WaitStatus(syscall.SIGKILL)
+		shellSIGKILL := syscall.WaitStatus((shellSignalExitCodeOffset + int(syscall.SIGKILL)) << 8)
 
 		So(attributedMemoryDeath(true, false, normalExit, 200, 100, "lsf", true), ShouldBeFalse)
 		So(attributedMemoryDeath(true, false, sigkill, 200, 100, "lsf", true), ShouldBeTrue)
+		So(attributedMemoryDeath(true, false, shellSIGKILL, 200, 100, "lsf", true), ShouldBeTrue)
 		So(attributedMemoryDeath(true, false, sigkill, 50, 100, "lsf", true), ShouldBeFalse)
+		So(attributedMemoryDeath(true, false, shellSIGKILL, 50, 100, "lsf", true), ShouldBeFalse)
 	})
 }
 

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -153,13 +153,16 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		So(jqerr.Err, ShouldEqual, FailReasonSignal)
 	})
 
-	Convey("A cgroup OOM counter increase is authoritative", t, func() {
-		status := syscall.WaitStatus(1 << 8)
+	Convey("A cgroup OOM counter increase is authoritative for OOM-compatible exits", t, func() {
+		sigkill := syscall.WaitStatus(syscall.SIGKILL)
+		shellSIGKILL := syscall.WaitStatus((shellSignalExitCodeOffset + int(syscall.SIGKILL)) << 8)
+		normalExit := syscall.WaitStatus(1 << 8)
 
-		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf", true), ShouldBeTrue)
-		So(attributedMemoryDeath(false, true, status, 50, 100, "local", false), ShouldBeTrue)
-		So(attributedMemoryDeath(false, true, status, 50, 100, "openstack", false), ShouldBeTrue)
-		So(attributedMemoryDeath(false, true, status, 50, 100, "", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, sigkill, 50, 100, "lsf", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, sigkill, 50, 100, "local", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, shellSIGKILL, 50, 100, "openstack", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, shellSIGKILL, 50, 100, "", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, normalExit, 200, 100, "local", true), ShouldBeFalse)
 	})
 
 	Convey("wr's own memory kill still requires SIGKILL plus high peak", t, func() {

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -109,7 +109,7 @@ func TestMemoryFailureAttribution(t *testing.T) {
 	Convey("A high-memory non-SIGKILL exit is not attributed to RAM", t, func() {
 		status := syscall.WaitStatus(1 << 8)
 
-		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local", true), ShouldBeFalse)
 
 		err := Error{testExecuteOp, "job", FailReasonExit}
 		annotated := appendHighMemoryNote(err, 200, 100)
@@ -124,17 +124,24 @@ func TestMemoryFailureAttribution(t *testing.T) {
 	Convey("Local and cloud schedulers use SIGKILL plus high peak as the memory fallback", t, func() {
 		status := syscall.WaitStatus(syscall.SIGKILL)
 
-		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeTrue)
-		So(attributedMemoryDeath(false, false, status, 200, 100, "openstack"), ShouldBeTrue)
-		So(attributedMemoryDeath(false, false, status, 100, 100, "local"), ShouldBeTrue)
-		So(attributedMemoryDeath(false, false, status, 50, 100, "local"), ShouldBeFalse)
-		So(attributedMemoryDeath(false, false, status, 200, 100, "lsf"), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "openstack", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 100, 100, "local", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 50, 100, "local", true), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "lsf", true), ShouldBeFalse)
+	})
+
+	Convey("Scheduler SIGKILL fallback is suppressed after server contact is lost", t, func() {
+		status := syscall.WaitStatus(syscall.SIGKILL)
+
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local", false), ShouldBeFalse)
+		So(attributedMemoryDeath(false, true, status, 50, 100, "local", false), ShouldBeTrue)
 	})
 
 	Convey("A non-SIGKILL signal with high peak is not attributed to RAM", t, func() {
 		status := syscall.WaitStatus(syscall.SIGTERM)
 
-		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local", true), ShouldBeFalse)
 
 		err := Error{testExecuteOp, "job", FailReasonSignal}
 		annotated := appendHighMemoryNote(err, 200, 100)
@@ -149,16 +156,16 @@ func TestMemoryFailureAttribution(t *testing.T) {
 	Convey("A cgroup OOM counter increase is authoritative", t, func() {
 		status := syscall.WaitStatus(1 << 8)
 
-		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf"), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf", true), ShouldBeTrue)
 	})
 
 	Convey("wr's own memory kill still requires SIGKILL plus high peak", t, func() {
 		normalExit := syscall.WaitStatus(1 << 8)
 		sigkill := syscall.WaitStatus(syscall.SIGKILL)
 
-		So(attributedMemoryDeath(true, false, normalExit, 200, 100, "lsf"), ShouldBeFalse)
-		So(attributedMemoryDeath(true, false, sigkill, 200, 100, "lsf"), ShouldBeTrue)
-		So(attributedMemoryDeath(true, false, sigkill, 50, 100, "lsf"), ShouldBeFalse)
+		So(attributedMemoryDeath(true, false, normalExit, 200, 100, "lsf", true), ShouldBeFalse)
+		So(attributedMemoryDeath(true, false, sigkill, 200, 100, "lsf", true), ShouldBeTrue)
+		So(attributedMemoryDeath(true, false, sigkill, 50, 100, "lsf", true), ShouldBeFalse)
 	})
 }
 

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -194,10 +194,43 @@ func TestHighPeakMemoryRetryGrowth(t *testing.T) {
 
 		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
 
-		increaseJobRAMAfterHighPeak(job)
+		updateJobRequirementsForRetry(job, jobOverridePreferSystemReqs, nil)
 
 		So(job.Requirements.RAM, ShouldEqual, 1200)
 		So(job.FailReason, ShouldEqual, FailReasonExit)
+	})
+
+	Convey("A RAM failure grows RAM even when sampled peak did not exceed the request", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      90,
+			FailReason:   FailReasonRAM,
+		}
+
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
+
+		updateJobRequirementsForRetry(job, jobOverridePreferSystemReqs, nil)
+
+		So(job.Requirements.RAM, ShouldEqual, 1100)
+		So(job.RequirementsOrig.RAM, ShouldEqual, 100)
+	})
+
+	Convey("Recommended RAM is applied before non-RAM high-peak retry growth is reconsidered", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      200,
+			FailReason:   FailReasonExit,
+			State:        JobStateDelayed,
+		}
+		recommendedReq := &scheduler.Requirements{RAM: 300}
+
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
+
+		updateJobRequirementsForRetry(job, jobOverridePreferSystemReqs, recommendedReq)
+
+		So(job.Requirements.RAM, ShouldEqual, 300)
+		So(job.RequirementsOrig.RAM, ShouldEqual, 100)
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeFalse)
 	})
 
 	Convey("A high peak without a failure reason does not grow RAM", t, func() {

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const testExecuteOp = "Execute"
+
+func TestCgroupOOMKillAttribution(t *testing.T) {
+	Convey("Given fabricated cgroup v2 memory events, OOM kills are attributed by counter increases", t, func() {
+		tmp := t.TempDir()
+		proc := filepath.Join(tmp, "proc")
+		cgroups := filepath.Join(tmp, "cgroup")
+		pid := "123"
+		jobCgroup := filepath.Join(cgroups, "jobs", "abc")
+		So(os.MkdirAll(filepath.Join(proc, pid), 0755), ShouldBeNil)
+		So(os.MkdirAll(jobCgroup, 0755), ShouldBeNil)
+		So(os.WriteFile(filepath.Join(proc, pid, "cgroup"), []byte("0::/jobs/abc\n"), 0600), ShouldBeNil)
+		err := os.WriteFile(
+			filepath.Join(jobCgroup, "memory.events"),
+			[]byte("low 0\nhigh 0\noom 1\noom_kill 2\n"),
+			0600,
+		)
+		So(err, ShouldBeNil)
+
+		monitor, err := newCgroupOOMMonitor(123, proc, cgroups)
+		So(err, ShouldBeNil)
+		So(monitor.oomKillIncreased(), ShouldBeFalse)
+
+		err = os.WriteFile(
+			filepath.Join(jobCgroup, "memory.events"),
+			[]byte("low 0\nhigh 0\noom 2\noom_kill 3\n"),
+			0600,
+		)
+		So(err, ShouldBeNil)
+		So(monitor.oomKillIncreased(), ShouldBeTrue)
+	})
+
+	Convey("Given fabricated cgroup v1 memory.oom_control, OOM kills are attributed by counter increases", t, func() {
+		tmp := t.TempDir()
+		proc := filepath.Join(tmp, "proc")
+		cgroups := filepath.Join(tmp, "cgroup")
+		pid := "456"
+		jobCgroup := filepath.Join(cgroups, "memory", "batch", "one")
+		So(os.MkdirAll(filepath.Join(proc, pid), 0755), ShouldBeNil)
+		So(os.MkdirAll(jobCgroup, 0755), ShouldBeNil)
+
+		err := os.WriteFile(
+			filepath.Join(proc, pid, "cgroup"),
+			[]byte("7:cpu,cpuacct:/batch/one\n8:memory:/batch/one\n"),
+			0600,
+		)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(
+			filepath.Join(jobCgroup, "memory.oom_control"),
+			[]byte("under_oom 0\noom_kill 4\n"),
+			0600,
+		)
+		So(err, ShouldBeNil)
+
+		monitor, err := newCgroupOOMMonitor(456, proc, cgroups)
+		So(err, ShouldBeNil)
+		So(monitor.oomKillIncreased(), ShouldBeFalse)
+
+		err = os.WriteFile(
+			filepath.Join(jobCgroup, "memory.oom_control"),
+			[]byte("under_oom 0\noom_kill 5\n"),
+			0600,
+		)
+		So(err, ShouldBeNil)
+		So(monitor.oomKillIncreased(), ShouldBeTrue)
+	})
+}
+
+func TestMemoryFailureAttribution(t *testing.T) {
+	Convey("A high-memory non-SIGKILL exit is not attributed to RAM", t, func() {
+		status := syscall.WaitStatus(1 << 8)
+
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeFalse)
+
+		err := Error{testExecuteOp, "job", FailReasonExit}
+		annotated := appendHighMemoryNote(err, 200, 100)
+		So(annotated.Error(), ShouldContainSubstring, FailReasonExit)
+		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+	})
+
+	Convey("Local and cloud schedulers use SIGKILL plus high peak as the memory fallback", t, func() {
+		status := syscall.WaitStatus(syscall.SIGKILL)
+
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "openstack"), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 100, 100, "local"), ShouldBeTrue)
+		So(attributedMemoryDeath(false, false, status, 50, 100, "local"), ShouldBeFalse)
+		So(attributedMemoryDeath(false, false, status, 200, 100, "lsf"), ShouldBeFalse)
+	})
+
+	Convey("A non-SIGKILL signal with high peak is not attributed to RAM", t, func() {
+		status := syscall.WaitStatus(syscall.SIGTERM)
+
+		So(attributedMemoryDeath(false, false, status, 200, 100, "local"), ShouldBeFalse)
+
+		err := Error{testExecuteOp, "job", FailReasonSignal}
+		annotated := appendHighMemoryNote(err, 200, 100)
+		So(annotated.Error(), ShouldContainSubstring, FailReasonSignal)
+		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+	})
+
+	Convey("A cgroup OOM counter increase or wr's own memory kill is authoritative", t, func() {
+		status := syscall.WaitStatus(1 << 8)
+
+		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf"), ShouldBeTrue)
+		So(attributedMemoryDeath(true, false, status, 200, 100, "lsf"), ShouldBeTrue)
+	})
+}
+
+func TestHighPeakMemoryRetryGrowth(t *testing.T) {
+	Convey("A retry gets more RAM whenever peak RAM exceeded the reservation, regardless of fail reason", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      200,
+			FailReason:   FailReasonExit,
+		}
+
+		increaseJobRAMAfterHighPeak(job)
+
+		So(job.Requirements.RAM, ShouldEqual, 1200)
+		So(job.FailReason, ShouldEqual, FailReasonExit)
+	})
+}

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -170,9 +170,45 @@ func TestHighPeakMemoryRetryGrowth(t *testing.T) {
 			FailReason:   FailReasonExit,
 		}
 
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
+
 		increaseJobRAMAfterHighPeak(job)
 
 		So(job.Requirements.RAM, ShouldEqual, 1200)
 		So(job.FailReason, ShouldEqual, FailReasonExit)
+	})
+
+	Convey("A high peak without a failure reason does not grow RAM", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      200,
+		}
+
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeFalse)
+		So(job.Requirements.RAM, ShouldEqual, 100)
+	})
+
+	Convey("A kicked non-RAM failure does not grow RAM from stale peak usage", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      200,
+			FailReason:   FailReasonExit,
+			Retries:      3,
+			UntilBuried:  4,
+		}
+
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeFalse)
+		So(job.Requirements.RAM, ShouldEqual, 100)
+	})
+
+	Convey("A kicked RAM failure still grows RAM from peak usage", t, func() {
+		job := &Job{
+			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
+			PeakRAM:      200,
+			FailReason:   FailReasonRAM,
+			UntilBuried:  1,
+		}
+
+		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
 	})
 }

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -157,6 +157,9 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		status := syscall.WaitStatus(1 << 8)
 
 		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf", true), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, status, 50, 100, "local", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, status, 50, 100, "openstack", false), ShouldBeTrue)
+		So(attributedMemoryDeath(false, true, status, 50, 100, "", false), ShouldBeTrue)
 	})
 
 	Convey("wr's own memory kill still requires SIGKILL plus high peak", t, func() {
@@ -170,11 +173,12 @@ func TestMemoryFailureAttribution(t *testing.T) {
 }
 
 func TestHighPeakMemoryRetryGrowth(t *testing.T) {
-	Convey("A retry gets more RAM whenever peak RAM exceeded the reservation, regardless of fail reason", t, func() {
+	Convey("An automatic retry grows RAM after a high peak, regardless of fail reason", t, func() {
 		job := &Job{
 			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
 			PeakRAM:      200,
 			FailReason:   FailReasonExit,
+			State:        JobStateDelayed,
 		}
 
 		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeTrue)
@@ -200,8 +204,7 @@ func TestHighPeakMemoryRetryGrowth(t *testing.T) {
 			Requirements: &scheduler.Requirements{RAM: 100, Time: time.Minute, Cores: 1},
 			PeakRAM:      200,
 			FailReason:   FailReasonExit,
-			Retries:      3,
-			UntilBuried:  4,
+			State:        JobStateReady,
 		}
 
 		So(shouldIncreaseJobRAMAfterHighPeak(job), ShouldBeFalse)

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -26,6 +26,7 @@
 package jobqueue
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -114,6 +115,10 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		annotated := appendHighMemoryNote(err, 200, 100)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonExit)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+
+		var jqerr Error
+		So(errors.As(annotated, &jqerr), ShouldBeTrue)
+		So(jqerr.Err, ShouldEqual, FailReasonExit)
 	})
 
 	Convey("Local and cloud schedulers use SIGKILL plus high peak as the memory fallback", t, func() {
@@ -135,6 +140,10 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		annotated := appendHighMemoryNote(err, 200, 100)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonSignal)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+
+		var jqerr Error
+		So(errors.As(annotated, &jqerr), ShouldBeTrue)
+		So(jqerr.Err, ShouldEqual, FailReasonSignal)
 	})
 
 	Convey("A cgroup OOM counter increase or wr's own memory kill is authoritative", t, func() {

--- a/jobqueue/memory_attribution_test.go
+++ b/jobqueue/memory_attribution_test.go
@@ -114,7 +114,7 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		err := Error{testExecuteOp, "job", FailReasonExit}
 		annotated := appendHighMemoryNote(err, 200, 100)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonExit)
-		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+		So(annotated.Error(), ShouldContainSubstring, "note: "+FailReasonRAM)
 
 		var jqerr Error
 		So(errors.As(annotated, &jqerr), ShouldBeTrue)
@@ -139,18 +139,26 @@ func TestMemoryFailureAttribution(t *testing.T) {
 		err := Error{testExecuteOp, "job", FailReasonSignal}
 		annotated := appendHighMemoryNote(err, 200, 100)
 		So(annotated.Error(), ShouldContainSubstring, FailReasonSignal)
-		So(annotated.Error(), ShouldContainSubstring, FailReasonRAM)
+		So(annotated.Error(), ShouldContainSubstring, "note: "+FailReasonRAM)
 
 		var jqerr Error
 		So(errors.As(annotated, &jqerr), ShouldBeTrue)
 		So(jqerr.Err, ShouldEqual, FailReasonSignal)
 	})
 
-	Convey("A cgroup OOM counter increase or wr's own memory kill is authoritative", t, func() {
+	Convey("A cgroup OOM counter increase is authoritative", t, func() {
 		status := syscall.WaitStatus(1 << 8)
 
 		So(attributedMemoryDeath(false, true, status, 50, 100, "lsf"), ShouldBeTrue)
-		So(attributedMemoryDeath(true, false, status, 200, 100, "lsf"), ShouldBeTrue)
+	})
+
+	Convey("wr's own memory kill still requires SIGKILL plus high peak", t, func() {
+		normalExit := syscall.WaitStatus(1 << 8)
+		sigkill := syscall.WaitStatus(syscall.SIGKILL)
+
+		So(attributedMemoryDeath(true, false, normalExit, 200, 100, "lsf"), ShouldBeFalse)
+		So(attributedMemoryDeath(true, false, sigkill, 200, 100, "lsf"), ShouldBeTrue)
+		So(attributedMemoryDeath(true, false, sigkill, 50, 100, "lsf"), ShouldBeFalse)
 	})
 }
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -101,6 +101,10 @@ const (
 	serverWaitPeriodToStartRunning = 1 * time.Millisecond
 	serverMaxRetriesToStartRunning = 50
 	serverSocketWait               = 50 * time.Millisecond
+	jobOverridePreferSystemReqs    = uint8(0)
+	jobOverridePreferHigherReqs    = uint8(1)
+	jobOverrideAlwaysUseJobReqs    = uint8(2)
+	mbPerGB                        = 1024
 )
 
 // ServerVersion gets set during build:
@@ -1037,17 +1041,157 @@ func (s *Server) rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, key 
 	s.rememberRepGroupSubscriptionKey(newRepGroup, key)
 }
 
+func failureMayUpdateJobRequirements(job *Job) bool {
+	if job == nil {
+		return false
+	}
+
+	return shouldIncreaseJobRAMAfterHighPeak(job) ||
+		job.FailReason == FailReasonDisk ||
+		job.FailReason == FailReasonTime
+}
+
+func updateJobRequirementsForRetry(
+	job *Job,
+	jobOverride uint8,
+	recommendedReq *scheduler.Requirements,
+) {
+	if job.RequirementsOrig == nil {
+		job.RequirementsOrig = &scheduler.Requirements{
+			RAM:     job.Requirements.RAM,
+			Time:    job.Requirements.Time,
+			Disk:    job.Requirements.Disk,
+			DiskSet: job.Requirements.DiskSet,
+		}
+	}
+
+	applyRecommendedJobRequirements(job, jobOverride, recommendedReq)
+
+	if jobOverride == jobOverrideAlwaysUseJobReqs {
+		return
+	}
+
+	if shouldIncreaseJobRAMAfterHighPeak(job) {
+		increaseJobRAMAfterHighPeak(job)
+	}
+
+	switch job.FailReason {
+	case FailReasonDisk:
+		increaseJobDiskAfterFailure(job)
+	case FailReasonTime:
+		increaseJobTimeAfterFailure(job)
+	}
+}
+
 func shouldIncreaseJobRAMAfterHighPeak(job *Job) bool {
 	if job == nil || job.Requirements == nil || job.FailReason == "" {
 		return false
 	}
 
-	exceededRAM := commandExceededMemoryEstimate(job.PeakRAM, job.Requirements.RAM)
-	if !exceededRAM {
-		return false
+	if job.FailReason == FailReasonRAM {
+		return true
 	}
 
-	return job.FailReason == FailReasonRAM || job.State == JobStateDelayed
+	return job.State == JobStateDelayed &&
+		commandExceededMemoryEstimate(job.PeakRAM, job.Requirements.RAM)
+}
+
+func applyRecommendedJobRequirements(
+	job *Job,
+	jobOverride uint8,
+	recommendedReq *scheduler.Requirements,
+) {
+	if recommendedReq == nil {
+		return
+	}
+
+	applyRecommendedJobRAM(job, jobOverride, recommendedReq.RAM)
+	applyRecommendedJobDisk(job, jobOverride, recommendedReq.Disk)
+	applyRecommendedJobTime(job, jobOverride, recommendedReq.Time)
+}
+
+func applyRecommendedJobRAM(job *Job, jobOverride uint8, recommendedRAM int) {
+	if recommendedRAM <= 0 {
+		return
+	}
+
+	if job.RequirementsOrig.RAM == 0 {
+		job.Requirements.RAM = recommendedRAM
+
+		return
+	}
+
+	job.Requirements.RAM = preferredIntRequirement(
+		job.Requirements.RAM,
+		recommendedRAM,
+		jobOverride,
+	)
+}
+
+func applyRecommendedJobDisk(job *Job, jobOverride uint8, recommendedDisk int) {
+	if recommendedDisk <= 0 {
+		return
+	}
+
+	if job.RequirementsOrig.Disk == 0 && !job.RequirementsOrig.DiskSet {
+		job.Requirements.Disk = recommendedDisk
+
+		return
+	}
+
+	job.Requirements.Disk = preferredIntRequirement(
+		job.Requirements.Disk,
+		recommendedDisk,
+		jobOverride,
+	)
+}
+
+func preferredIntRequirement(current, recommended int, jobOverride uint8) int {
+	switch jobOverride {
+	case jobOverridePreferSystemReqs:
+		return recommended
+	case jobOverridePreferHigherReqs:
+		if recommended > current {
+			return recommended
+		}
+	}
+
+	return current
+}
+
+func applyRecommendedJobTime(job *Job, jobOverride uint8, recommendedTime time.Duration) {
+	if recommendedTime <= 0 {
+		return
+	}
+
+	if job.RequirementsOrig.Time == 0 {
+		job.Requirements.Time = recommendedTime
+
+		return
+	}
+
+	job.Requirements.Time = preferredDurationRequirement(
+		job.Requirements.Time,
+		recommendedTime,
+		jobOverride,
+	)
+}
+
+func preferredDurationRequirement(
+	current,
+	recommended time.Duration,
+	jobOverride uint8,
+) time.Duration {
+	switch jobOverride {
+	case jobOverridePreferSystemReqs:
+		return recommended
+	case jobOverridePreferHigherReqs:
+		if recommended > current {
+			return recommended
+		}
+	}
+
+	return current
 }
 
 func increaseJobRAMAfterHighPeak(job *Job) {
@@ -2159,8 +2303,7 @@ func (s *Server) createQueue(ctx context.Context) {
 			job.RLock()
 			jobOverride := job.Override
 			reqGroup := job.ReqGroup
-			failReason := job.FailReason
-			shouldIncreaseRAM := shouldIncreaseJobRAMAfterHighPeak(job)
+			failureUpdateNeeded := failureMayUpdateJobRequirements(job)
 			job.RUnlock()
 
 			// depending on job.Override, get memory, disk and time
@@ -2201,90 +2344,10 @@ func (s *Server) createQueue(ctx context.Context) {
 			}
 
 			shouldUpdateRequirements := recommendedReq != nil ||
-				shouldIncreaseRAM ||
-				failReason == FailReasonDisk ||
-				failReason == FailReasonTime
-			if shouldUpdateRequirements { //nolint:nestif
+				failureUpdateNeeded
+			if shouldUpdateRequirements {
 				job.Lock()
-				if job.RequirementsOrig == nil {
-					job.RequirementsOrig = &scheduler.Requirements{
-						RAM:     job.Requirements.RAM,
-						Time:    job.Requirements.Time,
-						Disk:    job.Requirements.Disk,
-						DiskSet: job.Requirements.DiskSet,
-					}
-				}
-
-				if recommendedReq != nil {
-					if recommendedReq.RAM > 0 {
-						if job.RequirementsOrig.RAM > 0 {
-							switch jobOverride {
-							case 0:
-								job.Requirements.RAM = recommendedReq.RAM
-							case 1:
-								if recommendedReq.RAM > job.Requirements.RAM {
-									job.Requirements.RAM = recommendedReq.RAM
-								}
-							}
-						} else {
-							job.Requirements.RAM = recommendedReq.RAM
-						}
-					}
-
-					if recommendedReq.Disk > 0 {
-						if job.RequirementsOrig.Disk > 0 || job.RequirementsOrig.DiskSet {
-							switch jobOverride {
-							case 0:
-								job.Requirements.Disk = recommendedReq.Disk
-							case 1:
-								if recommendedReq.Disk > job.Requirements.Disk {
-									job.Requirements.Disk = recommendedReq.Disk
-								}
-							}
-						} else {
-							job.Requirements.Disk = recommendedReq.Disk
-						}
-					}
-
-					if recommendedReq.Time.Seconds() > 0 {
-						if job.RequirementsOrig.Time > 0 {
-							switch jobOverride {
-							case 0:
-								job.Requirements.Time = recommendedReq.Time
-							case 1:
-								if recommendedReq.Time > job.Requirements.Time {
-									job.Requirements.Time = recommendedReq.Time
-								}
-							}
-						} else {
-							job.Requirements.Time = recommendedReq.Time
-						}
-					}
-				}
-
-				if jobOverride != 2 {
-					if shouldIncreaseRAM {
-						increaseJobRAMAfterHighPeak(job)
-					}
-
-					switch failReason {
-					case FailReasonDisk:
-						// flat increase of 30%
-						updatedMB := float64(job.PeakDisk) / float64(1024)
-						updatedMB *= RAMIncreaseMultHigh
-						newDisk := int(math.Ceil(updatedMB/100) * 100)
-						if newDisk > job.Requirements.Disk {
-							job.Requirements.Disk = newDisk
-						}
-					case FailReasonTime:
-						// flat increase of 1 hour
-						newTime := job.EndTime.Sub(job.StartTime) + (1 * time.Hour)
-						if newTime > job.Requirements.Time {
-							job.Requirements.Time = newTime
-						}
-					}
-				}
-
+				updateJobRequirementsForRetry(job, jobOverride, recommendedReq)
 				job.Unlock()
 			}
 
@@ -3444,6 +3507,25 @@ func (s *Server) getQueueJobsByRepGroupMatch(ctx context.Context, repGroup strin
 	}
 
 	return jobs
+}
+
+func increaseJobDiskAfterFailure(job *Job) {
+	const diskIncreaseRoundGB = 100
+
+	updatedGB := float64(job.PeakDisk) / float64(mbPerGB)
+	updatedGB *= RAMIncreaseMultHigh
+	newDisk := int(math.Ceil(updatedGB/diskIncreaseRoundGB) * diskIncreaseRoundGB)
+
+	if newDisk > job.Requirements.Disk {
+		job.Requirements.Disk = newDisk
+	}
+}
+
+func increaseJobTimeAfterFailure(job *Job) {
+	newTime := job.EndTime.Sub(job.StartTime) + (1 * time.Hour)
+	if newTime > job.Requirements.Time {
+		job.Requirements.Time = newTime
+	}
 }
 
 func normalizedStatusFilter(filter JobState) JobState {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -591,7 +591,8 @@ type Server struct {
 	ch        codec.Handle
 	// runner command string compatible with fmt.Sprintf(..., schedulerGroup,
 	// deployment, serverAddr, reserveTimeout, maxMinsAllowed).
-	rc                        string
+	rc string
+
 	ServerInfo                *ServerInfo
 	ServerVersions            *ServerVersions
 	db                        *db

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1046,7 +1046,7 @@ func shouldIncreaseJobRAMAfterHighPeak(job *Job) bool {
 		return false
 	}
 
-	return job.FailReason == FailReasonRAM || job.UntilBuried <= job.Retries
+	return job.FailReason == FailReasonRAM || job.State == JobStateDelayed
 }
 
 func increaseJobRAMAfterHighPeak(job *Job) {
@@ -2157,6 +2157,8 @@ func (s *Server) createQueue(ctx context.Context) {
 
 			job.RLock()
 			jobOverride := job.Override
+			reqGroup := job.ReqGroup
+			failReason := job.FailReason
 			shouldIncreaseRAM := shouldIncreaseJobRAMAfterHighPeak(job)
 			job.RUnlock()
 
@@ -2164,14 +2166,15 @@ func (s *Server) createQueue(ctx context.Context) {
 			// recommendations, which are rounded to get fewer larger
 			// groups
 			var recommendedReq *scheduler.Requirements
-			if rec, existed := reqGroupToReqs[job.ReqGroup]; existed {
+			if rec, existed := reqGroupToReqs[reqGroup]; existed { //nolint:nestif
 				recommendedReq = rec
 			} else {
-				recm, errm := s.db.recommendedReqGroupMemory(job.ReqGroup)
-				recd, errd := s.db.recommendedReqGroupDisk(job.ReqGroup)
-				recs, errs := s.db.recommendedReqGroupTime(job.ReqGroup)
+				recm, errm := s.db.recommendedReqGroupMemory(reqGroup)
+				recd, errd := s.db.recommendedReqGroupDisk(reqGroup)
+
+				recs, errs := s.db.recommendedReqGroupTime(reqGroup)
 				if errm != nil || errd != nil || errs != nil {
-					reqGroupToReqs[job.ReqGroup] = nil
+					reqGroupToReqs[reqGroup] = nil
 				} else {
 					recmMBs := 0
 					if recm > 0 {
@@ -2192,14 +2195,14 @@ func (s *Server) createQueue(ctx context.Context) {
 						DiskSet: true,
 						Time:    time.Duration(recsSecs) * time.Second,
 					}
-					reqGroupToReqs[job.ReqGroup] = recommendedReq
+					reqGroupToReqs[reqGroup] = recommendedReq
 				}
 			}
 
 			shouldUpdateRequirements := recommendedReq != nil ||
 				shouldIncreaseRAM ||
-				job.FailReason == FailReasonDisk ||
-				job.FailReason == FailReasonTime
+				failReason == FailReasonDisk ||
+				failReason == FailReasonTime
 			if shouldUpdateRequirements { //nolint:nestif
 				job.Lock()
 				if job.RequirementsOrig == nil {
@@ -2263,7 +2266,7 @@ func (s *Server) createQueue(ctx context.Context) {
 						increaseJobRAMAfterHighPeak(job)
 					}
 
-					switch job.FailReason {
+					switch failReason {
 					case FailReasonDisk:
 						// flat increase of 30%
 						updatedMB := float64(job.PeakDisk) / float64(1024)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1036,6 +1036,19 @@ func (s *Server) rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, key 
 	s.rememberRepGroupSubscriptionKey(newRepGroup, key)
 }
 
+func shouldIncreaseJobRAMAfterHighPeak(job *Job) bool {
+	if job == nil || job.Requirements == nil || job.FailReason == "" {
+		return false
+	}
+
+	exceededRAM := commandExceededMemoryEstimate(job.PeakRAM, job.Requirements.RAM)
+	if !exceededRAM {
+		return false
+	}
+
+	return job.FailReason == FailReasonRAM || job.UntilBuried <= job.Retries
+}
+
 func increaseJobRAMAfterHighPeak(job *Job) {
 	const ramIncreaseRoundMB = 100
 
@@ -2144,7 +2157,7 @@ func (s *Server) createQueue(ctx context.Context) {
 
 			job.RLock()
 			jobOverride := job.Override
-			jobPeakExceededRAM := job.Requirements != nil && job.PeakRAM > job.Requirements.RAM
+			shouldIncreaseRAM := shouldIncreaseJobRAMAfterHighPeak(job)
 			job.RUnlock()
 
 			// depending on job.Override, get memory, disk and time
@@ -2184,7 +2197,7 @@ func (s *Server) createQueue(ctx context.Context) {
 			}
 
 			shouldUpdateRequirements := recommendedReq != nil ||
-				jobPeakExceededRAM ||
+				shouldIncreaseRAM ||
 				job.FailReason == FailReasonDisk ||
 				job.FailReason == FailReasonTime
 			if shouldUpdateRequirements { //nolint:nestif
@@ -2246,7 +2259,7 @@ func (s *Server) createQueue(ctx context.Context) {
 				}
 
 				if jobOverride != 2 {
-					if jobPeakExceededRAM {
+					if shouldIncreaseRAM {
 						increaseJobRAMAfterHighPeak(job)
 					}
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -1198,7 +1198,7 @@ func increaseJobRAMAfterHighPeak(job *Job) {
 	const ramIncreaseRoundMB = 100
 
 	// increase by 1GB or [100% if under 8GB, 30% if over],
-	// whichever is greater, and round up to nearest 100 ***
+	// whichever is greater, and round up to nearest 100MB.
 	// increase to greater than max seen for jobs in our ReqGroup?
 	updatedMB := float64(job.PeakRAM)
 	if updatedMB <= RAMIncreaseMultBreakpoint {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -582,11 +582,13 @@ type repGroupStatusOptions struct {
 
 // Server represents the server side of the socket that clients Connect() to.
 type Server struct {
-	token                     []byte
-	uploadDir                 string
-	sock                      mangos.Socket
-	ch                        codec.Handle
-	rc                        string // runner command string compatible with fmt.Sprintf(..., schedulerGroup, deployment, serverAddr, reserveTimeout, maxMinsAllowed)
+	token     []byte
+	uploadDir string
+	sock      mangos.Socket
+	ch        codec.Handle
+	// runner command string compatible with fmt.Sprintf(..., schedulerGroup,
+	// deployment, serverAddr, reserveTimeout, maxMinsAllowed).
+	rc                        string
 	ServerInfo                *ServerInfo
 	ServerVersions            *ServerVersions
 	db                        *db
@@ -1029,6 +1031,29 @@ func (s *Server) rememberRerunReplacementRepGroup(oldRepGroup, newRepGroup, key 
 	}
 
 	s.rememberRepGroupSubscriptionKey(newRepGroup, key)
+}
+
+func increaseJobRAMAfterHighPeak(job *Job) {
+	const ramIncreaseRoundMB = 100
+
+	// increase by 1GB or [100% if under 8GB, 30% if over],
+	// whichever is greater, and round up to nearest 100 ***
+	// increase to greater than max seen for jobs in our ReqGroup?
+	updatedMB := float64(job.PeakRAM)
+	if updatedMB <= RAMIncreaseMultBreakpoint {
+		updatedMB *= RAMIncreaseMultLow
+	} else {
+		updatedMB *= RAMIncreaseMultHigh
+	}
+
+	if updatedMB < float64(job.PeakRAM)+RAMIncreaseMin {
+		updatedMB = float64(job.PeakRAM) + RAMIncreaseMin
+	}
+
+	newRAM := int(math.Ceil(updatedMB/ramIncreaseRoundMB) * ramIncreaseRoundMB)
+	if newRAM > job.Requirements.RAM {
+		job.Requirements.RAM = newRAM
+	}
 }
 
 func subscriptionUpdateState(_, to JobState) (JobState, bool) {
@@ -2116,6 +2141,7 @@ func (s *Server) createQueue(ctx context.Context) {
 
 			job.RLock()
 			jobOverride := job.Override
+			jobPeakExceededRAM := job.Requirements != nil && job.PeakRAM > job.Requirements.RAM
 			job.RUnlock()
 
 			// depending on job.Override, get memory, disk and time
@@ -2143,12 +2169,22 @@ func (s *Server) createQueue(ctx context.Context) {
 					if recs > 0 {
 						recsSecs = recs
 					}
-					recommendedReq = &scheduler.Requirements{RAM: recmMBs, Disk: recdGBs, DiskSet: true, Time: time.Duration(recsSecs) * time.Second}
+
+					recommendedReq = &scheduler.Requirements{
+						RAM:     recmMBs,
+						Disk:    recdGBs,
+						DiskSet: true,
+						Time:    time.Duration(recsSecs) * time.Second,
+					}
 					reqGroupToReqs[job.ReqGroup] = recommendedReq
 				}
 			}
 
-			if recommendedReq != nil || job.FailReason == FailReasonRAM || job.FailReason == FailReasonDisk || job.FailReason == FailReasonTime {
+			if recommendedReq != nil || //nolint:nestif
+				jobPeakExceededRAM ||
+				job.FailReason == FailReasonDisk ||
+				job.FailReason == FailReasonTime {
+
 				job.Lock()
 				if job.RequirementsOrig == nil {
 					job.RequirementsOrig = &scheduler.Requirements{
@@ -2159,71 +2195,59 @@ func (s *Server) createQueue(ctx context.Context) {
 					}
 				}
 
-				if recommendedReq.RAM > 0 {
-					if job.RequirementsOrig.RAM > 0 {
-						switch jobOverride {
-						case 0:
-							job.Requirements.RAM = recommendedReq.RAM
-						case 1:
-							if recommendedReq.RAM > job.Requirements.RAM {
+				if recommendedReq != nil {
+					if recommendedReq.RAM > 0 {
+						if job.RequirementsOrig.RAM > 0 {
+							switch jobOverride {
+							case 0:
 								job.Requirements.RAM = recommendedReq.RAM
+							case 1:
+								if recommendedReq.RAM > job.Requirements.RAM {
+									job.Requirements.RAM = recommendedReq.RAM
+								}
 							}
+						} else {
+							job.Requirements.RAM = recommendedReq.RAM
 						}
-					} else {
-						job.Requirements.RAM = recommendedReq.RAM
 					}
-				}
 
-				if recommendedReq.Disk > 0 {
-					if job.RequirementsOrig.Disk > 0 || job.RequirementsOrig.DiskSet {
-						switch jobOverride {
-						case 0:
-							job.Requirements.Disk = recommendedReq.Disk
-						case 1:
-							if recommendedReq.Disk > job.Requirements.Disk {
+					if recommendedReq.Disk > 0 {
+						if job.RequirementsOrig.Disk > 0 || job.RequirementsOrig.DiskSet {
+							switch jobOverride {
+							case 0:
 								job.Requirements.Disk = recommendedReq.Disk
+							case 1:
+								if recommendedReq.Disk > job.Requirements.Disk {
+									job.Requirements.Disk = recommendedReq.Disk
+								}
 							}
+						} else {
+							job.Requirements.Disk = recommendedReq.Disk
 						}
-					} else {
-						job.Requirements.Disk = recommendedReq.Disk
 					}
-				}
 
-				if recommendedReq.Time.Seconds() > 0 {
-					if job.RequirementsOrig.Time > 0 {
-						switch jobOverride {
-						case 0:
-							job.Requirements.Time = recommendedReq.Time
-						case 1:
-							if recommendedReq.Time > job.Requirements.Time {
+					if recommendedReq.Time.Seconds() > 0 {
+						if job.RequirementsOrig.Time > 0 {
+							switch jobOverride {
+							case 0:
 								job.Requirements.Time = recommendedReq.Time
+							case 1:
+								if recommendedReq.Time > job.Requirements.Time {
+									job.Requirements.Time = recommendedReq.Time
+								}
 							}
+						} else {
+							job.Requirements.Time = recommendedReq.Time
 						}
-					} else {
-						job.Requirements.Time = recommendedReq.Time
 					}
 				}
 
 				if jobOverride != 2 {
+					if jobPeakExceededRAM {
+						increaseJobRAMAfterHighPeak(job)
+					}
+
 					switch job.FailReason {
-					case FailReasonRAM:
-						// increase by 1GB or [100% if under 8GB, 30% if over],
-						// whichever is greater, and round up to nearest 100 ***
-						// increase to greater than max seen for jobs in our
-						// ReqGroup?
-						updatedMB := float64(job.PeakRAM)
-						if updatedMB <= RAMIncreaseMultBreakpoint {
-							updatedMB *= RAMIncreaseMultLow
-						} else {
-							updatedMB *= RAMIncreaseMultHigh
-						}
-						if updatedMB < float64(job.PeakRAM)+RAMIncreaseMin {
-							updatedMB = float64(job.PeakRAM) + RAMIncreaseMin
-						}
-						newRAM := int(math.Ceil(updatedMB/100) * 100)
-						if newRAM > job.Requirements.RAM {
-							job.Requirements.RAM = newRAM
-						}
 					case FailReasonDisk:
 						// flat increase of 30%
 						updatedMB := float64(job.PeakDisk) / float64(1024)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -461,6 +461,7 @@ func (s *sgroup) decrement(drop int) int {
 	}
 
 	prev := s.count
+
 	s.count -= drop
 	if s.count < 0 {
 		s.count = 0
@@ -469,6 +470,7 @@ func (s *sgroup) decrement(drop int) int {
 	if s.count == prev {
 		return -1
 	}
+
 	return s.count
 }
 
@@ -476,6 +478,7 @@ func (s *sgroup) decrement(drop int) int {
 func (s *sgroup) hasSkips() bool {
 	s.RLock()
 	defer s.RUnlock()
+
 	return s.skipped > 0
 }
 
@@ -2180,11 +2183,11 @@ func (s *Server) createQueue(ctx context.Context) {
 				}
 			}
 
-			if recommendedReq != nil || //nolint:nestif
+			shouldUpdateRequirements := recommendedReq != nil ||
 				jobPeakExceededRAM ||
 				job.FailReason == FailReasonDisk ||
-				job.FailReason == FailReasonTime {
-
+				job.FailReason == FailReasonTime
+			if shouldUpdateRequirements { //nolint:nestif
 				job.Lock()
 				if job.RequirementsOrig == nil {
 					job.RequirementsOrig = &scheduler.Requirements{


### PR DESCRIPTION
## Summary
- only classify high-memory deaths as RAM failures when cgroup OOM evidence or SIGKILL plus peak-memory evidence supports it
- preserve real failure reasons with a non-authoritative high-memory note when attribution is unclear
- decouple retry RAM growth from FailReason and base it on PeakRAM exceeding requested RAM

Solves #502

## Tests
- golangci-lint run --fix ./jobqueue/...
- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -run "^$"
- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run "Test(CgroupOOMKillAttribution|MemoryFailureAttribution|HighPeakMemoryRetryGrowth)"
- git diff --check
