### PR TITLE
Solve #197/#19: allow job modification via web and REST

### DIFF
--- a/.docs/issue-197/phase1.md
+++ b/.docs/issue-197/phase1.md
@@ -1,0 +1,40 @@
+# Phase 1: Status and schema foundations
+
+Ref: [spec.md](spec.md) sections B1, A2
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer` skills.
+
+## Items
+
+### Item 1.1: B1 - Expose editable status fields to the UI
+
+spec.md section: B1
+
+Extend `JStatus` and `Job.ToStatus()` in `jobqueue/serverWebI.go` so
+websocket details and REST status rows expose `ReqGroup`, `EnvOverrides`,
+`Override`, `Priority`, `Retries`, `NoRetryOverWalltime`, and `CwdMatters`.
+Add GoConvey coverage in `jobqueue/serverWebI_test.go` for the websocket and
+`GET /rest/v1/jobs/<key>` paths. Cover all 2 acceptance tests from B1.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 1.2: A2 - Validate edits and editable states
+
+spec.md section: A2
+
+Add the public `JobModifyViaJSON` schema, body validation, conversion to
+`JobModifier`, and the `PATCH` behavior needed for A2's validation and
+editable-state outcomes in `jobqueue/serverREST.go`, including range checks,
+empty command/cwd errors, env clearing, duplicate-key edits, and the
+editable-state policy. Add GoConvey coverage in `jobqueue/rest_test.go` for
+bad values and state/identity outcomes. Cover all 12 acceptance tests from A2.
+Depends on item 1.1 for the `JStatus` fields asserted by successful A2
+responses. The broader A1/A3 field coverage, key mapping, auth integration,
+and bulk integration continue in phase 2.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-197/phase1.md
+++ b/.docs/issue-197/phase1.md
@@ -20,7 +20,7 @@ Add GoConvey coverage in `jobqueue/serverWebI_test.go` for the websocket and
 `GET /rest/v1/jobs/<key>` paths. Cover all 2 acceptance tests from B1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 1.2: A2 - Validate edits and editable states
 
@@ -37,4 +37,4 @@ responses. The broader A1/A3 field coverage, key mapping, auth integration,
 and bulk integration continue in phase 2.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-197/phase1.md
+++ b/.docs/issue-197/phase1.md
@@ -19,7 +19,7 @@ websocket details and REST status rows expose `ReqGroup`, `EnvOverrides`,
 Add GoConvey coverage in `jobqueue/serverWebI_test.go` for the websocket and
 `GET /rest/v1/jobs/<key>` paths. Cover all 2 acceptance tests from B1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 1.2: A2 - Validate edits and editable states
@@ -36,5 +36,5 @@ Depends on item 1.1 for the `JStatus` fields asserted by successful A2
 responses. The broader A1/A3 field coverage, key mapping, auth integration,
 and bulk integration continue in phase 2.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-197/phase2.md
+++ b/.docs/issue-197/phase2.md
@@ -22,7 +22,7 @@ acceptance tests from A1. Depends on phase 1's status fields and validation
 helpers.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 2.2: A3 - Modify multiple jobs without changing identity fields
 
@@ -36,4 +36,4 @@ Add REST integration coverage in `jobqueue/rest_test.go`. Cover all 2
 acceptance tests from A3. Depends on item 2.1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-197/phase2.md
+++ b/.docs/issue-197/phase2.md
@@ -1,0 +1,39 @@
+# Phase 2: REST endpoint
+
+Ref: [spec.md](spec.md) sections A1, A3
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer` skills.
+
+## Items
+
+### Item 2.1: A1 - Modify one editable job by key
+
+spec.md section: A1
+
+Wire `PATCH /rest/v1/jobs/<job-key>` in `jobqueue/serverREST.go`, reusing the
+existing token and bearer auth paths, `JobModifier` application, modified-job
+refetch, `JobModifyResponse`, and new-key to old-key mapping. Add REST
+integration coverage in `jobqueue/rest_test.go` for single-job edits, auth,
+stored status, old-key disappearance, and response shape. Cover all 5
+acceptance tests from A1. Depends on phase 1's status fields and validation
+helpers.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 2.2: A3 - Modify multiple jobs without changing identity fields
+
+spec.md section: A3
+
+Extend the `PATCH` path for RepGroup targets so multiple editable jobs can be
+modified together while non-editable matches stay unchanged. Reject identity
+changes such as `cmd` when more than one job would be modified, preserve
+existing GET path semantics for ids, and return stable fresh `JStatus` rows.
+Add REST integration coverage in `jobqueue/rest_test.go`. Cover all 2
+acceptance tests from A3. Depends on item 2.1.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-197/phase2.md
+++ b/.docs/issue-197/phase2.md
@@ -21,7 +21,7 @@ stored status, old-key disappearance, and response shape. Cover all 5
 acceptance tests from A1. Depends on phase 1's status fields and validation
 helpers.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 2.2: A3 - Modify multiple jobs without changing identity fields
@@ -35,5 +35,5 @@ existing GET path semantics for ids, and return stable fresh `JStatus` rows.
 Add REST integration coverage in `jobqueue/rest_test.go`. Cover all 2
 acceptance tests from A3. Depends on item 2.1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-197/phase3.md
+++ b/.docs/issue-197/phase3.md
@@ -23,7 +23,7 @@ replace the old details row with the returned `JStatus`, and only show Modify
 for editable states. Cover all 5 acceptance tests from B2. Depends on phases 1
 and 2.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 3.2: B3 - Edit env overrides only
@@ -37,7 +37,7 @@ preserve inherited env display while updating override values in the visible
 row. Cover all 3 acceptance tests from B3. Depends on item 3.1 and phase 1's
 `EnvOverrides` status field.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 3.3: B4 - Report web edit failures
@@ -49,5 +49,5 @@ so `400 Bad Request` and `409 Conflict` response bodies are shown without a
 trailing newline, the modal remains open, and the details row is unchanged.
 Cover all 2 acceptance tests from B4. Depends on item 3.1's submit path.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-197/phase3.md
+++ b/.docs/issue-197/phase3.md
@@ -24,7 +24,7 @@ for editable states. Cover all 5 acceptance tests from B2. Depends on phases 1
 and 2.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 3.2: B3 - Edit env overrides only
 
@@ -38,7 +38,7 @@ row. Cover all 3 acceptance tests from B3. Depends on item 3.1 and phase 1's
 `EnvOverrides` status field.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 3.3: B4 - Report web edit failures
 
@@ -50,4 +50,4 @@ trailing newline, the modal remains open, and the details row is unchanged.
 Cover all 2 acceptance tests from B4. Depends on item 3.1's submit path.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-197/phase3.md
+++ b/.docs/issue-197/phase3.md
@@ -1,0 +1,53 @@
+# Phase 3: Web UI
+
+Ref: [spec.md](spec.md) sections B2, B3, B4
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer` skills.
+
+## Items
+
+### Item 3.1: B2 - Edit one selected job from the details panel
+
+spec.md section: B2
+
+Add the Modify action and modal in `jobqueue/static/status.html`,
+`jobqueue/static/js/wr/action-handlers.js`,
+`jobqueue/static/js/wr/modal-handlers.js`, and
+`jobqueue/static/js/wr/status-viewmodel.js`, or a focused new module under
+`jobqueue/static/js/wr/` if that keeps the current style clearer. Pre-fill all
+mutable fields, create the exact `PATCH` payload, submit with bearer auth,
+replace the old details row with the returned `JStatus`, and only show Modify
+for editable states. Cover all 5 acceptance tests from B2. Depends on phases 1
+and 2.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 3.2: B3 - Edit env overrides only
+
+spec.md section: B3
+
+Build the env override editor in the Modify modal so it reads only
+`EnvOverrides`, never inherited effective `Env` values, and submits `env` as
+the changed override list or `[]` when overrides are cleared. After success,
+preserve inherited env display while updating override values in the visible
+row. Cover all 3 acceptance tests from B3. Depends on item 3.1 and phase 1's
+`EnvOverrides` status field.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 3.3: B4 - Report web edit failures
+
+spec.md section: B4
+
+Handle failed Modify submissions in `jobqueue/static/js/wr/modal-handlers.js`
+so `400 Bad Request` and `409 Conflict` response bodies are shown without a
+trailing newline, the modal remains open, and the details row is unchanged.
+Cover all 2 acceptance tests from B4. Depends on item 3.1's submit path.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-197/prompt.md
+++ b/.docs/issue-197/prompt.md
@@ -1,0 +1,56 @@
+# Feature: Modify jobs via REST and web UI
+
+## Issues
+
+Issue #197 asks for job modification through the web UI and public REST API,
+matching the capability already exposed by `wr mod` on the CLI.
+
+Issue #19 is folded into this feature. It asks for web editing of command env
+vars and expected resource requirements for buried, delayed, and other
+non-running incomplete jobs.
+
+REST currently supports only GET/POST/DELETE on jobs. The web UI has no modify
+action. Server-side modification already exists through `wr mod`.
+
+## Required behaviour
+
+Add REST and web UI job editing for non-running incomplete jobs.
+
+- Add a REST PUT or PATCH endpoint that applies `wr mod`-style changes using
+  existing server-side validation and modification logic where possible.
+- No auth model change: use the existing token/auth behaviour.
+- The web UI must allow editing every field it currently displays for a job,
+  for any non-running incomplete job.
+- Running jobs must not be editable in v1.
+- Include env vars and resource requirements from #19.
+- Include fields shown by the web UI such as requirements, env, priority,
+  retries, limit groups, and behaviours where they are displayed.
+- Add a Modify action/button in the job details UI.
+- Invalid edits must be reported with an error popup.
+- Successful edits should update the displayed job state without requiring a
+  manual page refresh.
+
+## Notes
+
+Deliver #197 and #19 together on branch `feat/issue-197`. There is no separate
+#19 branch or PR.
+
+Editable fields in v1 are the mutable job fields that existing `wr mod`-style
+server logic can already validate and change, when those fields are displayed
+by the web UI. Immutable identity, status, output, and execution-result fields
+remain read-only even if displayed.
+
+Environment editing modifies job-specific environment overrides, matching the
+existing `wr mod --env` model. It must not replace the full effective inherited
+environment unless existing modify logic already supports that safely.
+
+If a modification changes a job key, REST responses must expose enough mapping
+for callers and the web UI to track the edited job after the update, for
+example old key to new key.
+
+The web UI v1 Modify action edits one selected job at a time. Bulk edit of all
+matching or similar jobs is out of scope.
+
+Spec questions should be surfaced to the human only if they require a product
+or maintainer choice. Implementation details should be decided from existing
+wr patterns or sensible defaults and recorded in the spec.

--- a/.docs/issue-197/spec.md
+++ b/.docs/issue-197/spec.md
@@ -1,0 +1,476 @@
+# REST and Web Job Modification Specification
+
+## Overview
+
+Add job editing to the public REST API and status web UI. The feature exposes
+the existing `wr mod` capability for incomplete, non-running jobs without
+changing the token/auth model.
+
+REST uses `PATCH /rest/v1/jobs/<keys-or-repgroups>` with optional JSON fields.
+Omitted fields stay unchanged. Supplied fields are validated and applied with
+`JobModifier` semantics. The response returns new-to-old key mapping data and
+fresh job status rows so callers can follow jobs whose key changed.
+
+The web UI edits one selected job at a time. It shows a Modify action only for
+`delayed`, `ready`, `dependent`, and `buried` jobs. Successful edits replace
+the displayed row without a manual refresh. Invalid edits show an error popup.
+`reserved`, `running`, `lost`, `complete`, deleted, and unknown jobs are not
+editable in v1.
+
+## Architecture
+
+### Packages and files
+
+- `jobqueue/serverREST.go`: add `PATCH` handling to `restJobs`; add
+  `JobModifyViaJSON`, `JobModifyResponse`, body validation, conversion to
+  `JobModifier`, editable-state checks, and modified-job lookup.
+  Test in `jobqueue/rest_test.go`.
+- `jobqueue/job.go`: reuse `JobModifier`. Add no new mutation path unless an
+  unexported helper is needed to set env overrides from `[]string` without the
+  comma-separated CLI format.
+- `jobqueue/serverWebI.go`: extend `JStatus` and `Job.ToStatus()` with the
+  editable fields the UI needs but cannot currently read: `ReqGroup`,
+  `CwdMatters`, `Override`, `Priority`, `Retries`,
+  `NoRetryOverWalltime`, and job-specific `EnvOverrides`.
+  Test in `jobqueue/serverWebI_test.go`.
+- `jobqueue/static/status.html`: add Modify button, modal form, validation
+  error display, and refreshed row rendering.
+- `jobqueue/static/js/wr/action-handlers.js`,
+  `jobqueue/static/js/wr/modal-handlers.js`,
+  `jobqueue/static/js/wr/status-viewmodel.js`: add modify modal state, payload
+  creation, `PATCH` submission, error handling, and row/key replacement.
+  A new focused JS module under `jobqueue/static/js/wr/` is allowed if it keeps
+  the existing module style simpler.
+
+### REST API
+
+Add this public request type in package `jobqueue`:
+
+```go
+type JobModifyViaJSON struct {
+    MountConfigs         *MountConfigs      `json:"mounts,omitempty"`
+    LimitGrps            *[]string          `json:"limit_grps,omitempty"`
+    Modules              *[]string          `json:"modules,omitempty"`
+    Deps                 *[]string          `json:"deps,omitempty"`
+    CmdDeps              *Dependencies      `json:"cmd_deps,omitempty"`
+    OnFailure            *BehavioursViaJSON `json:"on_failure,omitempty"`
+    OnSuccess            *BehavioursViaJSON `json:"on_success,omitempty"`
+    OnExit               *BehavioursViaJSON `json:"on_exit,omitempty"`
+    Env                  *[]string          `json:"env,omitempty"`
+    Other                *map[string]string `json:"other,omitempty"`
+    Cmd                  *string            `json:"cmd,omitempty"`
+    Cwd                  *string            `json:"cwd,omitempty"`
+    ReqGrp               *string            `json:"req_grp,omitempty"`
+    Group                *string            `json:"group,omitempty"`
+    Memory               *string            `json:"memory,omitempty"`
+    Time                 *string            `json:"time,omitempty"`
+    MonitorDocker        *string            `json:"monitor_docker,omitempty"`
+    WithDocker           *string            `json:"with_docker,omitempty"`
+    WithSingularity      *string            `json:"with_singularity,omitempty"`
+    ContainerMounts      *string            `json:"container_mounts,omitempty"`
+    SchedulerQueue       *string            `json:"queue,omitempty"`
+    SchedulerQueuesAvoid *string            `json:"queues_avoid,omitempty"`
+    SchedulerMisc        *string            `json:"misc,omitempty"`
+    CloudOS              *string            `json:"cloud_os,omitempty"`
+    CloudUser            *string            `json:"cloud_username,omitempty"`
+    CloudRAM             *int               `json:"cloud_ram,omitempty"`
+    CloudFlavor          *string            `json:"cloud_flavor,omitempty"`
+    CloudScript          *string            `json:"cloud_script,omitempty"`
+    CloudConfigFiles     *string            `json:"cloud_config_files,omitempty"`
+    CloudShared          *bool              `json:"cloud_shared,omitempty"`
+    CPUs                 *float64           `json:"cpus,omitempty"`
+    Disk                 *int               `json:"disk,omitempty"`
+    Override             *int               `json:"override,omitempty"`
+    Priority             *int               `json:"priority,omitempty"`
+    Retries              *int               `json:"retries,omitempty"`
+    NoRetryOverWalltime  *string            `json:"no_retry_over_walltime,omitempty"`
+    CwdMatters           *bool              `json:"cwd_matters,omitempty"`
+    ChangeHome           *bool              `json:"change_home,omitempty"`
+}
+```
+
+```go
+type JobModifyResponse struct {
+    // Modified maps new internal job key to old internal job key.
+    Modified map[string]string `json:"modified"`
+    Jobs     []JStatus         `json:"jobs"`
+}
+```
+
+Field rules:
+
+- Omitted field: no change.
+- `cmd` and `cwd`: if supplied, must be non-empty. `cmd` may target only one
+  editable job.
+- `env`: modifies only job-specific env overrides. `[]` clears overrides. It
+  must not replace inherited environment values.
+- `deps` are dep-group dependencies. `cmd_deps` use the documented command
+  dependency JSON shape `{"cmd":"...","cwd":"..."}`. Supplying either replaces
+  the full `Job.Dependencies` value with the supplied groups and commands.
+- `memory`: parse with `bytefmt.ToMegabytes`; `time` and
+  `no_retry_over_walltime`: parse with `time.ParseDuration`.
+- `cpus` and `disk`: set `CoresSet` and `DiskSet`; zero is valid.
+- `other`: replaces `Requirements.Other`; `{}` clears it. Named cloud and
+  scheduler fields merge into `other` using existing `wr mod` keys:
+  `cloud_os`, `cloud_user`, `cloud_os_ram`, `cloud_flavor`,
+  `cloud_script`, `cloud_config_files`, `cloud_shared`,
+  `scheduler_queue`, `scheduler_queues_avoid`, and `scheduler_misc`.
+- `override` must be `0..2`; `priority` and `retries` must be `0..255`.
+- `on_failure`, `on_success`, and `on_exit`: supplied empty arrays become
+  `[]BehaviourViaJSON{{Nothing: true}}` for that trigger, matching
+  `wr mod --on_* ""`.
+- Immutable in v1: `rep_grp`, `dep_grps`, `bsub_mode`, internal key, state,
+  stdout/stderr, host/PID, start/end time, attempts, exit code, failure reason,
+  peak resource use, actual cwd, queue name, and bsub id.
+
+Endpoint rules:
+
+- Authorized like existing REST endpoints: token query parameter or
+  `Authorization: Bearer <token>`.
+- `PATCH /rest/v1/jobs/<id>` accepts one 32-char job key or one RepGroup.
+  Comma-separated ids use existing GET path semantics.
+- Empty path returns `400 Bad Request` with `job identifier is required`.
+- Editable states are exactly `delayed`, `ready`, `dependent`, and `buried`.
+  A target that resolves only to other states returns `409 Conflict` with
+  `no editable jobs matched`.
+- A target that resolves to no queued or complete job and no RepGroup returns
+  `404 Not Found` with `job not found`.
+- Duplicate-key edits, such as changing a command to match another live or
+  complete job, return `409 Conflict` with `no jobs were modified`.
+- Success returns `200 OK` and `JobModifyResponse`. `Jobs` contains one fresh
+  `JStatus` for each modified job, sorted by new key for stable JSON.
+
+## Section A: REST Job Modification
+
+### A1: Modify one editable job by key
+
+As a REST client, I want to patch a queued job by key, so that I can make the
+same safe edits as `wr mod` without shelling out.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverREST.go`
+**Test file:** `jobqueue/rest_test.go`
+
+Use:
+
+```http
+PATCH /rest/v1/jobs/<job-key>
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**Acceptance tests:**
+
+1. Given a ready job with command `echo rest old`, cwd `/tmp`, req group
+   `rest-old`, RAM `50M`, time `1m`, cores `1`, disk `0`, priority `1`,
+   retries `1`, override `0`, limit groups `["old:1"]`, and env override
+   `["REST_MOD=old"]`, when `PATCH /rest/v1/jobs/<oldKey>` is sent with:
+
+   ```json
+   {
+     "cmd": "echo rest new",
+     "cwd": "/tmp/rest-new",
+     "cwd_matters": true,
+     "change_home": true,
+     "req_grp": "rest-new",
+     "memory": "64M",
+     "time": "2m",
+     "cpus": 0.5,
+     "disk": 2,
+     "priority": 7,
+     "retries": 4,
+     "override": 2,
+     "limit_grps": ["new:2"],
+     "modules": ["module-a"],
+     "env": ["REST_MOD=new", "REST_EXTRA=1"],
+     "other": {"scheduler_queue": "short"},
+     "on_exit": [{"nothing": true}]
+   }
+   ```
+
+   then the response is `200 OK`, `Modified` has length `1`, the sole map
+   value is `<oldKey>`, the sole map key equals `Jobs[0].Key`, and that key is
+   not `<oldKey>`.
+2. Given the response from test 1, when `GET /rest/v1/jobs/<newKey>?env=true`
+   is sent, then it returns one job with `Cmd == "echo rest new"`,
+   `CwdBase == "/tmp/rest-new"`, `ReqGroup == "rest-new"`,
+   `CwdMatters == true`, `HomeChanged == true`, `ExpectedRAM == 64`,
+   `ExpectedTime == 120`, `Cores == 0.5`, `RequestedDisk == 2`,
+   `Priority == 7`, `Retries == 4`, `Override == 2`,
+   `LimitGroups == []string{"new:2"}`, `Modules == []string{"module-a"}`,
+   `Env` contains `REST_MOD=new` and `REST_EXTRA=1`, `OtherRequests` contains
+   `scheduler_queue:short`, and `Behaviours` equals
+   `{"on_exit":[{"nothing":true}]}`.
+3. Given the response from test 1, when `GET /rest/v1/jobs/<oldKey>` is sent,
+   then the decoded status slice has length `0`.
+4. Given a ready job with priority `1`, when
+   `PATCH /rest/v1/jobs/<key>?token=<token>` supplies `{"priority": 9}`
+   without an `Authorization` header, then the response is `200 OK`, the
+   returned job has `Priority == 9`, and a later `GET` shows priority `9`.
+5. Given the same endpoint without a token or bearer header, when `PATCH` is
+   sent, then the response is `401 Unauthorized`.
+
+### A2: Validate edits and editable states
+
+As a REST client, I want invalid or unsafe edits rejected clearly, so that I do
+not mistake a no-op for success.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverREST.go`
+**Test file:** `jobqueue/rest_test.go`
+
+**Acceptance tests:**
+
+1. Given a delayed job with priority `1`, when `PATCH` supplies
+   `{"priority": 9}`, then the response is `200 OK`, the returned job has
+   `State == "delayed"` and `Priority == 9`, and the stored job is still
+   delayed.
+2. Given a dependent job with req group `dep-old`, when `PATCH` supplies
+   `{"req_grp": "dep-new"}`, then the response is `200 OK`, the returned job
+   has `State == "dependent"` and `ReqGroup == "dep-new"`, and the stored job
+   is still dependent.
+3. Given a buried job with retries `1`, when `PATCH` supplies
+   `{"retries": 3}`, then the response is `200 OK`, the returned job has
+   `State == "buried"` and `Retries == 3`, and the stored job is still buried.
+4. Given a ready job, when `PATCH` supplies `{"priority": 256}`, then the
+   response is `400 Bad Request`, the body contains
+   `priority value (256) is not in the range 0..255`, and the stored priority
+   is unchanged.
+5. Given a ready job, when `PATCH` supplies `{"cmd": ""}`, then the response is
+   `400 Bad Request`, the body is `cmd cannot be empty\n`, and the stored
+   command is unchanged.
+6. Given a running job, when `PATCH` supplies `{"priority": 9}`, then the
+   response is `409 Conflict`, the body is `no editable jobs matched\n`, and
+   the stored priority is unchanged.
+7. Given a complete job, when `PATCH` supplies `{"retries": 9}`, then the
+   response is `409 Conflict`, the body is `no editable jobs matched\n`, and
+   no ready job is created.
+8. Given a reserved job, when `PATCH` supplies `{"priority": 9}`, then the
+   response is `409 Conflict`, the body is `no editable jobs matched\n`, and
+   the stored priority is unchanged.
+9. Given a lost job, when `PATCH` supplies `{"priority": 9}`, then the
+   response is `409 Conflict`, the body is `no editable jobs matched\n`, and
+   the stored priority is unchanged.
+10. Given no job or RepGroup matches
+    `0123456789abcdef0123456789abcdef`, when `PATCH` supplies
+    `{"priority": 9}`, then the response is `404 Not Found`, the body is
+    `job not found\n`, and no job is created.
+11. Given a ready job with env override `REST_CLEAR=1`, when `PATCH` supplies
+    `{"env": []}`, then the response is `200 OK`; a later
+    `GET /rest/v1/jobs/<key>?env=true` returns one job whose `Env` does not
+    contain `REST_CLEAR=1`.
+12. Given two ready jobs in the same manager, when job A is patched with
+    `{"cmd": "<job B command>"}`, then the response is `409 Conflict`, the body
+    is `no jobs were modified\n`, job A keeps its old command, and job B is
+    unchanged.
+
+### A3: Modify multiple jobs without changing identity fields
+
+As a REST client, I want to patch several matching editable jobs, so that I can
+adjust common mutable settings for a RepGroup.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverREST.go`
+**Test file:** `jobqueue/rest_test.go`
+
+**Acceptance tests:**
+
+1. Given three editable jobs in RepGroup `rest-bulk` and one running job in the
+   same RepGroup, when `PATCH /rest/v1/jobs/rest-bulk` supplies
+   `{"priority": 8, "limit_grps": ["bulk:1"]}`, then the response is
+   `200 OK`, `Modified` has length `3`, `Jobs` has length `3`, every returned
+   job has `Priority == 8` and `LimitGroups == []string{"bulk:1"}`, and the
+   running job's priority and limit groups are unchanged.
+2. Given two editable jobs in RepGroup `rest-bulk-cmd`, when
+   `PATCH /rest/v1/jobs/rest-bulk-cmd` supplies `{"cmd": "echo same"}`, then
+   the response is `400 Bad Request`, the body is
+   `cmd can only be modified for one job\n`, and both commands are unchanged.
+
+## Section B: Web UI Modification
+
+### B1: Expose editable status fields to the UI
+
+As a web user, I want the modify dialog pre-filled from the selected job, so
+that I can review current values before editing them.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverWebI.go`
+**Test file:** `jobqueue/serverWebI_test.go`
+
+Extend `JStatus`:
+
+```go
+type JStatus struct {
+    // existing fields unchanged
+    ReqGroup            string
+    EnvOverrides        []string
+    Override            uint8
+    Priority            uint8
+    Retries             uint8
+    NoRetryOverWalltime float64
+    CwdMatters          bool
+}
+```
+
+**Acceptance tests:**
+
+1. Given a ready job with `ReqGroup == "web-req"`, `Override == 2`,
+   `Priority == 11`, `Retries == 5`,
+   `NoRetryOverWalltime == 3*time.Minute`, `CwdMatters == true`, and
+   `ChangeHome == true`, with env override `WEB_ONLY=old`, when a websocket
+   details request returns its `JStatus`, then the JSON has
+   `ReqGroup == "web-req"`, `Override == 2`, `Priority == 11`,
+   `Retries == 5`, `NoRetryOverWalltime == 180`, `CwdMatters == true`,
+   `HomeChanged == true`, and `EnvOverrides == []string{"WEB_ONLY=old"}`.
+2. Given the same job is fetched through `GET /rest/v1/jobs/<key>`, then the
+   decoded `JStatus` has the same values for `ReqGroup`, `EnvOverrides`,
+   `Override`, `Priority`, `Retries`, `NoRetryOverWalltime`, and
+   `CwdMatters` as test 1.
+
+### B2: Edit one selected job from the details panel
+
+As a web user, I want a Modify action on editable jobs, so that I can change a
+single job from the status page.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/static/status.html`
+**Test file:** `jobqueue/serverWebI_test.go`
+
+**Acceptance tests:**
+
+1. Given the details panel contains one `ready` job with command
+   `echo web old`, cwd `/tmp/web-old`, `CwdMatters == false`,
+   `HomeChanged == false`, `ReqGroup == "web-old"`, RAM `64M`, time `1m`,
+   cores `1`, disk `0`, priority `1`, retries `1`, override `0`,
+   `NoRetryOverWalltime == 0`, limit groups `["old:1"]`, modules
+   `["oldmod"]`, dependencies `["old-dep", "echo dep [/tmp/dep-old]"]`,
+   behaviours `{"on_exit":[{"nothing":true}]}`, other requests
+   `["scheduler_queue:old"]`, mounts
+   `[{"Mount":"oldmnt","Targets":[{"Profile":"old","Path":"old/data"}]}]`,
+   `MonitorDocker == "old-docker"`, `WithDocker == ""`,
+   `WithSingularity == "old.sif"`, and `ContainerMounts == "/old:/old"`,
+   when the user opens Modify, then modal controls for every listed mutable
+   field are pre-filled with exactly those values. Env is covered by B3.
+2. Given the modal from test 1, when the user changes every listed field and
+   submits, then the browser sends exactly one
+   `PATCH /rest/v1/jobs/<oldKey>` with bearer token auth and a body that
+   decodes to exactly:
+
+   ```json
+   {
+     "cmd": "echo web new",
+     "cwd": "/tmp/web-new",
+     "cwd_matters": true,
+     "change_home": true,
+     "req_grp": "web-new",
+     "memory": "128M",
+     "time": "3m",
+     "cpus": 2,
+     "disk": 5,
+     "priority": 12,
+     "retries": 6,
+     "override": 2,
+     "no_retry_over_walltime": "10m",
+     "limit_grps": ["new:2"],
+     "modules": ["mod-a", "mod-b"],
+     "deps": ["dep-a"],
+     "cmd_deps": [{"cmd": "echo dep", "cwd": "/tmp/dep"}],
+     "on_failure": [{"cleanup": true}],
+     "on_success": [{"remove": true}],
+     "on_exit": [{"nothing": true}],
+     "other": {"cloud_os": "Ubuntu 22", "scheduler_queue": "short"},
+     "mounts": [{
+       "Mount": "mnt",
+       "Targets": [{"Profile": "p", "Path": "bucket/data"}]
+     }],
+     "monitor_docker": "dock-new",
+     "with_docker": "ubuntu:22.04",
+     "with_singularity": "",
+     "container_mounts": "/data:/data"
+   }
+   ```
+
+3. Given the `PATCH` in test 2 returns `200 OK` with `Modified` mapping
+   `<newKey>` to `<oldKey>` and one `JStatus` matching the new values, then the
+   modal closes, the details observable replaces the old row with the returned
+   row, no row with `<oldKey>` remains, and the visible row shows every new
+   value from test 2, including cwd flags, req group, time, disk, limit groups,
+   modules, dependencies, behaviours, other requests, mounts, container fields,
+   monitor/with container values, override, and no-retry-over-walltime.
+4. Given a job state is `delayed`, `ready`, `dependent`, or `buried`, when the
+   row is rendered, then the Modify action is available.
+5. Given a job state is `reserved`, `running`, `lost`, or `complete`, when the
+   row is rendered, then the Modify action is unavailable.
+
+### B3: Edit env overrides only
+
+As a web user, I want env editing to affect only job-specific overrides, so
+that inherited manager environment values are not accidentally submitted.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/static/js/wr/modal-handlers.js`
+**Test file:** `jobqueue/serverWebI_test.go`
+
+**Acceptance tests:**
+
+1. Given a job status has effective `Env` containing `PATH=/bin`,
+   `INHERITED=base`, and `WEB_ONLY=old`, and has
+   `EnvOverrides == []string{"WEB_ONLY=old"}`, when the user opens Modify,
+   then the env override editor is pre-filled with exactly `WEB_ONLY=old` and
+   does not include `PATH=/bin` or `INHERITED=base`.
+2. Given the env editor from test 1, when the user changes the row to
+   `WEB_ONLY=new` and submits, then the `PATCH` body contains
+   `{"env": ["WEB_ONLY=new"]}` and does not contain `PATH=/bin` or
+   `INHERITED=base`; after success the visible effective env still contains
+   `PATH=/bin` and `INHERITED=base`, and contains `WEB_ONLY=new`.
+3. Given the env editor from test 1, when the user clears all override rows and
+   submits, then the `PATCH` body contains `{"env": []}`; after success
+   `EnvOverrides` is empty, effective env still contains `PATH=/bin` and
+   `INHERITED=base`, and effective env does not contain `WEB_ONLY=old`.
+
+### B4: Report web edit failures
+
+As a web user, I want failed edits shown in the UI, so that I know the job was
+not changed.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/static/js/wr/modal-handlers.js`
+**Test file:** `jobqueue/serverWebI_test.go`
+
+**Acceptance tests:**
+
+1. Given the Modify dialog is open for a ready job, when the server returns
+   `400 Bad Request` with body
+   `priority value (300) is not in the range 0..255\n`, then the dialog remains
+   open, an error popup displays that exact text without the trailing newline,
+   and the details row is unchanged.
+2. Given the Modify dialog is open for a job that becomes running before
+   submit, when the server returns `409 Conflict` with body
+   `no editable jobs matched\n`, then the dialog remains open, an error popup
+   displays `no editable jobs matched`, and the details row is unchanged.
+
+## Implementation Order
+
+1. Status and schema foundations (B1, A2): extend `JStatus`/`ToStatus()`, add
+   `JobModifyViaJSON`, validation, conversion to `JobModifier`, and bad-value
+   coverage.
+2. REST endpoint (A1, A3): wire `PATCH`, editable-state filtering, conflict
+   handling, modified job refetch, key mapping, and REST integration tests.
+3. Web UI (B2, B3, B4): add Modify action/modal, payload creation, `PATCH`
+   submission, success row replacement, and error popup behavior. Depends on
+   items 1 and 2.
+
+## Appendix: Key Decisions
+
+- Use `PATCH`, not `PUT`, because requests are partial edits and omitted fields
+  must remain unchanged.
+- Use existing token or bearer auth only; no auth model or permission change.
+- Keep v1 web editing to one selected job. REST may edit multiple jobs for
+  non-identity fields, matching the existing `wr mod` server behavior.
+- Treat env editing as job-specific overrides only. Inherited environment is
+  read-only unless existing job modify logic gains safe full-env support later.
+- Do not expose bulk web edit, running-job edit, RepGroup rename, dep-group
+  membership edit, or bsub-mode edit in v1.
+- Tests use GoConvey and user-visible behavior: REST HTTP responses, decoded
+  `JStatus`, websocket details, and browser-observable modify state. Follow
+  `go-implementor`, `go-reviewer`, and `testing-principles`.

--- a/jobqueue/dependency.go
+++ b/jobqueue/dependency.go
@@ -27,10 +27,63 @@ package jobqueue
 
 // This file contains the dependency related code.
 
+import "encoding/json"
+
 // Dependencies is a slice of *Dependency, for use in Job.Dependencies. It
 // describes the jobs that must be complete before the Job you associate this
 // with will start.
 type Dependencies []*Dependency
+
+// UnmarshalJSON accepts the public REST command dependency shape
+// [{"cmd":"...","cwd":"..."}] as well as the historical struct-shaped JSON.
+func (d *Dependencies) UnmarshalJSON(data []byte) error {
+	var deps []dependencyViaJSON
+	if err := json.Unmarshal(data, &deps); err != nil {
+		return err
+	}
+
+	converted := make(Dependencies, 0, len(deps))
+	for _, dep := range deps {
+		converted = appendDependencyViaJSON(converted, dep)
+	}
+
+	*d = converted
+
+	return nil
+}
+
+type dependencyViaJSON struct {
+	Essence       *JobEssence `json:"essence"`
+	LegacyEssence *JobEssence `json:"Essence"`
+	Cmd           string      `json:"cmd"`
+	Cwd           string      `json:"cwd"`
+	DepGroup      string      `json:"dep_group"`
+	LegacyDepGrp  string      `json:"DepGroup"`
+}
+
+func appendDependencyViaJSON(deps Dependencies, dep dependencyViaJSON) Dependencies {
+	if dep.DepGroup != "" {
+		return append(deps, NewDepGroupDependency(dep.DepGroup))
+	}
+
+	if dep.LegacyDepGrp != "" {
+		return append(deps, NewDepGroupDependency(dep.LegacyDepGrp))
+	}
+
+	if dep.Cmd != "" || dep.Cwd != "" {
+		return append(deps, NewEssenceDependency(dep.Cmd, dep.Cwd))
+	}
+
+	if dep.Essence != nil {
+		return append(deps, &Dependency{Essence: dep.Essence})
+	}
+
+	if dep.LegacyEssence != nil {
+		return append(deps, &Dependency{Essence: dep.LegacyEssence})
+	}
+
+	return deps
+}
 
 // incompleteJobKeys converts the constituent Dependency structs in to internal
 // job keys that uniquely identify the jobs we are dependent upon. Note that if

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -177,6 +178,10 @@ type Job struct {
 	// other jobs as the limit are currently running, this job will not start
 	// running. It's a way of not running too many of a type of job at once.
 	LimitGroups []string
+
+	// LimitGroupsForDisplay preserves any user-supplied limit suffixes for
+	// status output after LimitGroups has been normalised for scheduling.
+	LimitGroupsForDisplay []string
 
 	// Modules are the names of environment modules that should be loaded before
 	// running Cmd.
@@ -946,11 +951,16 @@ func (j *Job) ToStatus() (JStatus, error) {
 		ot = append(ot, key+":"+val)
 	}
 
+	limitGroups := j.LimitGroups
+	if len(j.LimitGroupsForDisplay) > 0 {
+		limitGroups = j.LimitGroupsForDisplay
+	}
+
 	js := JStatus{
 		Key:                 j.Key(),
 		RepGroup:            j.RepGroup,
 		ReqGroup:            j.ReqGroup,
-		LimitGroups:         j.LimitGroups,
+		LimitGroups:         limitGroups,
 		DepGroups:           j.DepGroups,
 		Dependencies:        j.Dependencies.Stringify(),
 		Modules:             j.Modules,
@@ -1407,7 +1417,8 @@ func (j *JobModifier) Modify(jobs []*Job, server *Server) (map[string]string, er
 			job.EnvOverride = j.EnvOverride
 		}
 		if j.LimitGroupsSet {
-			job.LimitGroups = j.LimitGroups
+			job.LimitGroups = slices.Clone(j.LimitGroups)
+			job.LimitGroupsForDisplay = nil
 		}
 
 		if j.ModulesSet {

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -922,6 +922,11 @@ func (j *Job) ToStatus() (JStatus, error) {
 	if err != nil {
 		return JStatus{}, err
 	}
+
+	envOverrides, err := j.envCurrentOverrides()
+	if err != nil {
+		return JStatus{}, err
+	}
 	var cwdLeaf string
 	j.RLock()
 	defer j.RUnlock()
@@ -942,44 +947,51 @@ func (j *Job) ToStatus() (JStatus, error) {
 	}
 
 	js := JStatus{
-		Key:             j.Key(),
-		RepGroup:        j.RepGroup,
-		LimitGroups:     j.LimitGroups,
-		DepGroups:       j.DepGroups,
-		Dependencies:    j.Dependencies.Stringify(),
-		Modules:         j.Modules,
-		Cmd:             j.Cmd,
-		State:           state,
-		CwdBase:         j.Cwd,
-		Cwd:             cwdLeaf,
-		HomeChanged:     j.ChangeHome,
-		Behaviours:      j.Behaviours.String(),
-		Mounts:          j.MountConfigs.String(),
-		MonitorDocker:   j.MonitorDocker,
-		WithDocker:      j.WithDocker,
-		WithSingularity: j.WithSingularity,
-		ContainerMounts: j.ContainerMounts,
-		ExpectedRAM:     j.Requirements.RAM,
-		ExpectedTime:    j.Requirements.Time.Seconds(),
-		RequestedDisk:   j.Requirements.Disk,
-		OtherRequests:   ot,
-		Cores:           j.Requirements.Cores,
-		PeakRAM:         j.PeakRAM,
-		PeakDisk:        j.PeakDisk,
-		Exited:          j.Exited,
-		Exitcode:        j.Exitcode,
-		FailReason:      j.FailReason,
-		Pid:             j.Pid,
-		Host:            j.Host,
-		HostID:          j.HostID,
-		HostIP:          j.HostIP,
-		Walltime:        j.WallTime().Seconds(),
-		CPUtime:         j.CPUtime.Seconds(),
-		Attempts:        j.Attempts,
-		Similar:         j.Similar,
-		StdErr:          stderr,
-		StdOut:          stdout,
-		Env:             env,
+		Key:                 j.Key(),
+		RepGroup:            j.RepGroup,
+		ReqGroup:            j.ReqGroup,
+		LimitGroups:         j.LimitGroups,
+		DepGroups:           j.DepGroups,
+		Dependencies:        j.Dependencies.Stringify(),
+		Modules:             j.Modules,
+		Cmd:                 j.Cmd,
+		State:               state,
+		CwdBase:             j.Cwd,
+		Cwd:                 cwdLeaf,
+		HomeChanged:         j.ChangeHome,
+		Behaviours:          j.Behaviours.String(),
+		Mounts:              j.MountConfigs.String(),
+		MonitorDocker:       j.MonitorDocker,
+		WithDocker:          j.WithDocker,
+		WithSingularity:     j.WithSingularity,
+		ContainerMounts:     j.ContainerMounts,
+		ExpectedRAM:         j.Requirements.RAM,
+		ExpectedTime:        j.Requirements.Time.Seconds(),
+		RequestedDisk:       j.Requirements.Disk,
+		EnvOverrides:        envOverrides,
+		OtherRequests:       ot,
+		Cores:               j.Requirements.Cores,
+		NoRetryOverWalltime: j.NoRetriesOverWalltime.Seconds(),
+		PeakRAM:             j.PeakRAM,
+		PeakDisk:            j.PeakDisk,
+		Exited:              j.Exited,
+		Exitcode:            j.Exitcode,
+		FailReason:          j.FailReason,
+		Pid:                 j.Pid,
+		Host:                j.Host,
+		HostID:              j.HostID,
+		HostIP:              j.HostIP,
+		Walltime:            j.WallTime().Seconds(),
+		CPUtime:             j.CPUtime.Seconds(),
+		Attempts:            j.Attempts,
+		Similar:             j.Similar,
+		Override:            j.Override,
+		Priority:            j.Priority,
+		Retries:             j.Retries,
+		CwdMatters:          j.CwdMatters,
+		StdErr:              stderr,
+		StdOut:              stdout,
+		Env:                 env,
 	}
 
 	if !j.StartTime.IsZero() {
@@ -1175,6 +1187,24 @@ func (j *JobModifier) SetEnvOverride(newVal string) error {
 	if newVal != "" {
 		var err error
 		compressedEnv, err = compressEnv(strings.Split(newVal, ","))
+		if err != nil {
+			return err
+		}
+	}
+
+	j.EnvOverride = compressedEnv
+	j.EnvOverrideSet = true
+
+	return nil
+}
+
+func (j *JobModifier) setEnvOverrideValues(newVal []string) error {
+	var compressedEnv []byte
+
+	if len(newVal) > 0 {
+		var err error
+
+		compressedEnv, err = compressEnv(newVal)
 		if err != nil {
 			return err
 		}

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -495,21 +495,33 @@ func (j *Job) Env() ([]string, error) {
 
 // envCurrentOverrides decompresses and decodes any existing EnvOverride.
 func (j *Job) envCurrentOverrides() ([]string, error) {
-	if len(j.EnvOverride) > 0 {
-		decompressed, err := decompress(j.EnvOverride)
-		if err != nil {
-			return nil, err
-		}
-		ch := new(codec.BincHandle)
-		dec := codec.NewDecoderBytes(decompressed, ch)
-		overrideEs := &envStr{}
-		err = dec.Decode(overrideEs)
-		if err != nil {
-			return nil, err
-		}
-		return overrideEs.Environ, err
+	envOverride := j.envOverrideSnapshot()
+	if len(envOverride) == 0 {
+		return nil, nil
 	}
-	return nil, nil
+
+	decompressed, err := decompress(envOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := new(codec.BincHandle)
+	dec := codec.NewDecoderBytes(decompressed, ch)
+	overrideEs := &envStr{}
+
+	err = dec.Decode(overrideEs)
+	if err != nil {
+		return nil, err
+	}
+
+	return overrideEs.Environ, err
+}
+
+func (j *Job) envOverrideSnapshot() []byte {
+	j.RLock()
+	defer j.RUnlock()
+
+	return slices.Clone(j.EnvOverride)
 }
 
 // EnvAddOverride adds additional overrides to the jobs existing overrides (if
@@ -523,9 +535,16 @@ func (j *Job) EnvAddOverride(env []string) error {
 		return err
 	}
 
-	j.EnvOverride, err = compressEnv(envOverride(current, env))
+	compressed, err := compressEnv(envOverride(current, env))
+	if err != nil {
+		return err
+	}
 
-	return err
+	j.Lock()
+	j.EnvOverride = compressed
+	j.Unlock()
+
+	return nil
 }
 
 // Getenv is like os.Getenv(), but for the environment variables stored in the

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -260,5 +261,53 @@ func TestJob(t *testing.T) {
 		So(*status.Started, ShouldEqual, started.UnixNano())
 		So(*status.Ended, ShouldEqual, ended.UnixNano())
 		So(*status.Ended, ShouldBeGreaterThan, *status.Started)
+	})
+
+	Convey("ToStatus() safely reports env overrides while they change", t, func() {
+		job := &Job{
+			Cmd:          "true",
+			Cwd:          "/cwd",
+			Requirements: &scheduler.Requirements{RAM: 1, Time: time.Second, Cores: 1},
+			State:        JobStateReady,
+		}
+		overrideA, erra := compressEnv([]string{"WR_RACE=A"})
+		So(erra, ShouldBeNil)
+
+		overrideB, errb := compressEnv([]string{"WR_RACE=B"})
+		So(errb, ShouldBeNil)
+
+		start := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			for i := range 5000 {
+				job.Lock()
+				if i%2 == 0 {
+					job.EnvOverride = overrideA
+				} else {
+					job.EnvOverride = overrideB
+				}
+				job.Unlock()
+			}
+		}()
+
+		close(start)
+
+		readErrors := 0
+
+		for range 5000 {
+			if _, err := job.ToStatus(); err != nil {
+				readErrors++
+			}
+		}
+
+		wg.Wait()
+		So(readErrors, ShouldEqual, 0)
 	})
 }

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -530,6 +530,17 @@ func TestRESTJobModificationValidation(t *testing.T) {
 			So(getJobStatus(key, false).Cmd, ShouldEqual, "echo rest empty cmd")
 		})
 
+		Convey("PATCH reports no-retry walltime parse errors with the field name", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest bad no retry", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-bad-no-retry",
+			})
+
+			status, body, _ := patchJob(key, `{"no_retry_over_walltime":"notaduration"}`)
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldContainSubstring, "no_retry_over_walltime value (notaduration) was not specified correctly")
+		})
+
 		Convey("PATCH rejects running jobs without changing them", func() {
 			key := addJob(&Job{
 				Cmd: "echo rest running", Cwd: testCwd, ReqGroup: restA2ReqGroup,

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -51,6 +51,285 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+func TestRESTJobModificationEndpoint(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+	config, serverConfig, addr, _, clientConnectTime := jobqueueTestInit(true)
+
+	Convey("Once the REST modification endpoint is up", t, func() {
+		server, _, token, errs := serve(ctx, serverConfig)
+		So(errs, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		handler := restJobs(ctx, server)
+		bearer := "Bearer " + string(token)
+
+		const restBulkCmdGroup = "rest-bulk-cmd"
+
+		addJob := func(job *Job) string {
+			inserts, already, erra := jq.Add([]*Job{job}, envVars, true)
+			So(erra, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
+
+			return job.Key()
+		}
+
+		patchJob := func(target, body, authHeader string) (int, string, JobModifyResponse) {
+			w := httptest.NewRecorder()
+
+			r := httptest.NewRequestWithContext(ctx, http.MethodPatch, target, strings.NewReader(body))
+			if authHeader != "" {
+				r.Header.Set("Authorization", authHeader)
+			}
+
+			r.Header.Set("Content-Type", "application/json")
+
+			handler(w, r)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			responseData, errr := io.ReadAll(resp.Body)
+			So(errr, ShouldBeNil)
+
+			var decoded JobModifyResponse
+			if resp.StatusCode == http.StatusOK {
+				errr = json.Unmarshal(responseData, &decoded)
+				So(errr, ShouldBeNil)
+			}
+
+			return resp.StatusCode, string(responseData), decoded
+		}
+
+		getJobStatuses := func(key string, getEnv bool) []JStatus {
+			target := restJobsEndpoint + key
+			if getEnv {
+				target += "?env=true"
+			}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+			r.Header.Set("Authorization", bearer)
+
+			handler(w, r)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			var statuses []JStatus
+
+			errr := json.NewDecoder(resp.Body).Decode(&statuses)
+			So(errr, ShouldBeNil)
+
+			return statuses
+		}
+
+		reserveOnly := func(key string) *Job {
+			job, errr := jq.Reserve(50 * time.Millisecond)
+			So(errr, ShouldBeNil)
+			So(job, ShouldNotBeNil)
+			So(job.Key(), ShouldEqual, key)
+
+			return job
+		}
+
+		Convey("PATCH modifies one ready job by key and returns fresh status rows", func() {
+			job := &Job{
+				Cmd:          "echo rest old",
+				Cwd:          testCwd,
+				ReqGroup:     "rest-old",
+				Requirements: &jqs.Requirements{RAM: 50, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				Priority:     1,
+				Retries:      1,
+				Override:     0,
+				LimitGroups:  []string{"old:1"},
+				RepGroup:     "rest-a1-single",
+			}
+			err = job.EnvAddOverride([]string{"REST_MOD=old"})
+			So(err, ShouldBeNil)
+
+			oldKey := addJob(job)
+			body := `{
+				"cmd": "echo rest new",
+				"cwd": "/tmp/rest-new",
+				"cwd_matters": true,
+				"change_home": true,
+				"req_grp": "rest-new",
+				"memory": "64M",
+				"time": "2m",
+				"cpus": 0.5,
+				"disk": 2,
+				"priority": 7,
+				"retries": 4,
+				"override": 2,
+				"limit_grps": ["new:2"],
+				"modules": ["module-a"],
+				"env": ["REST_MOD=new", "REST_EXTRA=1"],
+				"other": {"scheduler_queue": "short"},
+				"on_exit": [{"nothing": true}]
+			}`
+
+			status, _, decoded := patchJob(restJobsEndpoint+oldKey, body, bearer)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Modified), ShouldEqual, 1)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+
+			newKey := decoded.Jobs[0].Key
+			So(newKey, ShouldNotEqual, "")
+			So(newKey, ShouldNotEqual, oldKey)
+			So(decoded.Modified[newKey], ShouldEqual, oldKey)
+
+			stored := getJobStatuses(newKey, true)
+			So(len(stored), ShouldEqual, 1)
+			So(stored[0].Cmd, ShouldEqual, "echo rest new")
+			So(stored[0].CwdBase, ShouldEqual, "/tmp/rest-new")
+			So(stored[0].ReqGroup, ShouldEqual, "rest-new")
+			So(stored[0].CwdMatters, ShouldBeTrue)
+			So(stored[0].HomeChanged, ShouldBeTrue)
+			So(stored[0].ExpectedRAM, ShouldEqual, 64)
+			So(stored[0].ExpectedTime, ShouldEqual, 120)
+			So(stored[0].Cores, ShouldEqual, 0.5)
+			So(stored[0].RequestedDisk, ShouldEqual, 2)
+			So(stored[0].Priority, ShouldEqual, 7)
+			So(stored[0].Retries, ShouldEqual, 4)
+			So(stored[0].Override, ShouldEqual, 2)
+			So(stored[0].LimitGroups, ShouldResemble, []string{"new:2"})
+			So(stored[0].Modules, ShouldResemble, []string{"module-a"})
+			So(stored[0].Env, ShouldContain, "REST_MOD=new")
+			So(stored[0].Env, ShouldContain, "REST_EXTRA=1")
+			So(stored[0].OtherRequests, ShouldContain, "scheduler_queue:short")
+			So(stored[0].Behaviours, ShouldEqual, `{"on_exit":[{"nothing":true}]}`)
+
+			storedWithoutEnv := getJobStatuses(newKey, false)
+			So(len(storedWithoutEnv), ShouldEqual, 1)
+			So(decoded.Jobs[0], ShouldResemble, storedWithoutEnv[0])
+
+			oldStatuses := getJobStatuses(oldKey, false)
+			So(len(oldStatuses), ShouldEqual, 0)
+		})
+
+		Convey("PATCH accepts the token query parameter without bearer auth", func() {
+			key := addJob(&Job{
+				Cmd:          "echo rest token auth",
+				Cwd:          testCwd,
+				ReqGroup:     "rest-token",
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				Priority:     1,
+				RepGroup:     "rest-a1-token",
+			})
+
+			status, _, decoded := patchJob(restJobsEndpoint+key+"?token="+string(token), `{"priority":9}`, "")
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+			So(decoded.Jobs[0].Priority, ShouldEqual, 9)
+			So(decoded.Modified[decoded.Jobs[0].Key], ShouldEqual, key)
+
+			stored := getJobStatuses(key, false)
+			So(len(stored), ShouldEqual, 1)
+			So(stored[0].Priority, ShouldEqual, 9)
+		})
+
+		Convey("PATCH rejects requests without token or bearer auth", func() {
+			key := addJob(&Job{
+				Cmd:          "echo rest no auth",
+				Cwd:          testCwd,
+				ReqGroup:     "rest-no-auth",
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				RepGroup:     "rest-a1-no-auth",
+			})
+
+			status, _, _ := patchJob(restJobsEndpoint+key, `{"priority":9}`, "")
+			So(status, ShouldEqual, http.StatusUnauthorized)
+		})
+
+		Convey("PATCH modifies multiple editable RepGroup jobs and leaves running jobs unchanged", func() {
+			runningKey := addJob(&Job{
+				Cmd:          "echo rest bulk running",
+				Cwd:          testCwd,
+				ReqGroup:     "rest-bulk-running",
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				Priority:     3,
+				LimitGroups:  []string{"running:1"},
+				RepGroup:     "rest-bulk",
+			})
+			runningJob := reserveOnly(runningKey)
+			err = jq.Started(runningJob, os.Getpid())
+			So(err, ShouldBeNil)
+
+			for i := range 3 {
+				addJob(&Job{
+					Cmd:          fmt.Sprintf("echo rest bulk %d", i),
+					Cwd:          testCwd,
+					ReqGroup:     "rest-bulk-editable",
+					Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+					Priority:     1,
+					LimitGroups:  []string{"oldbulk:2"},
+					RepGroup:     "rest-bulk",
+				})
+			}
+
+			status, _, decoded := patchJob(restJobsEndpoint+"rest-bulk", `{"priority":8,"limit_grps":["bulk:1"]}`, bearer)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Modified), ShouldEqual, 3)
+			So(len(decoded.Jobs), ShouldEqual, 3)
+
+			for _, job := range decoded.Jobs {
+				So(job.Priority, ShouldEqual, 8)
+				So(job.LimitGroups, ShouldResemble, []string{"bulk:1"})
+				So(decoded.Modified[job.Key], ShouldEqual, job.Key)
+				So(job.Key, ShouldNotEqual, runningKey)
+			}
+
+			runningStatuses := getJobStatuses(runningKey, false)
+			So(len(runningStatuses), ShouldEqual, 1)
+			So(runningStatuses[0].State, ShouldEqual, JobStateRunning)
+			So(runningStatuses[0].Priority, ShouldEqual, 3)
+			So(runningStatuses[0].LimitGroups, ShouldResemble, []string{"running:1"})
+		})
+
+		Convey("PATCH rejects command changes when a RepGroup matches multiple editable jobs", func() {
+			keyA := addJob(&Job{
+				Cmd:          "echo rest bulk cmd a",
+				Cwd:          testCwd,
+				ReqGroup:     restBulkCmdGroup,
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				RepGroup:     restBulkCmdGroup,
+			})
+			keyB := addJob(&Job{
+				Cmd:          "echo rest bulk cmd b",
+				Cwd:          testCwd,
+				ReqGroup:     restBulkCmdGroup,
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				RepGroup:     restBulkCmdGroup,
+			})
+
+			status, body, _ := patchJob(restJobsEndpoint+restBulkCmdGroup, `{"cmd":"echo same"}`, bearer)
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldEqual, "cmd can only be modified for one job\n")
+
+			storedA := getJobStatuses(keyA, false)
+			So(len(storedA), ShouldEqual, 1)
+			So(storedA[0].Cmd, ShouldEqual, "echo rest bulk cmd a")
+
+			storedB := getJobStatuses(keyB, false)
+			So(len(storedB), ShouldEqual, 1)
+			So(storedB[0].Cmd, ShouldEqual, "echo rest bulk cmd b")
+		})
+	})
+}
+
 func TestRESTJobModificationValidation(t *testing.T) {
 	if runnermode || servermode {
 		return

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -159,6 +159,8 @@ func TestRESTJobModificationValidation(t *testing.T) {
 			So(decoded.Jobs[0].Priority, ShouldEqual, 9)
 			So(getJobStatus(key, false).State, ShouldEqual, JobStateDelayed)
 			So(getJobStatus(key, false).Priority, ShouldEqual, 9)
+			time.Sleep(50 * time.Millisecond)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateDelayed)
 		})
 
 		Convey("PATCH modifies dependent jobs and preserves their state", func() {

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -36,9 +36,11 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,6 +50,305 @@ import (
 	"github.com/inconshreveable/log15/v3"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func TestRESTJobModificationValidation(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
+
+	const restA2ReqGroup = "rest-a2"
+
+	Convey("Once the REST modification server is up", t, func() {
+		server, _, token, errs := serve(ctx, serverConfig)
+		So(errs, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		handler := restJobs(ctx, server)
+		bearer := "Bearer " + string(token)
+
+		addJob := func(job *Job) string {
+			inserts, already, erra := jq.Add([]*Job{job}, envVars, true)
+			So(erra, ShouldBeNil)
+			So(inserts, ShouldEqual, 1)
+			So(already, ShouldEqual, 0)
+
+			return job.Key()
+		}
+
+		patchJob := func(id, body string) (int, string, JobModifyResponse) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(ctx, http.MethodPatch, restJobsEndpoint+id, strings.NewReader(body))
+			r.Header.Set("Authorization", bearer)
+			r.Header.Set("Content-Type", "application/json")
+
+			handler(w, r)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			responseData, errr := io.ReadAll(resp.Body)
+			So(errr, ShouldBeNil)
+
+			var decoded JobModifyResponse
+			if resp.StatusCode == http.StatusOK {
+				errr = json.Unmarshal(responseData, &decoded)
+				So(errr, ShouldBeNil)
+			}
+
+			return resp.StatusCode, string(responseData), decoded
+		}
+
+		getJobStatus := func(key string, getEnv bool) JStatus {
+			target := restJobsEndpoint + key
+			if getEnv {
+				target += "?env=true"
+			}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+			r.Header.Set("Authorization", bearer)
+
+			handler(w, r)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			var statuses []JStatus
+
+			errr := json.NewDecoder(resp.Body).Decode(&statuses)
+			So(errr, ShouldBeNil)
+			So(len(statuses), ShouldEqual, 1)
+
+			return statuses[0]
+		}
+
+		reserveOnly := func(key string) *Job {
+			job, errr := jq.Reserve(50 * time.Millisecond)
+			So(errr, ShouldBeNil)
+			So(job, ShouldNotBeNil)
+			So(job.Key(), ShouldEqual, key)
+
+			return job
+		}
+
+		Convey("PATCH modifies delayed jobs and preserves their state", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest delayed", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-delayed", Priority: 1, Retries: 3,
+			})
+			job := reserveOnly(key)
+			err = jq.Release(job, &JobEndState{Exited: true, Exitcode: 1, EndTime: time.Now()}, FailReasonExit)
+			So(err, ShouldBeNil)
+			So(waitUntilJobState(jq, &JobEssence{JobKey: key}, JobStateDelayed, 5).State, ShouldEqual, JobStateDelayed)
+
+			status, _, decoded := patchJob(key, `{"priority":9}`)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+			So(decoded.Jobs[0].State, ShouldEqual, JobStateDelayed)
+			So(decoded.Jobs[0].Priority, ShouldEqual, 9)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateDelayed)
+			So(getJobStatus(key, false).Priority, ShouldEqual, 9)
+		})
+
+		Convey("PATCH modifies dependent jobs and preserves their state", func() {
+			addJob(&Job{
+				Cmd: "echo rest dep parent", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-dep-parent", DepGroups: []string{"rest-a2-parent"},
+			})
+			key := addJob(&Job{
+				Cmd: "echo rest dep child", Cwd: testCwd, ReqGroup: "dep-old",
+				Requirements: standardReqs, RepGroup: "rest-a2-dependent",
+				Dependencies: Dependencies{NewDepGroupDependency("rest-a2-parent")},
+			})
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateDependent)
+
+			status, _, decoded := patchJob(key, `{"req_grp":"dep-new"}`)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+			So(decoded.Jobs[0].State, ShouldEqual, JobStateDependent)
+			So(decoded.Jobs[0].ReqGroup, ShouldEqual, "dep-new")
+
+			stored := getJobStatus(key, false)
+			So(stored.State, ShouldEqual, JobStateDependent)
+			So(stored.ReqGroup, ShouldEqual, "dep-new")
+		})
+
+		Convey("PATCH modifies buried jobs and preserves their state", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest buried", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-buried", Retries: 1,
+			})
+			job := reserveOnly(key)
+			err = jq.Bury(job, nil, "rest buried")
+			So(err, ShouldBeNil)
+			So(waitUntilJobState(jq, &JobEssence{JobKey: key}, JobStateBuried, 5).State, ShouldEqual, JobStateBuried)
+
+			status, _, decoded := patchJob(key, `{"retries":3}`)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+			So(decoded.Jobs[0].State, ShouldEqual, JobStateBuried)
+			So(decoded.Jobs[0].Retries, ShouldEqual, 3)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateBuried)
+			So(getJobStatus(key, false).Retries, ShouldEqual, 3)
+		})
+
+		Convey("PATCH rejects priority values outside 0..255", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest bad priority", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-bad-priority", Priority: 1,
+			})
+
+			status, body, _ := patchJob(key, `{"priority":256}`)
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldContainSubstring, "priority value (256) is not in the range 0..255")
+			So(getJobStatus(key, false).Priority, ShouldEqual, 1)
+		})
+
+		Convey("PATCH rejects an empty command", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest empty cmd", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-empty-cmd",
+			})
+
+			status, body, _ := patchJob(key, `{"cmd":""}`)
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldEqual, "cmd cannot be empty\n")
+			So(getJobStatus(key, false).Cmd, ShouldEqual, "echo rest empty cmd")
+		})
+
+		Convey("PATCH rejects running jobs without changing them", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest running", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-running", Priority: 1,
+			})
+			job := reserveOnly(key)
+			err = jq.Started(job, os.Getpid())
+			So(err, ShouldBeNil)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateRunning)
+
+			status, body, _ := patchJob(key, `{"priority":9}`)
+			So(status, ShouldEqual, http.StatusConflict)
+			So(body, ShouldEqual, "no editable jobs matched\n")
+			So(getJobStatus(key, false).Priority, ShouldEqual, 1)
+		})
+
+		Convey("PATCH rejects complete jobs without creating ready jobs", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest complete", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-complete", Retries: 1,
+			})
+			job := reserveOnly(key)
+			err = jq.Started(job, os.Getpid())
+			So(err, ShouldBeNil)
+			err = jq.Archive(job, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()})
+			So(err, ShouldBeNil)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateComplete)
+
+			status, body, _ := patchJob(key, `{"retries":9}`)
+			So(status, ShouldEqual, http.StatusConflict)
+			So(body, ShouldEqual, "no editable jobs matched\n")
+
+			jobs, errg := jq.GetByRepGroup("rest-a2-complete", false, 0, JobStateReady, false, false)
+			So(errg, ShouldBeNil)
+			So(len(jobs), ShouldEqual, 0)
+		})
+
+		Convey("PATCH rejects reserved jobs without changing them", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest reserved", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-reserved", Priority: 1,
+			})
+			reserveOnly(key)
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateReserved)
+
+			status, body, _ := patchJob(key, `{"priority":9}`)
+			So(status, ShouldEqual, http.StatusConflict)
+			So(body, ShouldEqual, "no editable jobs matched\n")
+			So(getJobStatus(key, false).Priority, ShouldEqual, 1)
+		})
+
+		Convey("PATCH rejects lost jobs without changing them", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest lost", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-lost", Priority: 1,
+			})
+			job := reserveOnly(key)
+			err = jq.Started(job, os.Getpid())
+			So(err, ShouldBeNil)
+
+			item, errq := server.q.Get(key)
+			So(errq, ShouldBeNil)
+
+			serverJob, ok := item.Data().(*Job)
+			So(ok, ShouldBeTrue)
+			serverJob.Lock()
+			serverJob.Lost = true
+			serverJob.Unlock()
+			So(getJobStatus(key, false).State, ShouldEqual, JobStateLost)
+
+			status, body, _ := patchJob(key, `{"priority":9}`)
+			So(status, ShouldEqual, http.StatusConflict)
+			So(body, ShouldEqual, "no editable jobs matched\n")
+			So(getJobStatus(key, false).Priority, ShouldEqual, 1)
+		})
+
+		Convey("PATCH returns not found for unknown jobs", func() {
+			status, body, _ := patchJob("0123456789abcdef0123456789abcdef", `{"priority":9}`)
+			So(status, ShouldEqual, http.StatusNotFound)
+			So(body, ShouldEqual, "job not found\n")
+
+			jobs, errg := jq.GetByRepGroup("0123456789abcdef0123456789abcdef", false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(len(jobs), ShouldEqual, 0)
+		})
+
+		Convey("PATCH clears job-specific env overrides", func() {
+			job := &Job{
+				Cmd: "echo rest clear env", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-clear-env",
+			}
+			err = job.EnvAddOverride([]string{"REST_CLEAR=1"})
+			So(err, ShouldBeNil)
+
+			key := addJob(job)
+
+			status, _, _ := patchJob(key, `{"env":[]}`)
+			So(status, ShouldEqual, http.StatusOK)
+
+			stored := getJobStatus(key, true)
+			So(stored.Env, ShouldNotContain, "REST_CLEAR=1")
+			So(stored.EnvOverrides, ShouldBeEmpty)
+		})
+
+		Convey("PATCH reports duplicate-key command edits without changing either job", func() {
+			keyA := addJob(&Job{
+				Cmd: "echo rest duplicate a", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-duplicate-a",
+			})
+			keyB := addJob(&Job{
+				Cmd: "echo rest duplicate b", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-duplicate-b",
+			})
+
+			status, body, _ := patchJob(keyA, `{"cmd":"echo rest duplicate b"}`)
+			So(status, ShouldEqual, http.StatusConflict)
+			So(body, ShouldEqual, "no jobs were modified\n")
+			So(getJobStatus(keyA, false).Cmd, ShouldEqual, "echo rest duplicate a")
+			So(getJobStatus(keyB, false).Cmd, ShouldEqual, "echo rest duplicate b")
+		})
+	})
+}
 
 // waitForRESTJobState polls the REST job endpoint at url until it returns
 // exactly one job in the wanted state (or pollUntil's deadline elapses),

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -241,6 +241,28 @@ func TestRESTJobModificationEndpoint(t *testing.T) {
 			So(stored[0].Priority, ShouldEqual, 9)
 		})
 
+		Convey("PATCH accepts public command dependency JSON", func() {
+			key := addJob(&Job{
+				Cmd:          "echo rest cmd deps",
+				Cwd:          testCwd,
+				ReqGroup:     "rest-cmd-deps",
+				Requirements: &jqs.Requirements{RAM: 10, Time: time.Minute, Cores: 1, Disk: 0, Other: make(map[string]string)},
+				RepGroup:     "rest-a1-cmd-deps",
+			})
+
+			body := `{"deps":["dep-a"],"cmd_deps":[{"cmd":"echo dep","cwd":"/tmp/dep"}]}`
+			status, _, decoded := patchJob(restJobsEndpoint+key, body, bearer)
+			So(status, ShouldEqual, http.StatusOK)
+			So(len(decoded.Jobs), ShouldEqual, 1)
+			So(decoded.Jobs[0].Dependencies, ShouldContain, "dep-a")
+			So(decoded.Jobs[0].Dependencies, ShouldContain, "echo dep [/tmp/dep]")
+
+			stored := getJobStatuses(key, false)
+			So(len(stored), ShouldEqual, 1)
+			So(stored[0].Dependencies, ShouldContain, "dep-a")
+			So(stored[0].Dependencies, ShouldContain, "echo dep [/tmp/dep]")
+		})
+
 		Convey("PATCH rejects requests without token or bearer auth", func() {
 			key := addJob(&Job{
 				Cmd:          "echo rest no auth",

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -581,6 +581,22 @@ func TestRESTJobModificationValidation(t *testing.T) {
 			So(getJobStatus(key, false).Priority, ShouldEqual, 1)
 		})
 
+		Convey("PATCH reports no editable jobs when queue state changes before modification", func() {
+			key := addJob(&Job{
+				Cmd: "echo rest stale editable", Cwd: testCwd, ReqGroup: restA2ReqGroup,
+				Requirements: standardReqs, RepGroup: "rest-a2-stale-editable", Priority: 1,
+			})
+			reserveOnly(key)
+
+			modifier := NewJobModifer()
+			modifier.SetPriority(9)
+
+			modified, errm := server.modifyJobsByKeys(ctx, []string{key}, modifier)
+			So(errm, ShouldBeNil)
+			So(len(modified), ShouldEqual, 0)
+			So(server.restModifyEmptyResultError([]string{key}), ShouldEqual, errRESTModifyNoEditable)
+		})
+
 		Convey("PATCH rejects lost jobs without changing them", func() {
 			key := addJob(&Job{
 				Cmd: "echo rest lost", Cwd: testCwd, ReqGroup: restA2ReqGroup,

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -2832,9 +2832,12 @@ func (s *Server) createJobs(ctx context.Context, inputJobs []*Job, envkey string
 // latest limit on groups, if any were specified. You should hold the lock on
 // the Job before calling this.
 func (s *Server) handleUserSpecifiedJobLimitGroups(job *Job, limitGroups map[string]*limiter.GroupData) {
+	displayByName := make(map[string]string, len(job.LimitGroups))
+
 	// remove limit suffixes and remember the last limit per group specified
 	for i, group := range job.LimitGroups {
 		name, limit := s.splitSuffixedLimitGroup(group)
+		displayByName[name] = group
 
 		if limit != nil {
 			job.LimitGroups[i] = name
@@ -2846,6 +2849,11 @@ func (s *Server) handleUserSpecifiedJobLimitGroups(job *Job, limitGroups map[str
 	// them in sorted order, with no duplicates
 	if len(job.LimitGroups) > 1 {
 		job.LimitGroups = internal.DedupSortStrings(job.LimitGroups)
+	}
+
+	job.LimitGroupsForDisplay = make([]string, 0, len(job.LimitGroups))
+	for _, group := range job.LimitGroups {
+		job.LimitGroupsForDisplay = append(job.LimitGroupsForDisplay, displayByName[group])
 	}
 }
 

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -1128,6 +1128,7 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 		ReqGroup:              sjob.ReqGroup,
 		Group:                 sjob.Group,
 		LimitGroups:           sjob.LimitGroups,
+		LimitGroupsForDisplay: sjob.LimitGroupsForDisplay,
 		Modules:               sjob.Modules,
 		DepGroups:             sjob.DepGroups,
 		Cmd:                   sjob.Cmd,

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -1136,6 +1136,7 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 		ChangeHome:            sjob.ChangeHome,
 		ActualCwd:             sjob.ActualCwd,
 		Requirements:          req,
+		Override:              sjob.Override,
 		Priority:              sjob.Priority,
 		Retries:               sjob.Retries,
 		DelayTime:             sjob.DelayTime,

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -42,6 +42,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -50,6 +51,8 @@ import (
 	"github.com/VertebrateResequencing/wr/clog"
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	"github.com/VertebrateResequencing/wr/limiter"
+	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/ugorji/go/codec"
 )
 
@@ -63,7 +66,197 @@ const (
 	restInfoEndpoint       = "/rest/v" + restAPIVersion + "/info/"
 	restFormTrue           = "true"
 	bearerSchema           = "Bearer "
+	restJobKeyLength       = 32
+	restModifyOverrideMax  = 2
+	restModifyUint8Max     = 255
 )
+
+var (
+	errRESTModifyCmdEmpty        = errors.New("cmd cannot be empty")
+	errRESTModifyCwdEmpty        = errors.New("cwd cannot be empty")
+	errRESTModifyIdentifierEmpty = errors.New("job identifier is required")
+	errRESTModifyNoEditable      = errors.New("no editable jobs matched")
+	errRESTModifyCmdMultiJob     = errors.New("cmd can only be modified for one job")
+	errRESTModifyNoneModified    = errors.New("no jobs were modified")
+	errRESTModifyNotFound        = errors.New("job not found")
+)
+
+type restRangeError struct {
+	name  string
+	value int
+	limit int
+}
+
+func (e restRangeError) Error() string {
+	return fmt.Sprintf("%s value (%d) is not in the range 0..%d", e.name, e.value, e.limit)
+}
+
+func uint8ModificationValue(name string, value *int, limit int) (uint8, bool, error) {
+	if value == nil {
+		return 0, false, nil
+	}
+
+	if *value < 0 || *value > limit {
+		return 0, false, restRangeError{name: name, value: *value, limit: limit}
+	}
+
+	parsed, err := strconv.ParseUint(strconv.Itoa(*value), 10, 8)
+	if err != nil {
+		return 0, false, err
+	}
+
+	return uint8(parsed), true, nil
+}
+
+func restJobsModify(ctx context.Context, r *http.Request, s *Server) (*JobModifyResponse, int, error) {
+	ids, modifier, status, err := restJobModifierFromRequest(r)
+	if err != nil {
+		return nil, status, err
+	}
+
+	editableKeys, status, err := restEditableKeysForModification(ctx, s, ids, modifier)
+	if err != nil {
+		return nil, status, err
+	}
+
+	modified, err := s.modifyJobsByKeys(ctx, editableKeys, modifier)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	if len(modified) == 0 {
+		return nil, http.StatusConflict, errRESTModifyNoneModified
+	}
+
+	statuses, err := s.modifiedJobStatuses(ctx, modified)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+
+	return &JobModifyResponse{Modified: modified, Jobs: statuses}, http.StatusOK, nil
+}
+
+func restJobModifierFromRequest(r *http.Request) (string, *JobModifier, int, error) {
+	ids := strings.TrimPrefix(r.URL.Path, restJobsEndpoint)
+	if ids == "" {
+		return "", nil, http.StatusBadRequest, errRESTModifyIdentifierEmpty
+	}
+
+	var modifyJSON JobModifyViaJSON
+	if err := json.NewDecoder(r.Body).Decode(&modifyJSON); err != nil {
+		return "", nil, http.StatusBadRequest, err
+	}
+
+	modifier, err := modifyJSON.Convert()
+	if err != nil {
+		return "", nil, http.StatusBadRequest, err
+	}
+
+	return ids, modifier, http.StatusOK, nil
+}
+
+func restEditableKeysForModification(ctx context.Context, s *Server, ids string,
+	modifier *JobModifier,
+) ([]string, int, error) {
+	targets, status, err := restJobsModificationTargets(ctx, s, ids)
+	if err != nil {
+		return nil, status, err
+	}
+
+	editableKeys := restEditableJobKeys(targets)
+	if len(editableKeys) == 0 {
+		return nil, http.StatusConflict, errRESTModifyNoEditable
+	}
+
+	if modifier.Cmd != "" && len(editableKeys) > 1 {
+		return nil, http.StatusBadRequest, errRESTModifyCmdMultiJob
+	}
+
+	return editableKeys, http.StatusOK, nil
+}
+
+func restJobsModificationTargets(ctx context.Context, s *Server, ids string) ([]*Job, int, error) {
+	var targets []*Job
+
+	for _, id := range strings.Split(ids, ",") {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+
+		jobs, status, err := restJobsModificationTarget(ctx, s, id)
+		if err != nil {
+			return nil, status, err
+		}
+
+		targets = append(targets, jobs...)
+	}
+
+	if len(targets) == 0 {
+		return nil, http.StatusNotFound, errRESTModifyNotFound
+	}
+
+	return targets, http.StatusOK, nil
+}
+
+func restJobsModificationTarget(ctx context.Context, s *Server, id string) ([]*Job, int, error) {
+	if len(id) != restJobKeyLength {
+		return restJobsModificationRepGroupTarget(ctx, s, id)
+	}
+
+	jobs, _, qerr := s.getJobsByKeys(ctx, []string{id}, false, false)
+	if qerr != "" {
+		return nil, http.StatusInternalServerError, Error{Err: qerr}
+	}
+
+	if len(jobs) > 0 {
+		return jobs, http.StatusOK, nil
+	}
+
+	return restJobsModificationRepGroupTarget(ctx, s, id)
+}
+
+func restJobsModificationRepGroupTarget(ctx context.Context, s *Server, id string) ([]*Job, int, error) {
+	opts := repGroupOptions{
+		RepGroup: id,
+		Match:    RepGroupMatchExact,
+	}
+
+	jobs, _, qerr := s.getJobsByRepGroup(ctx, opts)
+	if qerr != "" {
+		return nil, http.StatusInternalServerError, Error{Err: qerr}
+	}
+
+	return jobs, http.StatusOK, nil
+}
+
+func restEditableJobKeys(jobs []*Job) []string {
+	keys := make(map[string]bool)
+
+	for _, job := range jobs {
+		if restEditableState(job.State) {
+			keys[job.Key()] = true
+		}
+	}
+
+	editable := make([]string, 0, len(keys))
+	for key := range keys {
+		editable = append(editable, key)
+	}
+
+	sort.Strings(editable)
+
+	return editable
+}
+
+func restEditableState(state JobState) bool {
+	switch state {
+	case JobStateDelayed, JobStateReady, JobStateDependent, JobStateBuried:
+		return true
+	default:
+		return false
+	}
+}
 
 // JobViaJSON describes the properties of a JOB that a user wishes to add to the
 // queue, convenient if they are supplying JSON.
@@ -557,6 +750,473 @@ func (jvj *JobViaJSON) Convert(jd *JobDefaults) (*Job, error) {
 	}, nil
 }
 
+// JobModifyViaJSON describes the properties of queued jobs that a REST client
+// wishes to modify. Nil fields are left unchanged.
+type JobModifyViaJSON struct {
+	MountConfigs         *MountConfigs      `json:"mounts,omitempty"`
+	LimitGrps            *[]string          `json:"limit_grps,omitempty"`
+	Modules              *[]string          `json:"modules,omitempty"`
+	Deps                 *[]string          `json:"deps,omitempty"`
+	CmdDeps              *Dependencies      `json:"cmd_deps,omitempty"`
+	OnFailure            *BehavioursViaJSON `json:"on_failure,omitempty"`
+	OnSuccess            *BehavioursViaJSON `json:"on_success,omitempty"`
+	OnExit               *BehavioursViaJSON `json:"on_exit,omitempty"`
+	Env                  *[]string          `json:"env,omitempty"`
+	Other                *map[string]string `json:"other,omitempty"`
+	Cmd                  *string            `json:"cmd,omitempty"`
+	Cwd                  *string            `json:"cwd,omitempty"`
+	ReqGrp               *string            `json:"req_grp,omitempty"`
+	Group                *string            `json:"group,omitempty"`
+	Memory               *string            `json:"memory,omitempty"`
+	Time                 *string            `json:"time,omitempty"`
+	MonitorDocker        *string            `json:"monitor_docker,omitempty"`
+	WithDocker           *string            `json:"with_docker,omitempty"`
+	WithSingularity      *string            `json:"with_singularity,omitempty"`
+	ContainerMounts      *string            `json:"container_mounts,omitempty"`
+	SchedulerQueue       *string            `json:"queue,omitempty"`
+	SchedulerQueuesAvoid *string            `json:"queues_avoid,omitempty"`
+	SchedulerMisc        *string            `json:"misc,omitempty"`
+	CloudOS              *string            `json:"cloud_os,omitempty"`
+	CloudUser            *string            `json:"cloud_username,omitempty"`
+	CloudRAM             *int               `json:"cloud_ram,omitempty"`
+	CloudFlavor          *string            `json:"cloud_flavor,omitempty"`
+	CloudScript          *string            `json:"cloud_script,omitempty"`
+	CloudConfigFiles     *string            `json:"cloud_config_files,omitempty"`
+	CloudShared          *bool              `json:"cloud_shared,omitempty"`
+	CPUs                 *float64           `json:"cpus,omitempty"`
+	Disk                 *int               `json:"disk,omitempty"`
+	Override             *int               `json:"override,omitempty"`
+	Priority             *int               `json:"priority,omitempty"`
+	Retries              *int               `json:"retries,omitempty"`
+	NoRetryOverWalltime  *string            `json:"no_retry_over_walltime,omitempty"`
+	CwdMatters           *bool              `json:"cwd_matters,omitempty"`
+	ChangeHome           *bool              `json:"change_home,omitempty"`
+}
+
+// Convert converts REST JSON modification fields to a JobModifier.
+func (jvj *JobModifyViaJSON) Convert() (*JobModifier, error) {
+	modifier := NewJobModifer()
+
+	if err := jvj.setModifierIdentityFields(modifier); err != nil {
+		return nil, err
+	}
+
+	if err := jvj.setModifierRequirements(modifier); err != nil {
+		return nil, err
+	}
+
+	if err := jvj.setModifierRetryFields(modifier); err != nil {
+		return nil, err
+	}
+
+	jvj.setModifierSliceFields(modifier)
+
+	if err := jvj.setModifierEnv(modifier); err != nil {
+		return nil, err
+	}
+
+	jvj.setModifierBehaviours(modifier)
+	jvj.setModifierContainerFields(modifier)
+
+	return modifier, nil
+}
+
+func (jvj *JobModifyViaJSON) setModifierIdentityFields(modifier *JobModifier) error {
+	if err := jvj.setModifierCommandFields(modifier); err != nil {
+		return err
+	}
+
+	jvj.setModifierIdentityFlags(modifier)
+
+	return nil
+}
+
+func (jvj *JobModifyViaJSON) setModifierCommandFields(modifier *JobModifier) error {
+	if jvj.Cmd != nil {
+		if *jvj.Cmd == "" {
+			return errRESTModifyCmdEmpty
+		}
+
+		modifier.SetCmd(*jvj.Cmd)
+	}
+
+	if jvj.Cwd != nil {
+		if *jvj.Cwd == "" {
+			return errRESTModifyCwdEmpty
+		}
+
+		modifier.SetCwd(*jvj.Cwd)
+	}
+
+	return nil
+}
+
+func (jvj *JobModifyViaJSON) setModifierIdentityFlags(modifier *JobModifier) {
+	if jvj.CwdMatters != nil {
+		modifier.SetCwdMatters(*jvj.CwdMatters)
+	}
+
+	if jvj.ChangeHome != nil {
+		modifier.SetChangeHome(*jvj.ChangeHome)
+	}
+
+	if jvj.ReqGrp != nil {
+		modifier.SetReqGroup(*jvj.ReqGrp)
+	}
+
+	if jvj.Group != nil {
+		modifier.SetUnixGroup(*jvj.Group)
+	}
+}
+
+func (jvj *JobModifyViaJSON) setModifierRequirements(modifier *JobModifier) error {
+	req, set, err := jvj.requirements()
+	if err != nil {
+		return err
+	}
+
+	if set {
+		modifier.SetRequirements(req)
+	}
+
+	return nil
+}
+
+func (jvj *JobModifyViaJSON) requirements() (*jqs.Requirements, bool, error) {
+	req := &jqs.Requirements{}
+
+	var set bool
+
+	memorySet, err := jvj.setMemoryRequirement(req)
+	if err != nil {
+		return nil, false, err
+	}
+
+	timeSet, err := jvj.setTimeRequirement(req)
+	if err != nil {
+		return nil, false, err
+	}
+
+	set = anyTrue(memorySet, timeSet, jvj.setCPURequirement(req), jvj.setDiskRequirement(req))
+
+	other, otherSet, err := jvj.otherRequirements()
+	if err != nil {
+		return nil, false, err
+	}
+
+	if otherSet {
+		req.Other = other
+		req.OtherSet = true
+		set = true
+	}
+
+	return req, set, nil
+}
+
+func anyTrue(values ...bool) bool {
+	for _, value := range values {
+		if value {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (jvj *JobModifyViaJSON) setMemoryRequirement(req *jqs.Requirements) (bool, error) {
+	if jvj.Memory == nil {
+		return false, nil
+	}
+
+	mb, err := bytefmt.ToMegabytes(*jvj.Memory)
+	if err != nil {
+		return false, fmt.Errorf("memory value (%s) was not specified correctly: %w", *jvj.Memory, err)
+	}
+
+	maxInt := int(^uint(0) >> 1)
+	if mb > uint64(maxInt) {
+		return false, fmt.Errorf("memory value (%s) was not specified correctly: %w", *jvj.Memory, strconv.ErrRange)
+	}
+
+	ram, err := strconv.Atoi(strconv.FormatUint(mb, 10))
+	if err != nil {
+		return false, fmt.Errorf("memory value (%s) was not specified correctly: %w", *jvj.Memory, err)
+	}
+
+	req.RAM = ram
+
+	return true, nil
+}
+
+func (jvj *JobModifyViaJSON) setTimeRequirement(req *jqs.Requirements) (bool, error) {
+	if jvj.Time == nil {
+		return false, nil
+	}
+
+	dur, err := time.ParseDuration(*jvj.Time)
+	if err != nil {
+		return false, fmt.Errorf("time value (%s) was not specified correctly: %w", *jvj.Time, err)
+	}
+
+	req.Time = dur
+
+	return true, nil
+}
+
+func (jvj *JobModifyViaJSON) setCPURequirement(req *jqs.Requirements) bool {
+	if jvj.CPUs == nil {
+		return false
+	}
+
+	req.Cores = *jvj.CPUs
+	req.CoresSet = true
+
+	return true
+}
+
+func (jvj *JobModifyViaJSON) setDiskRequirement(req *jqs.Requirements) bool {
+	if jvj.Disk == nil {
+		return false
+	}
+
+	req.Disk = *jvj.Disk
+	req.DiskSet = true
+
+	return true
+}
+
+func (jvj *JobModifyViaJSON) otherRequirements() (map[string]string, bool, error) {
+	other := make(map[string]string)
+
+	var set bool
+
+	if jvj.Other != nil {
+		for key, val := range *jvj.Other {
+			other[key] = val
+		}
+
+		set = true
+	}
+
+	jvj.setStringOtherRequirements(other, &set)
+
+	if err := jvj.setCloudOtherRequirements(other, &set); err != nil {
+		return nil, false, err
+	}
+
+	return other, set, nil
+}
+
+func (jvj *JobModifyViaJSON) setStringOtherRequirements(other map[string]string, set *bool) {
+	setStringOther(other, "cloud_os", jvj.CloudOS, set)
+	setStringOther(other, "cloud_user", jvj.CloudUser, set)
+	setStringOther(other, "cloud_flavor", jvj.CloudFlavor, set)
+	setStringOther(other, "cloud_config_files", jvj.CloudConfigFiles, set)
+	setStringOther(other, "scheduler_queue", jvj.SchedulerQueue, set)
+	setStringOther(other, "scheduler_queues_avoid", jvj.SchedulerQueuesAvoid, set)
+	setStringOther(other, "scheduler_misc", jvj.SchedulerMisc, set)
+}
+
+func setStringOther(other map[string]string, key string, value *string, set *bool) {
+	if value == nil {
+		return
+	}
+
+	other[key] = *value
+	*set = true
+}
+
+func (jvj *JobModifyViaJSON) setCloudOtherRequirements(other map[string]string, set *bool) error {
+	if jvj.CloudRAM != nil {
+		other["cloud_os_ram"] = strconv.Itoa(*jvj.CloudRAM)
+		*set = true
+	}
+
+	if jvj.CloudShared != nil {
+		other["cloud_shared"] = strconv.FormatBool(*jvj.CloudShared)
+		*set = true
+	}
+
+	if jvj.CloudScript == nil {
+		return nil
+	}
+
+	content, err := internal.PathToContent(*jvj.CloudScript)
+	if err != nil {
+		return err
+	}
+
+	other["cloud_script"] = content
+	*set = true
+
+	return nil
+}
+
+func (jvj *JobModifyViaJSON) setModifierRetryFields(modifier *JobModifier) error {
+	if err := setUint8ModificationField("override", jvj.Override, restModifyOverrideMax,
+		modifier.SetOverride); err != nil {
+		return err
+	}
+
+	if err := setUint8ModificationField("priority", jvj.Priority, restModifyUint8Max, modifier.SetPriority); err != nil {
+		return err
+	}
+
+	if err := setUint8ModificationField("retries", jvj.Retries, restModifyUint8Max, modifier.SetRetries); err != nil {
+		return err
+	}
+
+	if jvj.NoRetryOverWalltime != nil {
+		dur, err := time.ParseDuration(*jvj.NoRetryOverWalltime)
+		if err != nil {
+			return fmt.Errorf("time value (%s) was not specified correctly: %w", *jvj.NoRetryOverWalltime, err)
+		}
+
+		modifier.SetNoRetriesOverWalltime(dur)
+	}
+
+	return nil
+}
+
+func setUint8ModificationField(name string, value *int, limit int, set func(uint8)) error {
+	converted, ok, err := uint8ModificationValue(name, value, limit)
+	if err != nil || !ok {
+		return err
+	}
+
+	set(converted)
+
+	return nil
+}
+
+func (jvj *JobModifyViaJSON) setModifierSliceFields(modifier *JobModifier) {
+	if jvj.LimitGrps != nil {
+		modifier.SetLimitGroups(*jvj.LimitGrps)
+	}
+
+	if jvj.Modules != nil {
+		modifier.SetModules(*jvj.Modules)
+	}
+
+	if jvj.MountConfigs != nil {
+		modifier.SetMountConfigs(*jvj.MountConfigs)
+	}
+
+	if jvj.Deps != nil || jvj.CmdDeps != nil {
+		modifier.SetDependencies(jvj.dependencies())
+	}
+}
+
+func (jvj *JobModifyViaJSON) dependencies() Dependencies {
+	var deps Dependencies
+	if jvj.CmdDeps != nil {
+		deps = append(deps, (*jvj.CmdDeps)...)
+	}
+
+	if jvj.Deps != nil {
+		for _, depgroup := range *jvj.Deps {
+			deps = append(deps, NewDepGroupDependency(depgroup))
+		}
+	}
+
+	return deps
+}
+
+func (jvj *JobModifyViaJSON) setModifierEnv(modifier *JobModifier) error {
+	if jvj.Env == nil {
+		return nil
+	}
+
+	return modifier.setEnvOverrideValues(*jvj.Env)
+}
+
+func (jvj *JobModifyViaJSON) setModifierBehaviours(modifier *JobModifier) {
+	var (
+		behaviours Behaviours
+		set        bool
+	)
+
+	if jvj.OnFailure != nil {
+		behaviours = append(behaviours, modifyBehaviours(*jvj.OnFailure, OnFailure)...)
+		set = true
+	}
+
+	if jvj.OnSuccess != nil {
+		behaviours = append(behaviours, modifyBehaviours(*jvj.OnSuccess, OnSuccess)...)
+		set = true
+	}
+
+	if jvj.OnExit != nil {
+		behaviours = append(behaviours, modifyBehaviours(*jvj.OnExit, OnExit)...)
+		set = true
+	}
+
+	if set {
+		modifier.SetBehaviours(behaviours)
+	}
+}
+
+func modifyBehaviours(bvj BehavioursViaJSON, when BehaviourTrigger) Behaviours {
+	if len(bvj) == 0 {
+		bvj = BehavioursViaJSON{{Nothing: true}}
+	}
+
+	return bvj.Behaviours(when)
+}
+
+func (jvj *JobModifyViaJSON) setModifierContainerFields(modifier *JobModifier) {
+	if jvj.MonitorDocker != nil {
+		modifier.SetMonitorDocker(*jvj.MonitorDocker)
+	}
+
+	if jvj.WithDocker != nil {
+		modifier.SetWithDocker(*jvj.WithDocker)
+	}
+
+	if jvj.WithSingularity != nil {
+		modifier.SetWithSingularity(*jvj.WithSingularity)
+	}
+
+	if jvj.ContainerMounts != nil {
+		modifier.SetContainerMounts(*jvj.ContainerMounts)
+	}
+}
+
+// JobModifyResponse describes the jobs changed by a REST modification request.
+type JobModifyResponse struct {
+	Modified map[string]string `json:"modified"`
+	Jobs     []JStatus         `json:"jobs"`
+}
+
+func restEditableItemState(state queue.ItemState) bool {
+	switch state {
+	case queue.ItemStateDelay, queue.ItemStateReady, queue.ItemStateDependent, queue.ItemStateBury:
+		return true
+	default:
+		return false
+	}
+}
+
+func modifiedJobs(modified map[string]string, byOldKey map[string]*Job) []*Job {
+	jobs := make([]*Job, 0, len(modified))
+	for _, old := range modified {
+		if job := byOldKey[old]; job != nil {
+			jobs = append(jobs, job)
+		}
+	}
+
+	return jobs
+}
+
+func modifiedOldKeys(modified map[string]string, jobs []*Job) []string {
+	oldKeys := make([]string, len(jobs))
+	for i, job := range jobs {
+		oldKeys[i] = modified[job.Key()]
+	}
+
+	return oldKeys
+}
+
 // httpAuthorized checks for parameter 'token' and for Authorization header for
 // Bearer token; if not supplied, or the token is wrong, writes out an error to
 // w, otherwise returns true.
@@ -611,10 +1271,29 @@ func restJobs(ctx context.Context, s *Server) http.HandlerFunc {
 			jobs, status, err = restJobsStatus(ctx, r, s)
 		case http.MethodPost:
 			jobs, status, err = restJobsAdd(ctx, r, s)
+		case http.MethodPatch:
+			response, modifyStatus, modifyErr := restJobsModify(ctx, r, s)
+			if modifyStatus >= 400 || modifyErr != nil {
+				http.Error(w, modifyErr.Error(), modifyStatus)
+
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+			w.WriteHeader(modifyStatus)
+			encoder := json.NewEncoder(w)
+			encoder.SetEscapeHTML(false)
+
+			erre := encoder.Encode(response)
+			if erre != nil {
+				clog.Warn(ctx, "restJobs failed to encode modified jobs", "err", erre)
+			}
+
+			return
 		case http.MethodDelete:
 			jobs, status, err = restJobsCancel(ctx, r, s)
 		default:
-			http.Error(w, "So far only GET, POST and DELETE are supported", http.StatusBadRequest)
+			http.Error(w, "So far only GET, POST, PATCH and DELETE are supported", http.StatusBadRequest)
 			return
 		}
 
@@ -1190,4 +1869,177 @@ func compressEnv(envars []string) ([]byte, error) {
 		return nil, err
 	}
 	return compress(encoded)
+}
+
+func (s *Server) modifiedJobStatuses(ctx context.Context, modified map[string]string) ([]JStatus, error) {
+	keys := make([]string, 0, len(modified))
+	for key := range modified {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	jobs, _, qerr := s.getJobsByKeys(ctx, keys, false, false)
+	if qerr != "" {
+		return nil, Error{Err: qerr}
+	}
+
+	statuses := make([]JStatus, 0, len(jobs))
+	for _, job := range jobs {
+		status, err := job.ToStatus()
+		if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err
+		}
+
+		statuses = append(statuses, status)
+	}
+
+	sort.Slice(statuses, func(i, j int) bool {
+		return statuses[i].Key < statuses[j].Key
+	})
+
+	return statuses, nil
+}
+
+func (s *Server) modifyJobsByKeys(ctx context.Context, keys []string,
+	modifier *JobModifier,
+) (modified map[string]string, err error) {
+	paused, err := s.Pause()
+	if err != nil {
+		return nil, err
+	}
+	defer s.resumeAfterModify(ctx, &modified, &err)
+
+	if paused {
+		clog.Debug(ctx, "rest modify requested, paused server")
+	}
+
+	toModifyJobs, toModifyKeys := s.editableQueueJobs(keys)
+
+	modified, err = modifier.Modify(toModifyJobs, s)
+	if err != nil || len(modified) == 0 {
+		return modified, err
+	}
+
+	return modified, s.storeModifiedJobs(ctx, modified, toModifyKeys, modifier)
+}
+
+func (s *Server) resumeAfterModify(ctx context.Context, modified *map[string]string, modifyErr *error) {
+	resumed, resumeErr := s.Resume(ctx)
+	if resumeErr != nil && *modifyErr == nil {
+		*modifyErr = resumeErr
+
+		return
+	}
+
+	if resumed {
+		clog.Debug(ctx, "rest modify completed, resumed server", "count", len(*modified))
+	}
+}
+
+func (s *Server) editableQueueJobs(keys []string) ([]*Job, map[string]*Job) {
+	jobs := make([]*Job, 0, len(keys))
+	byOldKey := make(map[string]*Job, len(keys))
+
+	for _, key := range keys {
+		item, err := s.q.Get(key)
+		if err != nil || item == nil || !restEditableItemState(item.Stats().State) {
+			continue
+		}
+
+		job, ok := item.Data().(*Job)
+		if !ok {
+			continue
+		}
+
+		jobs = append(jobs, job)
+		byOldKey[key] = job
+	}
+
+	return jobs, byOldKey
+}
+
+func (s *Server) storeModifiedJobs(ctx context.Context, modified map[string]string, byOldKey map[string]*Job,
+	modifier *JobModifier,
+) error {
+	jobs := modifiedJobs(modified, byOldKey)
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	if err := s.changeModifiedQueueKeys(modified, jobs); err != nil {
+		return err
+	}
+
+	if err := s.db.modifyLiveJobs(ctx, modifiedOldKeys(modified, jobs), jobs); err != nil {
+		return err
+	}
+
+	s.storeModifiedLimitGroupsIfNeeded(ctx, jobs, modifier)
+
+	if modifier.DependenciesSet || modifier.PrioritySet {
+		return s.updateModifiedQueueJobs(ctx, jobs)
+	}
+
+	return nil
+}
+
+func (s *Server) storeModifiedLimitGroupsIfNeeded(ctx context.Context, jobs []*Job, modifier *JobModifier) {
+	if modifier.LimitGroupsSet {
+		s.storeModifiedLimitGroups(ctx, jobs)
+	}
+}
+
+func (s *Server) storeModifiedLimitGroups(ctx context.Context, jobs []*Job) {
+	limitGroups := make(map[string]*limiter.GroupData)
+	for _, job := range jobs {
+		s.handleUserSpecifiedJobLimitGroups(job, limitGroups)
+	}
+
+	if err := s.storeLimitGroups(limitGroups); err != nil {
+		clog.Error(ctx, "failed to store limit groups", "err", err)
+	}
+}
+
+func (s *Server) changeModifiedQueueKeys(modified map[string]string, jobs []*Job) error {
+	keyToRP := make(map[string]string, len(jobs))
+	for _, job := range jobs {
+		keyToRP[job.Key()] = job.RepGroup
+	}
+
+	s.rpl.Lock()
+	defer s.rpl.Unlock()
+
+	for newKey, oldKey := range modified {
+		if oldKey == newKey {
+			continue
+		}
+
+		if err := s.q.ChangeKey(oldKey, newKey); err != nil {
+			return err
+		}
+
+		rp := keyToRP[newKey]
+		s.rpl.Delete(rp, oldKey)
+		s.rpl.Add(rp, newKey)
+	}
+
+	return nil
+}
+
+func (s *Server) updateModifiedQueueJobs(ctx context.Context, jobs []*Job) error {
+	for _, job := range jobs {
+		deps, err := job.Dependencies.incompleteJobKeys(s.db)
+		if err != nil {
+			return err
+		}
+
+		err = s.q.Update(ctx, job.Key(), job.getSchedulerGroup(), job, job.Priority,
+			0*time.Second, s.itemTTRDuration(), deps)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -549,7 +549,8 @@ func (jvj *JobViaJSON) Convert(jd *JobDefaults) (*Job, error) {
 		var err error
 		noRetry, err = time.ParseDuration(jvj.NoRetriesOverWalltime)
 		if err != nil {
-			return nil, fmt.Errorf("time value (%s) was not specified correctly: %w", jvj.NoRetriesOverWalltime, err)
+			return nil, fmt.Errorf("no_retry_over_walltime value (%s) was not specified correctly: %w",
+				jvj.NoRetriesOverWalltime, err)
 		}
 	}
 
@@ -1069,7 +1070,8 @@ func (jvj *JobModifyViaJSON) setModifierRetryFields(modifier *JobModifier) error
 	if jvj.NoRetryOverWalltime != nil {
 		dur, err := time.ParseDuration(*jvj.NoRetryOverWalltime)
 		if err != nil {
-			return fmt.Errorf("time value (%s) was not specified correctly: %w", *jvj.NoRetryOverWalltime, err)
+			return fmt.Errorf("no_retry_over_walltime value (%s) was not specified correctly: %w",
+				*jvj.NoRetryOverWalltime, err)
 		}
 
 		modifier.SetNoRetriesOverWalltime(dur)

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -2034,8 +2034,15 @@ func (s *Server) updateModifiedQueueJobs(ctx context.Context, jobs []*Job) error
 			return err
 		}
 
+		item, err := s.q.Get(job.Key())
+		if err != nil {
+			return err
+		}
+
+		stats := item.Stats()
+
 		err = s.q.Update(ctx, job.Key(), job.getSchedulerGroup(), job, job.Priority,
-			0*time.Second, s.itemTTRDuration(), deps)
+			stats.Delay, stats.TTR, deps)
 		if err != nil {
 			return err
 		}

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -125,7 +125,7 @@ func restJobsModify(ctx context.Context, r *http.Request, s *Server) (*JobModify
 	}
 
 	if len(modified) == 0 {
-		return nil, http.StatusConflict, errRESTModifyNoneModified
+		return nil, http.StatusConflict, s.restModifyEmptyResultError(editableKeys)
 	}
 
 	statuses, err := s.modifiedJobStatuses(ctx, modified)
@@ -1215,6 +1215,15 @@ func modifiedOldKeys(modified map[string]string, jobs []*Job) []string {
 	}
 
 	return oldKeys
+}
+
+func (s *Server) restModifyEmptyResultError(editableKeys []string) error {
+	editableJobs, _ := s.editableQueueJobs(editableKeys)
+	if len(editableJobs) == 0 {
+		return errRESTModifyNoEditable
+	}
+
+	return errRESTModifyNoneModified
 }
 
 // httpAuthorized checks for parameter 'token' and for Authorization header for

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -1971,11 +1971,11 @@ func (s *Server) storeModifiedJobs(ctx context.Context, modified map[string]stri
 		return err
 	}
 
+	s.storeModifiedLimitGroupsIfNeeded(ctx, jobs, modifier)
+
 	if err := s.db.modifyLiveJobs(ctx, modifiedOldKeys(modified, jobs), jobs); err != nil {
 		return err
 	}
-
-	s.storeModifiedLimitGroupsIfNeeded(ctx, jobs, modifier)
 
 	if modifier.DependenciesSet || modifier.PrioritySet {
 		return s.updateModifiedQueueJobs(ctx, jobs)

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -133,47 +133,54 @@ func completedJobMatchesRerunRequest(job *Job, req jstatusReq) bool {
 // JStatus is the job info we send to the status webpage (only real difference
 // to Job is that some of the values are converted to easy-to-display forms).
 type JStatus struct {
-	LimitGroups     []string
-	DepGroups       []string
-	Modules         []string
-	Dependencies    []string
-	OtherRequests   []string
-	Env             []string
-	Key             string
-	RepGroup        string
-	Cmd             string
-	State           JobState
-	Cwd             string
-	CwdBase         string
-	Behaviours      string
-	Mounts          string
-	MonitorDocker   string
-	WithDocker      string
-	WithSingularity string
-	ContainerMounts string
-	FailReason      string
-	Host            string
-	HostID          string
-	HostIP          string
-	StdErr          string
-	StdOut          string
-	ExpectedRAM     int     // ExpectedRAM is in Megabytes.
-	ExpectedTime    float64 // ExpectedTime is in seconds.
-	RequestedDisk   int     // RequestedDisk is in Gigabytes.
-	Cores           float64
-	PeakRAM         int
-	PeakDisk        int64 // MBs
-	Exitcode        int
-	Pid             int
-	Walltime        float64
-	CPUtime         float64
-	Started         *int64
-	Ended           *int64
-	Similar         int
-	Attempts        uint32
-	HomeChanged     bool
-	Exited          bool
-	IsPushUpdate    bool
+	LimitGroups         []string
+	DepGroups           []string
+	Modules             []string
+	Dependencies        []string
+	OtherRequests       []string
+	Env                 []string
+	Key                 string
+	RepGroup            string
+	ReqGroup            string
+	Cmd                 string
+	State               JobState
+	Cwd                 string
+	CwdBase             string
+	Behaviours          string
+	Mounts              string
+	MonitorDocker       string
+	WithDocker          string
+	WithSingularity     string
+	ContainerMounts     string
+	FailReason          string
+	Host                string
+	HostID              string
+	HostIP              string
+	StdErr              string
+	StdOut              string
+	ExpectedRAM         int     // ExpectedRAM is in Megabytes.
+	ExpectedTime        float64 // ExpectedTime is in seconds.
+	RequestedDisk       int     // RequestedDisk is in Gigabytes.
+	EnvOverrides        []string
+	Cores               float64
+	NoRetryOverWalltime float64
+	PeakRAM             int
+	PeakDisk            int64 // MBs
+	Exitcode            int
+	Pid                 int
+	Walltime            float64
+	CPUtime             float64
+	Started             *int64
+	Ended               *int64
+	Similar             int
+	Attempts            uint32
+	Override            uint8
+	Priority            uint8
+	Retries             uint8
+	HomeChanged         bool
+	CwdMatters          bool
+	Exited              bool
+	IsPushUpdate        bool
 }
 
 func statusFromJobUpdate(update *JobUpdate) *JStatus {

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1859,6 +1859,17 @@ assert.equal(form.withDocker, '');
 assert.equal(form.withSingularity, 'old.sif');
 assert.equal(form.containerMounts, '/old:/old');
 
+const dayDurationForm = createModifyForm({
+  ...oldJob,
+  ExpectedTime: 86400,
+  NoRetryOverWalltime: 172800
+});
+assert.equal(dayDurationForm.time, '24h');
+assert.equal(dayDurationForm.noRetryOverWalltime, '48h');
+const dayDurationPayload = createModifyPayload(dayDurationForm);
+assert.equal(dayDurationPayload.time, '24h');
+assert.equal(dayDurationPayload.no_retry_over_walltime, '48h');
+
 Object.assign(form, {
   cmd: 'echo web new',
   cwd: '/tmp/web-new',

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -32,6 +32,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -1735,4 +1737,350 @@ func clearWriteDeadlineBestEffort(ws *websocket.Conn) {
 	if err := ws.SetWriteDeadline(time.Time{}); err != nil {
 		return
 	}
+}
+
+func TestWebUIModificationStaticContract(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("The status page exposes Modify actions and modal fields", t, func() {
+		statusHTML := readStaticText("static/status.html")
+		actionHandlers := readStaticText("static/js/wr/action-handlers.js")
+		viewModel := readStaticText("static/js/wr/status-viewmodel.js")
+
+		So(statusHTML, ShouldContainSubstring, "jobCanModify")
+		So(statusHTML, ShouldContainSubstring, "showModifyJob")
+		So(actionHandlers, ShouldContainSubstring, "showModifyJob")
+		So(viewModel, ShouldContainSubstring, "jobCanModify")
+
+		for _, field := range []string{
+			"cmd",
+			"cwd",
+			"cwd_matters",
+			"change_home",
+			"req_grp",
+			"memory",
+			"time",
+			"cpus",
+			"disk",
+			"priority",
+			"retries",
+			"override",
+			"no_retry_over_walltime",
+			"limit_grps",
+			"modules",
+			"deps",
+			"cmd_deps",
+			"on_failure",
+			"on_success",
+			"on_exit",
+			"other",
+			"mounts",
+			"monitor_docker",
+			"with_docker",
+			"with_singularity",
+			"container_mounts",
+			"env",
+		} {
+			So(statusHTML, ShouldContainSubstring, `data-modify-field="`+field+`"`)
+		}
+	})
+
+	Convey("The browser modify module builds requests and applies responses", t, func() {
+		runNodeWebUITest(t, `
+import assert from 'node:assert/strict';
+import {
+  createModifyForm,
+  createModifyPayload,
+  createModifyRequest,
+  jobCanModify,
+  replaceModifiedJobs,
+  trimTrailingNewline
+} from './jobqueue/static/js/wr/modify-job.js';
+
+const oldKey = '11111111111111111111111111111111';
+const newKey = '22222222222222222222222222222222';
+const oldJob = {
+  Key: oldKey,
+  State: 'ready',
+  Cmd: 'echo web old',
+  CwdBase: '/tmp/web-old',
+  CwdMatters: false,
+  HomeChanged: false,
+  ReqGroup: 'web-old',
+  ExpectedRAM: 64,
+  ExpectedTime: 60,
+  Cores: 1,
+  RequestedDisk: 0,
+  Priority: 1,
+  Retries: 1,
+  Override: 0,
+  NoRetryOverWalltime: 0,
+  LimitGroups: ['old:1'],
+  Modules: ['oldmod'],
+  Dependencies: ['old-dep', 'echo dep [/tmp/dep-old]'],
+  Behaviours: '{"on_exit":[{"nothing":true}]}',
+  OtherRequests: ['scheduler_queue:old'],
+  Mounts: '[{"Mount":"oldmnt","Targets":[{"Profile":"old","Path":"old/data"}]}]',
+  MonitorDocker: 'old-docker',
+  WithDocker: '',
+  WithSingularity: 'old.sif',
+  ContainerMounts: '/old:/old',
+  Env: [],
+  EnvOverrides: []
+};
+
+const form = createModifyForm(oldJob);
+assert.equal(form.cmd, 'echo web old');
+assert.equal(form.cwd, '/tmp/web-old');
+assert.equal(form.cwdMatters, false);
+assert.equal(form.changeHome, false);
+assert.equal(form.reqGrp, 'web-old');
+assert.equal(form.memory, '64M');
+assert.equal(form.time, '1m');
+assert.equal(form.cpus, '1');
+assert.equal(form.disk, '0');
+assert.equal(form.priority, '1');
+assert.equal(form.retries, '1');
+assert.equal(form.override, '0');
+assert.equal(form.noRetryOverWalltime, '');
+assert.equal(form.limitGrps, 'old:1');
+assert.equal(form.modules, 'oldmod');
+assert.equal(form.deps, 'old-dep');
+assert.deepEqual(JSON.parse(form.cmdDeps), [{cmd: 'echo dep', cwd: '/tmp/dep-old'}]);
+assert.equal(form.onFailure, '');
+assert.equal(form.onSuccess, '');
+assert.deepEqual(JSON.parse(form.onExit), [{nothing: true}]);
+assert.equal(form.other, 'scheduler_queue:old');
+assert.deepEqual(JSON.parse(form.mounts), [{Mount: 'oldmnt', Targets: [{Profile: 'old', Path: 'old/data'}]}]);
+assert.equal(form.monitorDocker, 'old-docker');
+assert.equal(form.withDocker, '');
+assert.equal(form.withSingularity, 'old.sif');
+assert.equal(form.containerMounts, '/old:/old');
+
+Object.assign(form, {
+  cmd: 'echo web new',
+  cwd: '/tmp/web-new',
+  cwdMatters: true,
+  changeHome: true,
+  reqGrp: 'web-new',
+  memory: '128M',
+  time: '3m',
+  cpus: '2',
+  disk: '5',
+  priority: '12',
+  retries: '6',
+  override: '2',
+  noRetryOverWalltime: '10m',
+  limitGrps: 'new:2',
+  modules: 'mod-a\nmod-b',
+  deps: 'dep-a',
+  cmdDeps: '[{"cmd":"echo dep","cwd":"/tmp/dep"}]',
+  onFailure: '[{"cleanup":true}]',
+  onSuccess: '[{"remove":true}]',
+  onExit: '[{"nothing":true}]',
+  other: 'cloud_os:Ubuntu 22\nscheduler_queue:short',
+  mounts: '[{"Mount":"mnt","Targets":[{"Profile":"p","Path":"bucket/data"}]}]',
+  monitorDocker: 'dock-new',
+  withDocker: 'ubuntu:22.04',
+  withSingularity: '',
+  containerMounts: '/data:/data'
+});
+
+const expectedPayload = {
+  cmd: 'echo web new',
+  cwd: '/tmp/web-new',
+  cwd_matters: true,
+  change_home: true,
+  req_grp: 'web-new',
+  memory: '128M',
+  time: '3m',
+  cpus: 2,
+  disk: 5,
+  priority: 12,
+  retries: 6,
+  override: 2,
+  no_retry_over_walltime: '10m',
+  limit_grps: ['new:2'],
+  modules: ['mod-a', 'mod-b'],
+  deps: ['dep-a'],
+  cmd_deps: [{cmd: 'echo dep', cwd: '/tmp/dep'}],
+  on_failure: [{cleanup: true}],
+  on_success: [{remove: true}],
+  on_exit: [{nothing: true}],
+  other: {cloud_os: 'Ubuntu 22', scheduler_queue: 'short'},
+  mounts: [{Mount: 'mnt', Targets: [{Profile: 'p', Path: 'bucket/data'}]}],
+  monitor_docker: 'dock-new',
+  with_docker: 'ubuntu:22.04',
+  with_singularity: '',
+  container_mounts: '/data:/data'
+};
+
+assert.deepEqual(createModifyPayload(form), expectedPayload);
+
+const request = createModifyRequest(form, 'web-token');
+assert.equal(request.url, '/rest/v1/jobs/' + oldKey);
+assert.equal(request.options.method, 'PATCH');
+assert.equal(request.options.headers.Authorization, 'Bearer web-token');
+assert.deepEqual(JSON.parse(request.options.body), expectedPayload);
+
+const returnedJob = {
+  ...oldJob,
+  Key: newKey,
+  Cmd: 'echo web new',
+  CwdBase: '/tmp/web-new',
+  CwdMatters: true,
+  HomeChanged: true,
+  ReqGroup: 'web-new',
+  ExpectedRAM: 128,
+  ExpectedTime: 180,
+  Cores: 2,
+  RequestedDisk: 5,
+  Priority: 12,
+  Retries: 6,
+  Override: 2,
+  NoRetryOverWalltime: 600,
+  LimitGroups: ['new:2'],
+  Modules: ['mod-a', 'mod-b'],
+  Dependencies: ['dep-a', 'echo dep [/tmp/dep]'],
+  Behaviours: '{"on_failure":[{"cleanup":true}],"on_success":[{"remove":true}],"on_exit":[{"nothing":true}]}',
+  OtherRequests: ['cloud_os:Ubuntu 22', 'scheduler_queue:short'],
+  Mounts: '[{"Mount":"mnt","Targets":[{"Profile":"p","Path":"bucket/data"}]}]',
+  MonitorDocker: 'dock-new',
+  WithDocker: 'ubuntu:22.04',
+  WithSingularity: '',
+  ContainerMounts: '/data:/data'
+};
+const replaced = replaceModifiedJobs([oldJob], {modified: {[newKey]: oldKey}, jobs: [returnedJob]});
+assert.equal(replaced.length, 1);
+assert.equal(replaced[0].Key, newKey);
+assert.equal(replaced[0].Cmd, 'echo web new');
+assert.equal(replaced[0].CwdBase, '/tmp/web-new');
+assert.equal(replaced[0].CwdMatters, true);
+assert.equal(replaced[0].HomeChanged, true);
+assert.equal(replaced[0].ReqGroup, 'web-new');
+assert.equal(replaced[0].ExpectedRAM, 128);
+assert.equal(replaced[0].ExpectedTime, 180);
+assert.equal(replaced[0].RequestedDisk, 5);
+assert.equal(replaced[0].NoRetryOverWalltime, 600);
+assert.equal(replaced.some(job => job.Key === oldKey), false);
+
+for (const state of ['delayed', 'ready', 'dependent', 'buried']) {
+  assert.equal(jobCanModify({State: state}), true);
+}
+for (const state of ['reserved', 'running', 'lost', 'complete']) {
+  assert.equal(jobCanModify({State: state}), false);
+}
+assert.equal(trimTrailingNewline('no editable jobs matched\n'), 'no editable jobs matched');
+`)
+	})
+
+	Convey("The env editor uses only overrides and preserves inherited env", t, func() {
+		runNodeWebUITest(t, `
+import assert from 'node:assert/strict';
+import { createModifyForm, createModifyPayload, replaceModifiedJobs } from './jobqueue/static/js/wr/modify-job.js';
+
+const key = '33333333333333333333333333333333';
+const job = {
+  Key: key,
+  State: 'ready',
+  Cmd: 'echo env',
+  CwdBase: '/tmp',
+  ReqGroup: 'env',
+  ExpectedRAM: 1,
+  ExpectedTime: 60,
+  Cores: 1,
+  RequestedDisk: 0,
+  Priority: 1,
+  Retries: 1,
+  Override: 0,
+  LimitGroups: [],
+  Modules: [],
+  Dependencies: [],
+  OtherRequests: [],
+  Env: ['PATH=/bin', 'INHERITED=base', 'WEB_ONLY=old'],
+  EnvOverrides: ['WEB_ONLY=old']
+};
+
+const form = createModifyForm(job);
+assert.equal(form.env, 'WEB_ONLY=old');
+assert.equal(form.env.includes('PATH=/bin'), false);
+assert.equal(form.env.includes('INHERITED=base'), false);
+
+form.env = 'WEB_ONLY=new';
+const changedPayload = createModifyPayload(form);
+assert.deepEqual(changedPayload.env, ['WEB_ONLY=new']);
+assert.equal(JSON.stringify(changedPayload).includes('PATH=/bin'), false);
+assert.equal(JSON.stringify(changedPayload).includes('INHERITED=base'), false);
+
+let replaced = replaceModifiedJobs([job], {
+  modified: {[key]: key},
+  jobs: [{...job, Env: [], EnvOverrides: ['WEB_ONLY=new']}]
+});
+assert.deepEqual(replaced[0].Env, ['PATH=/bin', 'INHERITED=base', 'WEB_ONLY=new']);
+
+form.env = '';
+const clearedPayload = createModifyPayload(form);
+assert.deepEqual(clearedPayload.env, []);
+
+replaced = replaceModifiedJobs([job], {
+  modified: {[key]: key},
+  jobs: [{...job, Env: [], EnvOverrides: []}]
+});
+assert.deepEqual(replaced[0].EnvOverrides, []);
+assert.deepEqual(replaced[0].Env, ['PATH=/bin', 'INHERITED=base']);
+`)
+	})
+
+	Convey("The browser modify module reports failed edits without changing rows", t, func() {
+		runNodeWebUITest(t, `
+import assert from 'node:assert/strict';
+import { replaceModifiedJobs, trimTrailingNewline } from './jobqueue/static/js/wr/modify-job.js';
+
+const row = {Key: '44444444444444444444444444444444', State: 'ready', Priority: 1};
+const priorityError = 'priority value (300) is not in the range 0..255';
+assert.equal(trimTrailingNewline(priorityError + '\n'), priorityError);
+assert.equal(trimTrailingNewline('no editable jobs matched\n'), 'no editable jobs matched');
+assert.deepEqual(replaceModifiedJobs([row], {modified: {}, jobs: []}), [row]);
+`)
+	})
+}
+
+func readStaticText(path string) string {
+	data, err := staticFS.ReadFile(path)
+	So(err, ShouldBeNil)
+
+	return string(data)
+}
+
+func runNodeWebUITest(t *testing.T, source string) {
+	t.Helper()
+
+	repoRoot := repoRootForWebUITest(t)
+	moduleURL := "file://" + filepath.ToSlash(filepath.Join(repoRoot, "jobqueue/static/js/wr/modify-job.js"))
+	source = strings.ReplaceAll(source, "'./jobqueue/static/js/wr/modify-job.js'", fmt.Sprintf("%q", moduleURL))
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "web_ui_modify_test.mjs")
+	err := os.WriteFile(script, []byte(source), 0600)
+	So(err, ShouldBeNil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "node", script)
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	So(string(output), ShouldEqual, "")
+	So(err, ShouldBeNil)
+}
+
+func repoRootForWebUITest(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	So(err, ShouldBeNil)
+
+	return filepath.Dir(wd)
 }

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -310,6 +310,67 @@ func TestServerWebI(t *testing.T) {
 				So(status2.RepGroup, ShouldEqual, "rg1")
 			})
 
+			Convey("The websocket and REST details expose editable status fields", func() {
+				statusJob := &Job{
+					Cmd:                   "echo web status fields",
+					Cwd:                   "/tmp",
+					CwdMatters:            true,
+					ChangeHome:            true,
+					ReqGroup:              "web-req",
+					Requirements:          standardReqs,
+					RepGroup:              "web-status-fields",
+					Override:              2,
+					Priority:              11,
+					Retries:               5,
+					NoRetriesOverWalltime: 3 * time.Minute,
+				}
+				err = statusJob.EnvAddOverride([]string{"WEB_ONLY=old"})
+				So(err, ShouldBeNil)
+
+				inserts, already, erra := jq.Add([]*Job{statusJob}, envVars, true)
+				So(erra, ShouldBeNil)
+				So(inserts, ShouldEqual, 1)
+				So(already, ShouldEqual, 0)
+
+				key := statusJob.Key()
+
+				Convey("via websocket details", func() {
+					err = ws.WriteJSON(jstatusReq{
+						Request:  jstatusRequestDetails,
+						RepGroup: "web-status-fields",
+						State:    JobStateReady,
+					})
+					So(err, ShouldBeNil)
+
+					status, ok := readJStatusMatching(ws, func(s JStatus) bool {
+						return s.Key == key
+					})
+					So(ok, ShouldBeTrue)
+					assertEditableStatusFields(status)
+				})
+
+				Convey("via REST GET by key", func() {
+					handler := restJobs(ctx, server)
+					w := httptest.NewRecorder()
+					r := httptest.NewRequestWithContext(ctx, http.MethodGet, restJobsEndpoint+key, nil)
+					r.Header.Set("Authorization", "Bearer "+string(token))
+
+					handler(w, r)
+
+					resp := w.Result()
+					defer resp.Body.Close()
+
+					So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+					var statuses []JStatus
+
+					err = json.NewDecoder(resp.Body).Decode(&statuses)
+					So(err, ShouldBeNil)
+					So(len(statuses), ShouldEqual, 1)
+					assertEditableStatusFields(statuses[0])
+				})
+			})
+
 			Convey("The websocket handler deals with paginated details requests", func() {
 				numPaginationJobs := 12
 				limit := 5
@@ -1147,6 +1208,17 @@ func TestServerWebI(t *testing.T) {
 			server.Stop(ctx, true)
 		})
 	})
+}
+
+func assertEditableStatusFields(status JStatus) {
+	So(status.ReqGroup, ShouldEqual, "web-req")
+	So(status.Override, ShouldEqual, 2)
+	So(status.Priority, ShouldEqual, 11)
+	So(status.Retries, ShouldEqual, 5)
+	So(status.NoRetryOverWalltime, ShouldEqual, 180)
+	So(status.CwdMatters, ShouldBeTrue)
+	So(status.HomeChanged, ShouldBeTrue)
+	So(status.EnvOverrides, ShouldResemble, []string{"WEB_ONLY=old"})
 }
 
 func clearReadDeadlineBestEffort(ws *websocket.Conn) {

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1751,6 +1751,7 @@ func TestWebUIModificationStaticContract(t *testing.T) {
 
 		So(statusHTML, ShouldContainSubstring, "jobCanModify")
 		So(statusHTML, ShouldContainSubstring, "showModifyJob")
+		So(statusHTML, ShouldContainSubstring, "submit: function() { $root.submitModifyJob(); return false; }")
 		So(actionHandlers, ShouldContainSubstring, "showModifyJob")
 		So(viewModel, ShouldContainSubstring, "jobCanModify")
 
@@ -2237,6 +2238,10 @@ export function setupLiveWalltime(job, walltime) {
 
 func runNodeScript(t *testing.T, repoRoot, source string) {
 	t.Helper()
+
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not found on PATH; skipping browser module contract test")
+	}
 
 	dir := t.TempDir()
 	script := filepath.Join(dir, "web_ui_modify_test.mjs")

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1930,6 +1930,14 @@ const expectedPayload = {
 };
 
 assert.deepEqual(createModifyPayload(form), expectedPayload);
+assert.throws(
+  () => createModifyPayload({...form, cmdDeps: '{}'}),
+  /cmd_deps must be a JSON array/
+);
+assert.throws(
+  () => createModifyPayload({...form, mounts: '{}'}),
+  /mounts must be a JSON array/
+);
 
 const request = createModifyRequest(form, 'web-token');
 assert.equal(request.url, '/rest/v1/jobs/' + oldKey);

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -2045,6 +2045,127 @@ assert.equal(trimTrailingNewline('no editable jobs matched\n'), 'no editable job
 assert.deepEqual(replaceModifiedJobs([row], {modified: {}, jobs: []}), [row]);
 `)
 	})
+
+	Convey("The real modal handler submits PATCHes and keeps validation errors visible", t, func() {
+		runNodeModalHandlerTest(t, `
+import assert from 'node:assert/strict';
+import { showModifyJob, submitModifyJob } from './jobqueue/static/js/wr/modal-handlers.js';
+
+globalThis.ko = {
+  observable(initial) {
+    let value = initial;
+    return function observable(next) {
+      if (arguments.length > 0) {
+        value = next;
+        return observable;
+      }
+
+      return value;
+    };
+  }
+};
+
+function viewModelWith(job) {
+  return {
+    token: 'web-token',
+    detailsOA: ko.observable([job]),
+    modifyJobModalVisible: ko.observable(false),
+    modifyJobForm: ko.observable(),
+    modifyJobError: ko.observable(''),
+    modifyJobSubmitting: ko.observable(false)
+  };
+}
+
+const oldKey = '55555555555555555555555555555555';
+const newKey = '66666666666666666666666666666666';
+const oldJob = {
+  Key: oldKey,
+  State: 'ready',
+  Cmd: 'echo modal old',
+  CwdBase: '/tmp/modal-old',
+  CwdMatters: false,
+  HomeChanged: false,
+  ReqGroup: 'modal-old',
+  ExpectedRAM: 64,
+  ExpectedTime: 60,
+  Cores: 1,
+  RequestedDisk: 0,
+  Priority: 1,
+  Retries: 1,
+  Override: 0,
+  NoRetryOverWalltime: 0,
+  LimitGroups: [],
+  Modules: [],
+  Dependencies: [],
+  Behaviours: '',
+  OtherRequests: [],
+  Mounts: '',
+  MonitorDocker: '',
+  WithDocker: '',
+  WithSingularity: '',
+  ContainerMounts: '',
+  Env: ['PATH=/bin'],
+  EnvOverrides: [],
+  Walltime: 0
+};
+
+const successVM = viewModelWith(oldJob);
+showModifyJob(successVM, oldJob);
+assert.equal(successVM.modifyJobModalVisible(), true);
+successVM.modifyJobForm().cmd('echo modal new');
+
+const fetchCalls = [];
+globalThis.fetch = async (url, options) => {
+  fetchCalls.push({url, options});
+
+  return {
+    ok: true,
+    json: async () => ({
+      modified: {[newKey]: oldKey},
+      jobs: [{...oldJob, Key: newKey, Cmd: 'echo modal new', Env: ['PATH=/bin'], Walltime: 0}]
+    })
+  };
+};
+
+assert.equal(await submitModifyJob(successVM), true);
+assert.equal(successVM.modifyJobModalVisible(), false);
+assert.equal(fetchCalls.length, 1);
+assert.equal(fetchCalls[0].url, '/rest/v1/jobs/' + oldKey);
+assert.equal(fetchCalls[0].options.method, 'PATCH');
+assert.equal(fetchCalls[0].options.headers.Authorization, 'Bearer web-token');
+assert.equal(JSON.parse(fetchCalls[0].options.body).cmd, 'echo modal new');
+assert.equal(successVM.detailsOA().length, 1);
+assert.equal(successVM.detailsOA()[0].Key, newKey);
+assert.equal(successVM.detailsOA()[0].Cmd, 'echo modal new');
+
+const errorVM = viewModelWith(oldJob);
+showModifyJob(errorVM, oldJob);
+errorVM.modifyJobForm().priority('300');
+const priorityError = 'priority value (300) is not in the range 0..255';
+globalThis.fetch = async () => ({
+  ok: false,
+  text: async () => priorityError + '\n'
+});
+
+assert.equal(await submitModifyJob(errorVM), false);
+assert.equal(errorVM.modifyJobModalVisible(), true);
+assert.equal(errorVM.modifyJobError(), priorityError);
+assert.equal(errorVM.detailsOA().length, 1);
+assert.equal(errorVM.detailsOA()[0].Key, oldKey);
+assert.equal(errorVM.detailsOA()[0].Priority, 1);
+
+globalThis.fetch = async () => ({
+  ok: false,
+  text: async () => 'no editable jobs matched\n'
+});
+
+assert.equal(await submitModifyJob(errorVM), false);
+assert.equal(errorVM.modifyJobModalVisible(), true);
+assert.equal(errorVM.modifyJobError(), 'no editable jobs matched');
+assert.equal(errorVM.detailsOA()[0].Key, oldKey);
+assert.equal(errorVM.detailsOA()[0].Priority, 1);
+`)
+	})
 }
 
 func readStaticText(path string) string {
@@ -2058,8 +2179,53 @@ func runNodeWebUITest(t *testing.T, source string) {
 	t.Helper()
 
 	repoRoot := repoRootForWebUITest(t)
-	moduleURL := "file://" + filepath.ToSlash(filepath.Join(repoRoot, "jobqueue/static/js/wr/modify-job.js"))
+	moduleURL := fileURL(filepath.Join(repoRoot, "jobqueue/static/js/wr/modify-job.js"))
 	source = strings.ReplaceAll(source, "'./jobqueue/static/js/wr/modify-job.js'", fmt.Sprintf("%q", moduleURL))
+
+	runNodeScript(t, repoRoot, source)
+}
+
+func runNodeModalHandlerTest(t *testing.T, source string) {
+	t.Helper()
+
+	repoRoot := repoRootForWebUITest(t)
+	dir := t.TempDir()
+
+	utility := `export function capitalizeFirstLetter(value) {
+  return String(value || '').charAt(0).toUpperCase() + String(value || '').slice(1);
+}
+
+export function setupLiveWalltime(job, walltime) {
+  job.LiveWalltime = function () {
+    return walltime || 0;
+  };
+}
+`
+	utilityPath := filepath.Join(dir, "utility.js")
+	err := os.WriteFile(utilityPath, []byte(utility), 0600)
+	So(err, ShouldBeNil)
+
+	sourcePath := filepath.Join(repoRoot, "jobqueue/static/js/wr/modal-handlers.js")
+	modalSource, err := os.ReadFile(sourcePath)
+	So(err, ShouldBeNil)
+
+	rewritten := strings.ReplaceAll(string(modalSource), "'/js/wr/modify-job.js'",
+		fmt.Sprintf("%q", fileURL(filepath.Join(repoRoot, "jobqueue/static/js/wr/modify-job.js"))))
+	rewritten = strings.ReplaceAll(rewritten, "'/js/wr/utility.js'", fmt.Sprintf("%q", fileURL(utilityPath)))
+
+	modalPath := filepath.Join(dir, "modal-handlers.js")
+	// #nosec G703 -- modalPath is generated inside t.TempDir for a test-only module.
+	err = os.WriteFile(modalPath, []byte(rewritten), 0600)
+	So(err, ShouldBeNil)
+
+	source = strings.ReplaceAll(source, "'./jobqueue/static/js/wr/modal-handlers.js'",
+		fmt.Sprintf("%q", fileURL(modalPath)))
+
+	runNodeScript(t, repoRoot, source)
+}
+
+func runNodeScript(t *testing.T, repoRoot, source string) {
+	t.Helper()
 
 	dir := t.TempDir()
 	script := filepath.Join(dir, "web_ui_modify_test.mjs")
@@ -2074,6 +2240,10 @@ func runNodeWebUITest(t *testing.T, source string) {
 	output, err := cmd.CombinedOutput()
 	So(string(output), ShouldEqual, "")
 	So(err, ShouldBeNil)
+}
+
+func fileURL(path string) string {
+	return "file://" + filepath.ToSlash(path)
 }
 
 func repoRootForWebUITest(t *testing.T) string {

--- a/jobqueue/static/js/wr/action-handlers.js
+++ b/jobqueue/static/js/wr/action-handlers.js
@@ -2,7 +2,7 @@
  * Handles job actions for the WR status page.
  */
 import { removeBadServer, removeMessage } from '/js/wr/utility.js';
-import { jobToActionDetails } from '/js/wr/modal-handlers.js';
+import { jobToActionDetails, showModifyJob } from '/js/wr/modal-handlers.js';
 
 /**
  * Action handler functions for jobs
@@ -80,5 +80,9 @@ export const actionHandlers = {
         jobToActionDetails(viewModel, job, 'kill', 'confirm');
         viewModel.actionModalHeader('Confirm Commands are Dead');
         viewModel.actionModalVisible(true);
+    },
+
+    showModifyJob: function (viewModel, job) {
+        showModifyJob(viewModel, job);
     }
 };

--- a/jobqueue/static/js/wr/modal-handlers.js
+++ b/jobqueue/static/js/wr/modal-handlers.js
@@ -1,7 +1,45 @@
 /* Modal Handlers
  * Handles modals for the WR status page.
  */
-import { capitalizeFirstLetter } from '/js/wr/utility.js';
+import {
+    createModifyForm,
+    createModifyRequest,
+    jobCanModify,
+    replaceModifiedJobs,
+    trimTrailingNewline
+} from '/js/wr/modify-job.js';
+import { capitalizeFirstLetter, setupLiveWalltime } from '/js/wr/utility.js';
+
+const modifyFormObservableFields = [
+    'key',
+    'cmd',
+    'cwd',
+    'cwdMatters',
+    'changeHome',
+    'reqGrp',
+    'memory',
+    'time',
+    'cpus',
+    'disk',
+    'priority',
+    'retries',
+    'override',
+    'noRetryOverWalltime',
+    'limitGrps',
+    'modules',
+    'deps',
+    'cmdDeps',
+    'onFailure',
+    'onSuccess',
+    'onExit',
+    'other',
+    'mounts',
+    'monitorDocker',
+    'withDocker',
+    'withSingularity',
+    'containerMounts',
+    'env',
+];
 
 /**
  * Initializes the action details object for a modal
@@ -67,11 +105,110 @@ export function commitAction(viewModel, all) {
 }
 
 /**
+ * Shows the single-job Modify modal.
+ * @param {StatusViewModel} viewModel - The main view model
+ * @param {object} job - The job object
+ */
+export function showModifyJob(viewModel, job) {
+    if (!jobCanModify(job)) {
+        return;
+    }
+
+    viewModel.modifyJobError('');
+    viewModel.modifyJobForm(observableModifyForm(createModifyForm(job)));
+    viewModel.modifyJobModalVisible(true);
+}
+
+/**
+ * Submits the single-job Modify modal.
+ * @param {StatusViewModel} viewModel - The main view model
+ * @returns {Promise<boolean>} Whether the request succeeded
+ */
+export function submitModifyJob(viewModel) {
+    const form = viewModel.modifyJobForm();
+    if (!form) {
+        return Promise.resolve(false);
+    }
+
+    let request;
+
+    try {
+        request = createModifyRequest(form, viewModel.token);
+    } catch (error) {
+        viewModel.modifyJobError(trimTrailingNewline(error.message || String(error)));
+
+        return Promise.resolve(false);
+    }
+
+    viewModel.modifyJobError('');
+    viewModel.modifyJobSubmitting(true);
+
+    return fetch(request.url, request.options)
+        .then(async response => {
+            if (!response.ok) {
+                viewModel.modifyJobError(trimTrailingNewline(await response.text()));
+
+                return false;
+            }
+
+            const body = await response.json();
+            replaceVisibleModifiedJobs(viewModel, body);
+            viewModel.modifyJobModalVisible(false);
+
+            return true;
+        })
+        .catch(error => {
+            viewModel.modifyJobError(trimTrailingNewline(error.message || String(error)));
+
+            return false;
+        })
+        .finally(() => {
+            viewModel.modifyJobSubmitting(false);
+        });
+}
+
+function observableModifyForm(form) {
+    const observableForm = {
+        originalJob: form.originalJob,
+        originalCmdDeps: form.originalCmdDeps,
+        originalOnFailure: form.originalOnFailure,
+        originalOnSuccess: form.originalOnSuccess,
+        originalOnExit: form.originalOnExit,
+        originalOther: form.originalOther,
+        originalMounts: form.originalMounts,
+        originalEnv: form.originalEnv,
+    };
+
+    for (const field of modifyFormObservableFields) {
+        observableForm[field] = ko.observable(form[field]);
+    }
+
+    return observableForm;
+}
+
+function replaceVisibleModifiedJobs(viewModel, response) {
+    if (!viewModel.detailsOA) {
+        return;
+    }
+
+    const updated = replaceModifiedJobs(viewModel.detailsOA(), response);
+
+    for (const job of updated) {
+        setupLiveWalltime(job, job.Walltime, viewModel);
+    }
+
+    viewModel.detailsOA(updated);
+}
+
+/**
  * Setup functions for each modal type
  */
 export const modalHandlers = {
     showJobDetails: function (viewModel, job) {
         viewModel.jobDetailsData(job);
         viewModel.jobDetailsModalVisible(true);
-    }
+    },
+
+    showModifyJob,
+    submitModifyJob
 };

--- a/jobqueue/static/js/wr/modify-job.js
+++ b/jobqueue/static/js/wr/modify-job.js
@@ -1,0 +1,361 @@
+/* Modify Job Helpers
+ * Pure browser-side helpers for editing a single WR job.
+ */
+
+const editableJobStates = new Set(['delayed', 'ready', 'dependent', 'buried']);
+const commandDependencyPattern = /^(.*) \[([^\]]*)\]$/;
+
+/**
+ * Returns true when a status row can be edited through the web UI.
+ * @param {object} job - Job status row.
+ * @returns {boolean} Whether the row is editable.
+ */
+export function jobCanModify(job) {
+    return Boolean(job && editableJobStates.has(valueOf(job.State)));
+}
+
+/**
+ * Builds the plain form model used by the Modify modal.
+ * @param {object} job - Job status row.
+ * @returns {object} Plain form fields.
+ */
+export function createModifyForm(job) {
+    const dependencies = splitDependencies(job.Dependencies || []);
+    const behaviours = parseBehaviourMapping(job.Behaviours);
+    const onFailure = jsonArrayText(behaviours.on_failure);
+    const onSuccess = jsonArrayText(behaviours.on_success);
+    const onExit = jsonArrayText(behaviours.on_exit);
+    const cmdDeps = jsonArrayText(dependencies.cmdDeps);
+    const other = linesFromList(job.OtherRequests || []);
+    const mounts = job.Mounts || '';
+    const env = linesFromList(job.EnvOverrides || []);
+
+    return {
+        key: job.Key || '',
+        cmd: job.Cmd || '',
+        cwd: job.CwdBase || '',
+        cwdMatters: Boolean(job.CwdMatters),
+        changeHome: Boolean(job.HomeChanged),
+        reqGrp: job.ReqGroup || '',
+        memory: memoryText(job.ExpectedRAM),
+        time: durationText(job.ExpectedTime),
+        cpus: numberText(job.Cores),
+        disk: numberText(job.RequestedDisk),
+        priority: numberText(job.Priority),
+        retries: numberText(job.Retries),
+        override: numberText(job.Override),
+        noRetryOverWalltime: durationText(job.NoRetryOverWalltime),
+        limitGrps: linesFromList(job.LimitGroups || []),
+        modules: linesFromList(job.Modules || []),
+        deps: linesFromList(dependencies.deps),
+        cmdDeps,
+        onFailure,
+        onSuccess,
+        onExit,
+        other,
+        mounts,
+        monitorDocker: job.MonitorDocker || '',
+        withDocker: job.WithDocker || '',
+        withSingularity: job.WithSingularity || '',
+        containerMounts: job.ContainerMounts || '',
+        env,
+        originalJob: job,
+        originalCmdDeps: cmdDeps,
+        originalOnFailure: onFailure,
+        originalOnSuccess: onSuccess,
+        originalOnExit: onExit,
+        originalOther: other,
+        originalMounts: mounts,
+        originalEnv: env,
+    };
+}
+
+/**
+ * Builds the PATCH payload for a Modify form.
+ * @param {object} form - Plain or Knockout-observable form fields.
+ * @returns {object} REST PATCH payload.
+ */
+export function createModifyPayload(form) {
+    const payload = {
+        cmd: textField(form, 'cmd'),
+        cwd: textField(form, 'cwd'),
+        cwd_matters: boolField(form, 'cwdMatters'),
+        change_home: boolField(form, 'changeHome'),
+        req_grp: textField(form, 'reqGrp'),
+        memory: textField(form, 'memory'),
+        time: textField(form, 'time'),
+        cpus: numberField(form, 'cpus'),
+        disk: intField(form, 'disk'),
+        priority: intField(form, 'priority'),
+        retries: intField(form, 'retries'),
+        override: intField(form, 'override'),
+        no_retry_over_walltime: textField(form, 'noRetryOverWalltime') || '0s',
+        limit_grps: linesFromText(textField(form, 'limitGrps')),
+        modules: linesFromText(textField(form, 'modules')),
+        deps: linesFromText(textField(form, 'deps')),
+        monitor_docker: textField(form, 'monitorDocker'),
+        with_docker: textField(form, 'withDocker'),
+        with_singularity: textField(form, 'withSingularity'),
+        container_mounts: textField(form, 'containerMounts'),
+    };
+
+    setJSONPayloadField(payload, 'cmd_deps', form, 'cmdDeps', 'originalCmdDeps');
+    setJSONPayloadField(payload, 'on_failure', form, 'onFailure', 'originalOnFailure');
+    setJSONPayloadField(payload, 'on_success', form, 'onSuccess', 'originalOnSuccess');
+    setJSONPayloadField(payload, 'on_exit', form, 'onExit', 'originalOnExit');
+    setOtherPayloadField(payload, form);
+    setMountPayloadField(payload, form);
+    setEnvPayloadField(payload, form);
+
+    return payload;
+}
+
+/**
+ * Builds a fetch request for the Modify PATCH call.
+ * @param {object} form - Plain or Knockout-observable form fields.
+ * @param {string} token - Bearer token from the status page URL.
+ * @returns {object} Fetch URL and options.
+ */
+export function createModifyRequest(form, token) {
+    const headers = {
+        'Content-Type': 'application/json',
+    };
+
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+
+    return {
+        url: `/rest/v1/jobs/${encodeURIComponent(textField(form, 'key'))}`,
+        options: {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify(createModifyPayload(form)),
+        },
+    };
+}
+
+/**
+ * Applies a successful JobModifyResponse to the visible details rows.
+ * @param {Array<object>} details - Current visible rows.
+ * @param {object} response - REST modify response.
+ * @returns {Array<object>} Updated visible rows.
+ */
+export function replaceModifiedJobs(details, response) {
+    const rows = Array.isArray(details) ? details.slice() : [];
+    const modified = response?.modified || response?.Modified || {};
+    const jobs = response?.jobs || response?.Jobs || [];
+
+    if (!Array.isArray(jobs) || jobs.length === 0) {
+        return rows;
+    }
+
+    let updated = rows;
+
+    for (const job of jobs) {
+        const oldKey = modified[job.Key] || modified[job.key] || job.Key;
+        const index = updated.findIndex(row => row.Key === oldKey || row.Key === job.Key);
+        const previous = index >= 0 ? updated[index] : {};
+        const replacement = normalizeReturnedJob(previous, job);
+
+        if (index >= 0) {
+            updated.splice(index, 1, replacement);
+        } else {
+            updated.push(replacement);
+        }
+
+        if (oldKey && oldKey !== replacement.Key) {
+            updated = updated.filter(row => row.Key !== oldKey);
+        }
+    }
+
+    return updated;
+}
+
+/**
+ * Removes response-body newlines that http.Error appends.
+ * @param {string} text - Error response body.
+ * @returns {string} Text without trailing newlines.
+ */
+export function trimTrailingNewline(text) {
+    return String(text || '').replace(/(\r?\n)+$/g, '');
+}
+
+function valueOf(value) {
+    return typeof value === 'function' ? value() : value;
+}
+
+function textField(form, field) {
+    return String(valueOf(form[field]) ?? '');
+}
+
+function boolField(form, field) {
+    return Boolean(valueOf(form[field]));
+}
+
+function numberField(form, field) {
+    const value = Number(textField(form, field));
+    return Number.isNaN(value) ? 0 : value;
+}
+
+function intField(form, field) {
+    return Math.trunc(numberField(form, field));
+}
+
+function memoryText(megabytes) {
+    const value = Number(megabytes || 0);
+    return `${Number.isInteger(value) ? value : value.toString()}M`;
+}
+
+function numberText(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+
+    return String(value);
+}
+
+function durationText(seconds) {
+    const value = Number(seconds || 0);
+    if (!value) {
+        return '';
+    }
+
+    if (value % 86400 === 0) {
+        return `${value / 86400}d`;
+    }
+
+    if (value % 3600 === 0) {
+        return `${value / 3600}h`;
+    }
+
+    if (value % 60 === 0) {
+        return `${value / 60}m`;
+    }
+
+    return `${value}s`;
+}
+
+function linesFromList(list) {
+    return Array.isArray(list) ? list.join('\n') : '';
+}
+
+function linesFromText(text) {
+    return String(text || '')
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(line => line !== '');
+}
+
+function splitDependencies(dependencies) {
+    const deps = [];
+    const cmdDeps = [];
+
+    for (const dependency of dependencies) {
+        const match = String(dependency).match(commandDependencyPattern);
+        if (match) {
+            cmdDeps.push({ cmd: match[1], cwd: match[2] });
+        } else {
+            deps.push(dependency);
+        }
+    }
+
+    return { deps, cmdDeps };
+}
+
+function parseBehaviourMapping(behaviours) {
+    if (!behaviours) {
+        return {};
+    }
+
+    return JSON.parse(behaviours);
+}
+
+function jsonArrayText(value) {
+    return Array.isArray(value) && value.length > 0 ? JSON.stringify(value) : '';
+}
+
+function parseJSONList(text) {
+    const value = String(text || '').trim();
+    if (value === '') {
+        return [];
+    }
+
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+}
+
+function setJSONPayloadField(payload, payloadField, form, formField, originalField) {
+    const current = textField(form, formField).trim();
+    const original = textField(form, originalField).trim();
+
+    if (current !== '' || original !== '') {
+        payload[payloadField] = parseJSONList(current);
+    }
+}
+
+function setOtherPayloadField(payload, form) {
+    const current = textField(form, 'other').trim();
+    const original = textField(form, 'originalOther').trim();
+
+    if (current === '' && original === '') {
+        return;
+    }
+
+    const other = {};
+    for (const line of linesFromText(current)) {
+        const separator = line.indexOf(':');
+        if (separator < 0) {
+            other[line] = '';
+        } else {
+            other[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+        }
+    }
+
+    payload.other = other;
+}
+
+function setMountPayloadField(payload, form) {
+    const current = textField(form, 'mounts').trim();
+    const original = textField(form, 'originalMounts').trim();
+
+    if (current !== '' || original !== '') {
+        payload.mounts = parseJSONList(current);
+    }
+}
+
+function setEnvPayloadField(payload, form) {
+    const current = textField(form, 'env');
+    const original = textField(form, 'originalEnv');
+
+    if (current !== original || original.trim() !== '') {
+        payload.env = linesFromText(current);
+    }
+}
+
+function normalizeReturnedJob(previous, returned) {
+    const next = { ...returned };
+
+    if ((!Array.isArray(next.Env) || next.Env.length === 0) && Array.isArray(previous.Env)) {
+        next.Env = effectiveEnvWithOverrides(previous.Env, previous.EnvOverrides || [], next.EnvOverrides || []);
+    }
+
+    return next;
+}
+
+function effectiveEnvWithOverrides(previousEnv, previousOverrides, nextOverrides) {
+    const previousOverrideNames = envNames(previousOverrides);
+    const nextOverrideNames = envNames(nextOverrides);
+    const overrideNames = new Set([...previousOverrideNames, ...nextOverrideNames]);
+    const inherited = previousEnv.filter(entry => !overrideNames.has(envName(entry)));
+
+    return inherited.concat(nextOverrides);
+}
+
+function envNames(entries) {
+    return new Set((entries || []).map(envName));
+}
+
+function envName(entry) {
+    return String(entry).split('=')[0];
+}

--- a/jobqueue/static/js/wr/modify-job.js
+++ b/jobqueue/static/js/wr/modify-job.js
@@ -221,10 +221,6 @@ function durationText(seconds) {
         return '';
     }
 
-    if (value % 86400 === 0) {
-        return `${value / 86400}d`;
-    }
-
     if (value % 3600 === 0) {
         return `${value / 3600}h`;
     }

--- a/jobqueue/static/js/wr/modify-job.js
+++ b/jobqueue/static/js/wr/modify-job.js
@@ -271,14 +271,18 @@ function jsonArrayText(value) {
     return Array.isArray(value) && value.length > 0 ? JSON.stringify(value) : '';
 }
 
-function parseJSONList(text) {
+function parseJSONList(text, fieldName) {
     const value = String(text || '').trim();
     if (value === '') {
         return [];
     }
 
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : [];
+    if (!Array.isArray(parsed)) {
+        throw new Error(`${fieldName} must be a JSON array`);
+    }
+
+    return parsed;
 }
 
 function setJSONPayloadField(payload, payloadField, form, formField, originalField) {
@@ -286,7 +290,7 @@ function setJSONPayloadField(payload, payloadField, form, formField, originalFie
     const original = textField(form, originalField).trim();
 
     if (current !== '' || original !== '') {
-        payload[payloadField] = parseJSONList(current);
+        payload[payloadField] = parseJSONList(current, payloadField);
     }
 }
 
@@ -316,7 +320,7 @@ function setMountPayloadField(payload, form) {
     const original = textField(form, 'originalMounts').trim();
 
     if (current !== '' || original !== '') {
-        payload.mounts = parseJSONList(current);
+        payload.mounts = parseJSONList(current, 'mounts');
     }
 }
 

--- a/jobqueue/static/js/wr/status-viewmodel.js
+++ b/jobqueue/static/js/wr/status-viewmodel.js
@@ -14,6 +14,7 @@ import { setupWebSocket } from '/js/wr/websocket-handler.js';
 import { requestRepGroup, showGroupState, loadMoreJobs } from '/js/wr/repgroup-handler.js';
 import { modalHandlers, jobToActionDetails, commitAction } from '/js/wr/modal-handlers.js';
 import { actionHandlers } from '/js/wr/action-handlers.js';
+import { jobCanModify } from '/js/wr/modify-job.js';
 import {
     createMemoryChartConfig,
     createDiskChartConfig,
@@ -609,6 +610,18 @@ export function StatusViewModel() {
     self.jobDetailsData = ko.observable();
     self.showJobDetails = function (job) {
         modalHandlers.showJobDetails(self, job);
+    };
+
+    self.modifyJobModalVisible = ko.observable(false);
+    self.modifyJobForm = ko.observable();
+    self.modifyJobError = ko.observable('');
+    self.modifyJobSubmitting = ko.observable(false);
+    self.jobCanModify = jobCanModify;
+    self.showModifyJob = function (job) {
+        actionHandlers.showModifyJob(self, job);
+    };
+    self.submitModifyJob = function () {
+        return modalHandlers.submitModifyJob(self);
     };
 
     self.actionModalVisible = ko.observable(false);

--- a/jobqueue/static/status.html
+++ b/jobqueue/static/status.html
@@ -752,6 +752,10 @@
                                 </button>
                             </span>
                             <!-- /ko -->
+                            <!-- ko if: $root.jobCanModify($data) -->
+                            <button type="button" class="btn btn-primary pull-right"
+                                data-bind="click: $root.showModifyJob">Modify</button>
+                            <!-- /ko -->
                             <!-- ko if: State == "delayed" -->
                             <button type="button" class="btn btn-danger pull-right"
                                 data-bind="click: $root.confirmRemoveDelay">Remove</button>
@@ -839,6 +843,241 @@
                 <!-- /ko -->
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
             </div>
+        </script>
+
+        <!-- modify modal -->
+        <div data-bind="modal: {
+                visible: modifyJobModalVisible,
+                dialogCss: 'modal-lg',
+                header: { data: { label: 'Modify Job' } },
+                body: { name: 'modifyJobModalBodyTemplate', data: modifyJobForm },
+                footer: { name: 'modifyJobModalFooterTemplate', data: modifyJobForm }
+            }"></div>
+
+        <script type="text/html" id="modifyJobModalBodyTemplate">
+            <!-- ko if: $data -->
+            <form class="form-horizontal" data-bind="submit: $root.submitModifyJob">
+                <!-- ko if: $root.modifyJobError() -->
+                <div class="alert alert-danger" data-bind="text: $root.modifyJobError"></div>
+                <!-- /ko -->
+
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Command</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="cmd"
+                                    data-bind="value: cmd">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Working dir</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="cwd"
+                                    data-bind="value: cwd">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-sm-offset-4 col-sm-8">
+                                <label class="checkbox-inline">
+                                    <input type="checkbox" data-modify-field="cwd_matters"
+                                        data-bind="checked: cwdMatters"> cwd matters
+                                </label>
+                                <label class="checkbox-inline">
+                                    <input type="checkbox" data-modify-field="change_home"
+                                        data-bind="checked: changeHome"> change home
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Req group</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="req_grp"
+                                    data-bind="value: reqGrp">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">RAM</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="memory"
+                                    data-bind="value: memory">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Time</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="time"
+                                    data-bind="value: time">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Cores</label>
+                            <div class="col-sm-8">
+                                <input type="number" step="any" class="form-control" data-modify-field="cpus"
+                                    data-bind="value: cpus">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Disk GB</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control" data-modify-field="disk"
+                                    data-bind="value: disk">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Priority</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control" data-modify-field="priority"
+                                    data-bind="value: priority">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Retries</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control" data-modify-field="retries"
+                                    data-bind="value: retries">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Override</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control" data-modify-field="override"
+                                    data-bind="value: override">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">No retry over</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="no_retry_over_walltime"
+                                    data-bind="value: noRetryOverWalltime">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-sm-6">
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Limit groups</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="limit_grps"
+                                    data-bind="value: limitGrps"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Modules</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="modules"
+                                    data-bind="value: modules"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Dep groups</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="deps"
+                                    data-bind="value: deps"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Cmd deps</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="cmd_deps"
+                                    data-bind="value: cmdDeps"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">On failure</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="on_failure"
+                                    data-bind="value: onFailure"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">On success</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="on_success"
+                                    data-bind="value: onSuccess"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">On exit</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="on_exit"
+                                    data-bind="value: onExit"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Other</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="other"
+                                    data-bind="value: other"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Mounts</label>
+                            <div class="col-sm-8">
+                                <textarea class="form-control" rows="2" data-modify-field="mounts"
+                                    data-bind="value: mounts"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <hr>
+
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Monitor docker</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="monitor_docker"
+                                    data-bind="value: monitorDocker">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Docker image</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="with_docker"
+                                    data-bind="value: withDocker">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Singularity</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="with_singularity"
+                                    data-bind="value: withSingularity">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-sm-4 control-label">Container mounts</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control" data-modify-field="container_mounts"
+                                    data-bind="value: containerMounts">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">Env overrides</label>
+                    <div class="col-sm-10">
+                        <textarea class="form-control" rows="3" data-modify-field="env"
+                            data-bind="value: env"></textarea>
+                    </div>
+                </div>
+            </form>
+            <!-- /ko -->
+        </script>
+
+        <script type="text/html" id="modifyJobModalFooterTemplate">
+            <!-- ko if: $data -->
+            <div class="btn-group">
+                <button type="button" class="btn btn-primary"
+                    data-bind="click: $root.submitModifyJob, disable: $root.modifyJobSubmitting">Save</button>
+                <button type="button" class="btn btn-default" data-dismiss="modal"
+                    data-bind="disable: $root.modifyJobSubmitting">Cancel</button>
+            </div>
+            <!-- /ko -->
         </script>
 
         <!-- Single combined misc job details modal -->

--- a/jobqueue/static/status.html
+++ b/jobqueue/static/status.html
@@ -856,7 +856,7 @@
 
         <script type="text/html" id="modifyJobModalBodyTemplate">
             <!-- ko if: $data -->
-            <form class="form-horizontal" data-bind="submit: $root.submitModifyJob">
+            <form class="form-horizontal" data-bind="submit: function() { $root.submitModifyJob(); return false; }">
                 <!-- ko if: $root.modifyJobError() -->
                 <div class="alert alert-danger" data-bind="text: $root.modifyJobError"></div>
                 <!-- /ko -->


### PR DESCRIPTION
Solves #197
Solves #19

## Summary
- Add a REST PATCH job modification endpoint using existing auth and wr mod validation semantics.
- Expose editable job fields to status/detail payloads for the web UI.
- Add a web Modify flow for editable non-running jobs, including env overrides and resource requirements.

## Spec and phases
- .docs/issue-197/spec.md
- .docs/issue-197/phase1.md
- .docs/issue-197/phase2.md
- .docs/issue-197/phase3.md

## Verification
- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run 'TestRESTJobModificationEndpoint|TestRESTJobModificationValidation|TestWebUIModificationStaticContract'
- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run '^TestREST$'
- golangci-lint run