### PR TITLE
Solve #98: add live job introspection

### DIFF
--- a/.docs/issue-98/phase1.md
+++ b/.docs/issue-98/phase1.md
@@ -1,0 +1,36 @@
+# Phase 1: Add runner live tail capture and touch state
+
+Ref: [spec.md](spec.md) sections A1, A2
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer`
+skills.
+
+## Items
+
+### Item 1.1: A1 - Bound live output tail payloads
+
+spec.md section: A1
+
+Implement the unexported `liveTailSaver`, `Write`, and `FlushCompressed`
+helpers plus the `liveStdRawTailLimit` and `liveStdCompressedLimit` constants
+in `jobqueue/utils.go`. Add `jobqueue/utils_test.go` coverage for all 5
+acceptance tests from A1.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 1.2: A2 - Send live metrics on existing touches
+
+spec.md section: A2
+
+Implement the unexported `Client.touch(job, endState)` helper and wire
+`Touch` and `Execute` in `jobqueue/client.go` to assemble live `JobEndState`
+snapshots using the A1 tail saver, actual cwd, resource metrics, and flushed
+stdout/stderr tails. Add `jobqueue/client_payload_test.go` coverage for all 5
+acceptance tests from A2. Depends on item 1.1.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-98/phase1.md
+++ b/.docs/issue-98/phase1.md
@@ -19,7 +19,7 @@ helpers plus the `liveStdRawTailLimit` and `liveStdCompressedLimit` constants
 in `jobqueue/utils.go`. Add `jobqueue/utils_test.go` coverage for all 5
 acceptance tests from A1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 1.2: A2 - Send live metrics on existing touches
@@ -32,5 +32,5 @@ snapshots using the A1 tail saver, actual cwd, resource metrics, and flushed
 stdout/stderr tails. Add `jobqueue/client_payload_test.go` coverage for all 5
 acceptance tests from A2. Depends on item 1.1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-98/phase1.md
+++ b/.docs/issue-98/phase1.md
@@ -20,7 +20,7 @@ in `jobqueue/utils.go`. Add `jobqueue/utils_test.go` coverage for all 5
 acceptance tests from A1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 1.2: A2 - Send live metrics on existing touches
 
@@ -33,4 +33,4 @@ stdout/stderr tails. Add `jobqueue/client_payload_test.go` coverage for all 5
 acceptance tests from A2. Depends on item 1.1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-98/phase2.md
+++ b/.docs/issue-98/phase2.md
@@ -21,7 +21,7 @@ Add `jobqueue/jobqueue_test.go` coverage for all 5 acceptance tests from B1.
 Depends on phase 1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 2.2: D1 - Preserve existing status behaviour without live data
 
@@ -33,4 +33,4 @@ semantics. Add `jobqueue/jobqueue_test.go` and `jobqueue/serverWebI_test.go`
 coverage for all 3 acceptance tests from D1. Depends on item 2.1.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-98/phase2.md
+++ b/.docs/issue-98/phase2.md
@@ -1,0 +1,36 @@
+# Phase 2: Apply live snapshots in `jtouch` behind the secure gate
+
+Ref: [spec.md](spec.md) sections B1, D1
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer`
+skills.
+
+## Items
+
+### Item 2.1: B1 - Apply live snapshots on jtouch
+
+spec.md section: B1
+
+Implement `jtouch` live snapshot handling in `jobqueue/serverCLI.go` so the
+manager detects present live data, enforces the authenticated HTTPS secure
+gate, applies live fields to running jobs, and avoids setting terminal state.
+Add `jobqueue/jobqueue_test.go` coverage for all 5 acceptance tests from B1.
+Depends on phase 1.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 2.2: D1 - Preserve existing status behaviour without live data
+
+spec.md section: D1
+
+Guard the B1 changes so absent live data, older runner touches, completed job
+archives, and `KillCalled` running jobs preserve existing status and touch
+semantics. Add `jobqueue/jobqueue_test.go` and `jobqueue/serverWebI_test.go`
+coverage for all 3 acceptance tests from D1. Depends on item 2.1.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-98/phase2.md
+++ b/.docs/issue-98/phase2.md
@@ -20,7 +20,7 @@ gate, applies live fields to running jobs, and avoids setting terminal state.
 Add `jobqueue/jobqueue_test.go` coverage for all 5 acceptance tests from B1.
 Depends on phase 1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 2.2: D1 - Preserve existing status behaviour without live data
@@ -32,5 +32,5 @@ archives, and `KillCalled` running jobs preserve existing status and touch
 semantics. Add `jobqueue/jobqueue_test.go` and `jobqueue/serverWebI_test.go`
 coverage for all 3 acceptance tests from D1. Depends on item 2.1.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-98/phase3.md
+++ b/.docs/issue-98/phase3.md
@@ -22,4 +22,4 @@ RepGroup semantics. Add `jobqueue/subscription_test.go` coverage for all 6
 acceptance tests from B2. Depends on phase 2.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-98/phase3.md
+++ b/.docs/issue-98/phase3.md
@@ -1,0 +1,25 @@
+# Phase 3: Add `JobUpdateLive` delivery
+
+Ref: [spec.md](spec.md) sections B2
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer`
+skills.
+
+## Items
+
+### Item 3.1: B2 - Push live updates to job subscribers
+
+spec.md section: B2
+
+Append `JobUpdateLive` to `JobUpdateKind`, add the B2 live fields and
+`SSHCommand` to `JobUpdate` in `jobqueue/subscription.go`, and deliver live
+updates from `jobqueue/server_subscription.go` and `jtouch` to key and status
+websocket detail subscriptions. Preserve `AddAndWait` terminal waiting and
+RepGroup semantics. Add `jobqueue/subscription_test.go` coverage for all 6
+acceptance tests from B2. Depends on phase 2.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-98/phase3.md
+++ b/.docs/issue-98/phase3.md
@@ -21,5 +21,5 @@ websocket detail subscriptions. Preserve `AddAndWait` terminal waiting and
 RepGroup semantics. Add `jobqueue/subscription_test.go` coverage for all 6
 acceptance tests from B2. Depends on phase 2.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-98/phase4.md
+++ b/.docs/issue-98/phase4.md
@@ -22,7 +22,7 @@ details. Add `jobqueue/job_test.go`, `jobqueue/serverWebI_test.go`, and
 on phase 2.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed
 
 ### Item 4.2: C2 - Render live introspection in running job details
 
@@ -37,4 +37,4 @@ embedded terminal. Add `jobqueue/serverWebI_test.go` coverage for all 6
 acceptance tests from C2. Depends on item 4.1 and phase 3.
 
 - [x] implemented
-- [ ] reviewed
+- [x] reviewed

--- a/.docs/issue-98/phase4.md
+++ b/.docs/issue-98/phase4.md
@@ -21,7 +21,7 @@ details. Add `jobqueue/job_test.go`, `jobqueue/serverWebI_test.go`, and
 `jobqueue/rest_test.go` coverage for all 7 acceptance tests from C1. Depends
 on phase 2.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed
 
 ### Item 4.2: C2 - Render live introspection in running job details
@@ -36,5 +36,5 @@ stderr, and a copyable SSH command for running job details without adding an
 embedded terminal. Add `jobqueue/serverWebI_test.go` coverage for all 6
 acceptance tests from C2. Depends on item 4.1 and phase 3.
 
-- [ ] implemented
+- [x] implemented
 - [ ] reviewed

--- a/.docs/issue-98/phase4.md
+++ b/.docs/issue-98/phase4.md
@@ -1,0 +1,40 @@
+# Phase 4: Add live status JSON, REST, websocket, and UI updates
+
+Ref: [spec.md](spec.md) sections C1, C2
+
+## Instructions
+
+Use the `orchestrator` skill to complete this phase, coordinating
+subagents with the `go-implementor` and `go-reviewer`
+skills.
+
+## Items
+
+### Item 4.1: C1 - Include live fields and SSH command in status
+
+spec.md section: C1
+
+Add `SSHCommand` to `JStatus` in `jobqueue/job.go`, populate live status
+fields from running jobs, implement the running-job SSH command construction
+and quoting rules, and ensure REST/status JSON exposes only authenticated job
+details. Add `jobqueue/job_test.go`, `jobqueue/serverWebI_test.go`, and
+`jobqueue/rest_test.go` coverage for all 7 acceptance tests from C1. Depends
+on phase 2.
+
+- [ ] implemented
+- [ ] reviewed
+
+### Item 4.2: C2 - Render live introspection in running job details
+
+spec.md section: C2
+
+Update `jobqueue/static/status.html`,
+`jobqueue/static/js/wr/websocket-handler.js`,
+`jobqueue/static/js/wr/utility.js`, and
+`jobqueue/static/css/wr-0.36.0.css` to render live RAM, CPU time, stdout,
+stderr, and a copyable SSH command for running job details without adding an
+embedded terminal. Add `jobqueue/serverWebI_test.go` coverage for all 6
+acceptance tests from C2. Depends on item 4.1 and phase 3.
+
+- [ ] implemented
+- [ ] reviewed

--- a/.docs/issue-98/prompt.md
+++ b/.docs/issue-98/prompt.md
@@ -1,0 +1,38 @@
+# Feature: Live job introspection
+
+## Issue
+
+Issue #98 asks for live peak memory and CPU information for running jobs,
+recent stdout/stderr, and a quick way to reach the host where a job is running.
+
+Live walltime and live state updates already exist. The runner touches the
+manager periodically, and job subscriptions exist. Missing pieces are live
+resource usage and output-tail data during a run, plus an SSH convenience.
+
+## Required behaviour
+
+Extend the runner touch/subscription path so running jobs expose live
+introspection data.
+
+- On every existing touch heartbeat, send current peak RAM, CPU information,
+  and the most recent stdout/stderr tail from the last heartbeat.
+- The stdout/stderr tail must have a fixed compressed size limit so touch
+  payload size is bounded.
+- Surface the live metrics and output tail to clients that already receive
+  live job updates.
+- Surface the data in the web UI for running jobs.
+- Display an SSH command that lets a user reach the host and working directory
+  for the running job, for example an `ssh ... && cd ...` command.
+- Do not implement an embedded web terminal in v1.
+- Gate the feature on HTTPS/auth being enabled.
+- Keep existing live status behaviour working when the new data is absent,
+  older runners connect, or auth gating disables the feature.
+
+## Notes
+
+The touch frequency stays at the current configured touch interval. No new
+polling loop is required.
+
+Spec questions should be surfaced to the human only if they require a product
+or maintainer choice. Implementation details should be decided from existing
+wr patterns or sensible defaults and recorded in the spec.

--- a/.docs/issue-98/spec.md
+++ b/.docs/issue-98/spec.md
@@ -1,0 +1,470 @@
+# Live Job Introspection Specification
+
+## Overview
+
+Running job detail views already receive live walltime and state changes through
+runner touches and job subscriptions. Extend that path so each touch can carry
+the runner's latest peak RAM, CPU time, recent stdout/stderr tail, and actual
+working directory. The manager stores the latest live snapshot on the running
+job and pushes it to existing per-job subscribers.
+
+The feature is a secure convenience view, not a terminal. It must only expose
+live output tails and SSH commands over authenticated TLS manager surfaces. If
+live data is absent, an older runner touches the job, or the secure gate is not
+enabled for an authenticated runner, existing touch, status, and subscription
+behaviour remains unchanged.
+
+## Architecture
+
+### Packages and files
+
+- `jobqueue/client.go`: keep public `Touch` unchanged, add bounded live
+  stdout/stderr tail capture inside `Execute`, snapshot live peak RAM, disk,
+  CPU time, and actual cwd on the existing touch ticker. Test in
+  `jobqueue/client_payload_test.go` and `jobqueue/jobqueue_test.go`.
+- `jobqueue/utils.go`: add the bounded live tail writer/compressor next to
+  `prefixSuffixSaver` and `stdFilter`. Test in `jobqueue/utils_test.go`.
+- `jobqueue/serverCLI.go`: extend `jtouch` to apply live snapshots and enqueue
+  live subscription updates after `q.Touch`. Test in
+  `jobqueue/jobqueue_test.go` or `jobqueue/subscription_test.go`.
+- `jobqueue/subscription.go`: add `JobUpdateLive` and live fields to
+  `JobUpdate`. Existing terminal wait helpers ignore non-terminal live updates.
+  Test in `jobqueue/subscription_test.go`.
+- `jobqueue/server_subscription.go`: deliver live updates to key subscriptions
+  and status websocket detail subscriptions. Live updates must not complete a
+  RepGroup subscription. Test in `jobqueue/subscription_test.go`.
+- `jobqueue/job.go` and `jobqueue/serverWebI.go`: include live fields and an
+  SSH command in `JStatus`. Test in `jobqueue/serverWebI_test.go` and
+  `jobqueue/rest_test.go`.
+- `jobqueue/static/status.html`, `jobqueue/static/js/wr/websocket-handler.js`,
+  `jobqueue/static/js/wr/utility.js`, and `jobqueue/static/css/wr-0.36.0.css`:
+  render live RAM/CPU, live stdout/stderr, and a copyable SSH command for
+  running jobs. Do not add an embedded terminal.
+
+### Public API and wire shape
+
+Keep this public method signature:
+
+```go
+func (c *Client) Touch(job *Job) (bool, error)
+```
+
+Do not change `JobEndState`. During a live touch `Exited` is false, `Exitcode`
+and `EndTime` are ignored, and these existing fields are meaningful:
+
+```go
+Cwd      string
+PeakRAM  int
+PeakDisk int64
+CPUtime  time.Duration
+Stdout   []byte
+Stderr   []byte
+Exited   bool
+```
+
+Append the new kind after existing `JobUpdateKind` values so old numeric values
+do not move:
+
+```go
+const (
+    JobUpdateTerminal JobUpdateKind = iota
+    JobUpdateLost
+    JobUpdateRepGroupDone
+    JobUpdateResync
+    JobUpdateStateChange
+    JobUpdateLive
+)
+```
+
+Extend `JobUpdate` without removing existing fields. Add:
+
+```go
+PeakRAM    int
+PeakDisk   int64
+Pid        int
+CPUtime    time.Duration
+Host       string
+HostID     string
+HostIP     string
+CwdBase    string
+Cwd        string
+StdOut     string
+StdErr     string
+SSHCommand string
+```
+
+Extend `JStatus` without removing existing fields. Add:
+
+```go
+SSHCommand string
+```
+
+### Semantics
+
+- Touch frequency stays `Client.touchInterval`; no new heartbeat or polling
+  loop is added.
+- Live stdout/stderr tail is per stream:
+  - raw in-memory tail cap: `64 * 1024` bytes;
+  - compressed zlib payload cap: `4096` bytes;
+  - nil when no bytes were written since the previous touch attempt;
+  - data is reset after each touch attempt, successful or failed;
+  - final archived stdout/stderr still uses the existing final
+    `prefixSuffixSaver` path and is not truncated by live flushing.
+- Live `CPUtime` is cumulative process-tree user+system CPU time observed while
+  the job is running. Docker-monitored jobs add the existing container CPU
+  seconds. Zero means unavailable.
+- Live `PeakRAM` is the highest MB value observed so far by the existing
+  resource checker. `PeakDisk` is optional but should be updated when already
+  available.
+- A live snapshot is present only when `JobEndState != nil` and at least one
+  live field is set: `Cwd != ""`, `PeakRAM != 0`, `PeakDisk != 0`,
+  `CPUtime != 0`, `len(Stdout) != 0`, or `len(Stderr) != 0`. Nil
+  `JobEndState`, `&JobEndState{}`, and all-zero live fields from older runners
+  count as absent live data.
+- The manager applies live snapshots only for authenticated `jtouch` requests
+  and only when live introspection is enabled. In current `Serve` this means the
+  manager has a valid token and HTTPS web port. If `ServerInfo.WebPort == ""`
+  for an authenticated runner, `jtouch` only extends TTR and returns
+  `KillCalled`.
+- Absent live data must keep existing `jtouch` TTR and `KillCalled` behaviour.
+  It must not apply a live snapshot or emit live subscription or websocket
+  updates.
+- If HTTPS is present but the `jtouch` token is absent or invalid, the request
+  is denied. It must not touch TTR, update live fields, emit live updates, or
+  return a normal `KillCalled` response.
+- Applying a live snapshot must not set `Exited`, `Exitcode`, `EndTime`, or a
+  terminal state. Lost-to-running recovery performed by existing `jtouch`
+  remains unchanged.
+- `JobUpdateLive` is delivered to key subscriptions and status websocket detail
+  subscriptions. `AddAndWait` and terminal collection ignore it. RepGroup-only
+  subscriptions do not emit per-job live events and live events do not trigger
+  `JobUpdateRepGroupDone`.
+- SSH command is only for `JobStateRunning`. Return an empty command for
+  complete, buried, and lost jobs, even when `Host`, `HostIP`, and `ActualCwd`
+  are still set from the run. UI must hide the SSH command control whenever the
+  command is empty.
+- For running jobs, SSH command target is `cloud_user@HostIP` when
+  `Requirements.Other` contains `cloud_user` and `HostIP` is set; otherwise use
+  `HostIP`, then `Host`. The remote command is
+  `cd <actual-cwd> && exec ${SHELL:-/bin/sh} -l`, with local shell arguments and
+  the remote cwd shell-quoted. Return an empty command when host or actual cwd
+  is missing.
+
+## Section A: Runner Touch Payload
+
+### A1: Bound live output tail payloads
+
+As a runner, I want to send only a bounded recent output tail, so that touch
+payloads stay small even when jobs write large logs.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/utils.go`
+**Test file:** `jobqueue/utils_test.go`
+
+Add unexported helpers:
+
+```go
+const (
+    liveStdRawTailLimit        = 64 * 1024
+    liveStdCompressedLimit     = 4096
+)
+
+type liveTailSaver struct { /* unexported fields */ }
+
+func (w *liveTailSaver) Write(p []byte) (int, error)
+func (w *liveTailSaver) FlushCompressed() []byte
+```
+
+**Acceptance tests:**
+
+1. Given a new `liveTailSaver`, when `Write([]byte("one\n"))` then
+   `FlushCompressed()` is called, then the compressed result is non-nil,
+   `len(result) <= 4096`, and decompressing it returns exactly `"one\n"`.
+2. Given test 1 has flushed, when `FlushCompressed()` is called again without
+   more writes, then it returns nil.
+3. Given a new `liveTailSaver`, when it writes 64 KiB of deterministic
+   pseudo-random bytes from `rand.New(rand.NewSource(1))`, then
+   `FlushCompressed()` returns non-nil bytes with `len(result) <= 4096`, and
+   decompressed bytes equal a suffix of the written bytes.
+4. Given a new `liveTailSaver`, when it writes `"UNIQUE-PREFIX\n"`, 128 KiB
+   of deterministic pseudo-random bytes, and `"UNIQUE-SUFFIX\n"`, then
+   decompressed flush output contains `"UNIQUE-SUFFIX\n"` and does not contain
+   `"UNIQUE-PREFIX\n"`.
+5. Given stdout writes `"old\n"` then flushes and later writes `"new\n"`, when
+   the second flush is decompressed, then it returns exactly `"new\n"`.
+
+### A2: Send live metrics on existing touches
+
+As a runner, I want each normal touch to include current live resource and tail
+data, so that clients see the latest run information without a new polling loop.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/client.go`
+**Test file:** `jobqueue/client_payload_test.go`
+
+Add an unexported helper and keep `Touch` as a wrapper:
+
+```go
+func (c *Client) touch(job *Job, endState *JobEndState) (bool, error)
+```
+
+**Acceptance tests:**
+
+1. Given a job with key `k`, `PeakRAM=123`, `PeakDisk=456`,
+   `CPUtime=7*time.Second`, `StdOutC=zlib("out\n")`, and
+   `StdErrC=zlib("err\n")`, when `Touch(job)` is called on a capture client,
+   then the request method is `"jtouch"`, `Keys == []string{k}`, `Job == nil`,
+   and `JobEndState` contains exactly those five live fields.
+2. Given `Execute` runs a command in actual cwd `/tmp/wr-live/job1`, and the
+   command writes stdout `"alpha\n"` before the first touch and `"beta\n"`
+   before the second touch, when test hooks capture the two live touch states,
+   then their decompressed stdout values are exactly `"alpha\n"` and
+   `"beta\n"`, and both have `Cwd == "/tmp/wr-live/job1"`.
+3. Given `Execute` runs a command that writes stderr `"err-alpha\n"` before
+   the first touch and `"err-beta\n"` before the second touch, when test hooks
+   capture the two live touch states, then decompressed
+   `JobEndState.Stderr` values are exactly `"err-alpha\n"` and
+   `"err-beta\n"`.
+4. Given a running process tree has used at least `1*time.Millisecond` CPU and
+   peak RAM has been observed as `>= 1`, when a touch state is captured, then
+   `JobEndState.CPUtime >= 1*time.Millisecond` and `PeakRAM >= 1`.
+5. Given `Execute` writes `OUT-OLD\n`, 128 KiB of deterministic pseudo-random
+   stdout, `OUT-NEW\n`, `ERR-OLD\n`, 128 KiB of deterministic pseudo-random
+   stderr, and `ERR-NEW\n` before the first touch, when a test hook captures
+   that live touch and the job archives, then captured `JobEndState.Stdout` and
+   `JobEndState.Stderr` are non-nil, each `len <= 4096`, each decompresses to
+   a suffix containing its `*-NEW\n` marker and not its `*-OLD\n` marker, and
+   final archived `StdOut()`/`StdErr()` equal the existing final
+   `prefixSuffixSaver` output for each complete stream.
+
+## Section B: Manager Live State
+
+### B1: Apply live snapshots on jtouch
+
+As a manager, I want to store the latest live snapshot on the running job, so
+that all existing status paths read the same current data.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverCLI.go`
+**Test file:** `jobqueue/jobqueue_test.go`
+
+**Acceptance tests:**
+
+1. Given an authenticated server with live introspection enabled and a running
+   job with key `k`, when it handles `jtouch` for `k` with
+   `JobEndState{Cwd:"/tmp/wr/job1", PeakRAM:321, PeakDisk:9,
+   CPUtime:4*time.Second, Stdout:zlib("out\n"), Stderr:zlib("err\n")}`, then
+   the response has `KillCalled == false`, the job remains `running`,
+   `Exited == false`, `ActualCwd == "/tmp/wr/job1"`, `PeakRAM == 321`,
+   `PeakDisk == 9`, `CPUtime == 4*time.Second`, `StdOut() == "out\n"`, and
+   `StdErr() == "err\n"`.
+2. Given the same job already has `ActualCwd="/tmp/old"`, `PeakRAM=111`,
+   `PeakDisk=7`, `CPUtime=2*time.Second`, `StdOutC=zlib("old\n")`, and
+   `StdErrC=zlib("olderr\n")`, when an older runner sends authenticated
+   `jtouch` with `&JobEndState{}` (all live fields zero/nil/empty), then TTR is
+   extended, the response has `KillCalled == false`, the job remains running,
+   and all six live fields are unchanged.
+3. Given live introspection is disabled because `ServerInfo.WebPort == ""`,
+   when an authenticated `jtouch` supplies live stdout and metrics, then TTR is
+   extended, the response has `KillCalled == false`, and the job's `PeakRAM`,
+   `CPUtime`, `StdOutC`, `StdErrC`, and `ActualCwd` remain unchanged.
+4. Given HTTPS is present but auth/token is absent or invalid, when `jtouch`
+   supplies live stdout and metrics for a running job, then the response error
+   is `ErrPermissionDenied`, no normal `KillCalled` response is returned, TTR is
+   not extended, and `PeakRAM`, `CPUtime`, `StdOutC`, `StdErrC`, and
+   `ActualCwd` remain unchanged.
+5. Given HTTPS is present but auth/token is absent or invalid and a running job
+   has `KillCalled == true`, when `jtouch` supplies live stdout and metrics,
+   then the response error is `ErrPermissionDenied`, no normal
+   `KillCalled == true` response is returned, TTR is not extended, and
+   `PeakRAM`, `CPUtime`, `StdOutC`, `StdErrC`, and `ActualCwd` remain
+   unchanged.
+
+### B2: Push live updates to job subscribers
+
+As a subscribed client, I want live updates for the jobs I am already watching,
+so that I do not need a separate polling API.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/subscription.go`
+**Test file:** `jobqueue/subscription_test.go`
+
+**Acceptance tests:**
+
+1. Given a key subscription for running job `k`, when `jtouch` applies
+   `PeakRAM=321`, `CPUtime=4*time.Second`, `Stdout=zlib("out\n")`,
+   `Stderr=zlib("err\n")`, `Host="worker1"`, `HostIP="10.0.0.8"`,
+   `Pid=44`, and `Cwd="/tmp/wr/job1"`, then `Updates()` receives one
+   `JobUpdate` with `Kind == JobUpdateLive`, `Key == k`,
+   `State == JobStateRunning`, `PeakRAM == 321`,
+   `CPUtime == 4*time.Second`, `StdOut == "out\n"`, `StdErr == "err\n"`,
+   `Host == "worker1"`, `HostIP == "10.0.0.8"`, `Pid == 44`, and a
+   non-empty `SSHCommand`.
+2. Given `AddAndWait` is waiting on job `k`, when a `JobUpdateLive` for `k` is
+   delivered before the job completes, then `AddAndWait` does not return; when
+   `k` is later archived complete, `AddAndWait` returns exactly one complete
+   job and nil error.
+3. Given a RepGroup subscription has one running job, when that job receives a
+   `JobUpdateLive`, then no `JobUpdateRepGroupDone` is delivered within
+   `100*time.Millisecond`.
+4. Given key and status websocket detail subscriptions watch running job `k`,
+   when an older runner sends authenticated `jtouch` with `&JobEndState{}`
+   (all live fields zero/nil/empty), then no `JobUpdateLive` and no pushed live
+   `JStatus` are delivered within `100*time.Millisecond`.
+5. Given live introspection is disabled because `ServerInfo.WebPort == ""`,
+   and key and status websocket detail subscriptions watch running job `k`,
+   when an authenticated `jtouch` supplies `PeakRAM=321` and
+   `Stdout=zlib("out\n")`, then no `JobUpdateLive` and no pushed live
+   `JStatus` are delivered within `100*time.Millisecond`.
+6. Given HTTPS is present but auth/token is absent or invalid, and key and
+   status websocket detail subscriptions watch running job `k`, when `jtouch`
+   supplies `PeakRAM=321` and `Stdout=zlib("out\n")`, then the response error
+   is `ErrPermissionDenied` and no `JobUpdateLive` and no pushed live `JStatus`
+   are delivered within `100*time.Millisecond`.
+
+## Section C: Status JSON and Web UI
+
+### C1: Include live fields and SSH command in status
+
+As a status client, I want running job JSON to include live metrics, output
+tail, and a ready-to-copy SSH command, so that I can inspect the job host and
+working directory quickly.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/job.go`
+**Test file:** `jobqueue/job_test.go`, `jobqueue/serverWebI_test.go`,
+`jobqueue/rest_test.go`
+
+Add `SSHCommand` to `JStatus`. Reuse existing `PeakRAM`, `PeakDisk`, `CPUtime`,
+`StdOut`, `StdErr`, `Host`, `HostIP`, `Pid`, `CwdBase`, and `Cwd` fields.
+
+**Acceptance tests:**
+
+1. Given a running job with `Host="worker1"`, `HostIP="10.0.0.8"`,
+   `Pid=44`, `Cwd="/tmp/wr"`, `ActualCwd="/tmp/wr/job1"`,
+   `Requirements.Other["cloud_user"] == "ubuntu"`, `PeakRAM=321`,
+   `CPUtime=4*time.Second`, `StdOutC=zlib("out\n")`, and
+   `StdErrC=zlib("err\n")`, when `ToStatus()` is called, then
+   `CwdBase == "/tmp/wr"`, `Cwd == "/job1"`, `PeakRAM == 321`,
+   `CPUtime == 4`, `StdOut == "out\n"`, `StdErr == "err\n"`, and
+   `SSHCommand` equals `"ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec "`
+   plus `"${SHELL:-/bin/sh} -l'"`.
+2. Given a running job with `Host="worker1"`, empty `HostIP`, and
+   `ActualCwd="/tmp/wr/job1"`, when `ToStatus()` is called, then
+   `SSHCommand` equals `"ssh worker1 'cd /tmp/wr/job1 && exec "` plus
+   `"${SHELL:-/bin/sh} -l'"`.
+3. Given a running job has no host or no actual cwd, when `ToStatus()` is
+   called, then `SSHCommand == ""`.
+4. Given a running job with `Host="worker1"` and
+   `ActualCwd="/tmp/wr/live jobs/it's-ok"`, when `ToStatus()` is called, then
+   `SSHCommand` equals this Go expression:
+
+   ```go
+   `ssh worker1 'cd '"'"'/tmp/wr/live jobs/it'"'"'"'"'"'"'"'"'s-ok'"'"' ` +
+       `&& exec ${SHELL:-/bin/sh} -l'`
+   ```
+
+5. Given `JobStateComplete`, `JobStateBuried`, and `JobStateLost` jobs each
+   have `Host="worker1"`, `HostIP="10.0.0.8"`, and
+   `ActualCwd="/tmp/wr/job1"`, when status details call `ToStatus()`, then
+   every returned `SSHCommand == ""`.
+6. Given an authenticated REST GET for a running job with live data, when the
+   JSON is decoded, then the returned `JStatus` has `PeakRAM == 321`,
+   `CPUtime == 4`, `StdOut == "out\n"`, `StdErr == "err\n"`, and the SSH
+   command from test 1.
+7. Given the same REST URL without a token or bearer header, when it is
+   requested, then the response status is `401 Unauthorized` and no job JSON is
+   returned.
+
+### C2: Render live introspection in running job details
+
+As a web UI user, I want running job details to update in place with live
+resources, output tail, and an SSH command, so that I can inspect a running job
+without refreshing or opening an embedded terminal.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/static/status.html`,
+`jobqueue/static/js/wr/websocket-handler.js`
+**Test file:** `jobqueue/serverWebI_test.go`
+
+**Acceptance tests:**
+
+1. Given the details websocket is subscribed to RepGroup `rg1` and job `k` is
+   running, when a live touch update for `k` is applied, then the websocket
+   sends a `JStatus` with `IsPushUpdate == true`, `State == JobStateRunning`,
+   `PeakRAM == 321`, `CPUtime == 4`, `StdOut == "out\n"`,
+   `StdErr == "err\n"`, and the SSH command from C1 test 1.
+2. Given the browser DOM has a running detail row for `k` with no live values,
+   when `handleJobDetailsMessage` receives a push update with `PeakRAM=321`,
+   `CPUtime=4`, `StdOut="alpha-out\n"`, and `StdErr="alpha-err\n"`, then the
+   DOM panel for `k` visibly contains `321 MB`, `CPU: 4s`, `STDOUT`,
+   `alpha-out`, `STDERR`, and `alpha-err`.
+3. Given the DOM from test 2, when another push update for `k` has
+   `PeakRAM=654`, `CPUtime=8`, `StdOut="beta-out\n"`, and
+   `StdErr="beta-err\n"`, then the same DOM panel visibly contains `654 MB`,
+   `CPU: 8s`, `beta-out`, and `beta-err`, and no longer contains
+   `alpha-out` or `alpha-err`.
+4. Given a running job has `SSHCommand == ""`, when details render, then no SSH
+   command control is shown for that job.
+5. Given a running job has `SSHCommand` equal to the C1 test 1 command, when
+   details render, then a copyable command control is shown, its rendered text
+   or copy payload equals exactly `JStatus.SSHCommand`, and no embedded web
+   terminal element is created.
+6. Given the browser DOM has complete, buried, and lost detail rows with
+   historical host/cwd values and `SSHCommand == ""`, when details render, then
+   no SSH command control is shown for those rows.
+
+## Section D: Compatibility
+
+### D1: Preserve existing status behaviour without live data
+
+As an operator with mixed runner versions, I want old runners and absent live
+data to keep working, so that rolling upgrades do not break live status.
+
+**Package:** `jobqueue/`
+**File:** `jobqueue/serverCLI.go`
+**Test file:** `jobqueue/jobqueue_test.go`, `jobqueue/serverWebI_test.go`
+
+**Acceptance tests:**
+
+1. Given a running job with no live snapshot, when status details are requested,
+   then the returned `JStatus` has `PeakRAM == 0`, `CPUtime == 0`,
+   `StdOut == ""`, `StdErr == ""`, `SSHCommand == ""`, and the existing
+   `LiveWalltime` UI behaviour is unchanged.
+2. Given a live snapshot was applied and the job later archives complete with
+   final stdout `"final\n"` and stderr `"done\n"`, when status details are
+   requested after completion, then `StdOut == "final\n"`,
+   `StdErr == "done\n"`, `Exited == true`, and the final `PeakRAM` and
+   `CPUtime` values are the archive values, not stale live values.
+3. Given a running job has `KillCalled == true` and existing live fields, when
+   an authenticated live `jtouch` or older-runner `jtouch` with
+   `&JobEndState{}` arrives, then the response still has
+   `KillCalled == true`, TTR is not extended, and no live fields are
+   overwritten.
+
+## Implementation Order
+
+1. Add bounded live tail capture and live touch state assembly in the runner.
+   Stories: A1, A2. Sequential foundation for all later phases.
+2. Apply live snapshots in `jtouch` and store them on running jobs behind the
+   secure gate. Stories: B1, D1. Depends on phase 1.
+3. Add `JobUpdateLive` delivery for key subscriptions and preserve terminal
+   waiting semantics. Stories: B2. Depends on phase 2.
+4. Add `SSHCommand` and live fields to status JSON, REST, websocket detail
+   updates, and static UI rendering. Stories: C1, C2. Depends on phases 2-3.
+
+## Appendix: Key Decisions
+
+- Reuse the existing touch interval and subscription paths; no separate live
+  polling endpoint and no embedded terminal are part of v1.
+- Use existing status names (`PeakRAM`, `CPUtime`, `StdOut`, `StdErr`) so REST,
+  websocket, and UI code share one payload shape.
+- Bound stdout and stderr independently to 4096 compressed bytes per stream.
+  This keeps each touch payload bounded while final job output remains on the
+  current archive path.
+- Deliver live updates as a new `JobUpdateLive` kind appended to the enum, so
+  terminal update numeric values remain stable and `AddAndWait` can ignore
+  live events.
+- Follow `go-conventions` and `testing-principles`: GoConvey tests should
+  assert visible behaviour through client requests, subscriptions, REST JSON,
+  websocket JSON, and job status values.

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -123,6 +123,7 @@ var (
 const (
 	requestMethodStart          = "jstart"
 	requestMethodSubscribe      = "subscribe"
+	requestMethodTouch          = "jtouch"
 	requestMethodUnsubscribe    = "unsubscribe"
 	requestMethodWaitForUpdates = "waitForUpdates"
 )
@@ -2006,7 +2007,7 @@ func (c *Client) touch(job *Job, endState *JobEndState) (bool, error) {
 	c.inspectLiveTouch(endState)
 
 	resp, err := c.request(&clientRequest{
-		Method:      "jtouch",
+		Method:      requestMethodTouch,
 		Keys:        []string{key},
 		JobEndState: endState,
 	})

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -279,13 +279,17 @@ func (state *executeLiveState) updateResources(peakRAM int, peakDisk int64, cpuT
 	state.Lock()
 	defer state.Unlock()
 
-	if state.peakRAM == peakRAM && state.peakDisk == peakDisk && state.cpuTime == cpuTime {
-		return
+	if peakRAM > state.peakRAM {
+		state.peakRAM = peakRAM
 	}
 
-	state.peakRAM = peakRAM
-	state.peakDisk = peakDisk
-	state.cpuTime = cpuTime
+	if peakDisk > state.peakDisk {
+		state.peakDisk = peakDisk
+	}
+
+	if cpuTime > state.cpuTime {
+		state.cpuTime = cpuTime
+	}
 }
 
 func (state *executeLiveState) snapshot() *JobEndState {

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -259,13 +259,14 @@ func (state *serverContactState) schedulerMemoryFallbackAllowed() bool {
 
 type executeLiveState struct {
 	sync.Mutex
-	stdout    *liveTailSaver
-	stderr    *liveTailSaver
-	cwd       string
-	pid       int
-	peakRAM   int
-	peakDisk  int64
-	dockerCPU int
+	stdout   *liveTailSaver
+	stderr   *liveTailSaver
+	cwd      string
+	peakRAM  int
+	peakDisk int64
+	cpuTime  time.Duration
+	cwdSent  bool
+	dirty    bool
 }
 
 func newExecuteLiveState(cwd string, stdout, stderr *liveTailSaver) *executeLiveState {
@@ -276,39 +277,63 @@ func newExecuteLiveState(cwd string, stdout, stderr *liveTailSaver) *executeLive
 	}
 }
 
-func (state *executeLiveState) setPid(pid int) {
+func (state *executeLiveState) updateResources(peakRAM int, peakDisk int64, cpuTime time.Duration) {
 	state.Lock()
 	defer state.Unlock()
 
-	state.pid = pid
-}
-
-func (state *executeLiveState) updateResources(peakRAM int, peakDisk int64, dockerCPU int) {
-	state.Lock()
-	defer state.Unlock()
+	if state.peakRAM == peakRAM && state.peakDisk == peakDisk && state.cpuTime == cpuTime {
+		return
+	}
 
 	state.peakRAM = peakRAM
 	state.peakDisk = peakDisk
-	state.dockerCPU = dockerCPU
+	state.cpuTime = cpuTime
+	state.dirty = true
 }
 
 func (state *executeLiveState) snapshot() *JobEndState {
+	stdout := state.stdout.FlushCompressed()
+	stderr := state.stderr.FlushCompressed()
+	hasOutput := liveSnapshotHasOutput(stdout, stderr)
+
 	state.Lock()
-	cwd := state.cwd
-	pid := state.pid
-	peakRAM := state.peakRAM
-	peakDisk := state.peakDisk
-	dockerCPU := state.dockerCPU
-	state.Unlock()
+	defer state.Unlock()
+
+	cwd := state.snapshotCwd(hasOutput)
+	peakRAM, peakDisk, cpuTime := state.snapshotResources(hasOutput)
 
 	return &JobEndState{
 		Cwd:      cwd,
 		PeakRAM:  peakRAM,
 		PeakDisk: peakDisk,
-		CPUtime:  currentProcessTreeCPUtime(pid) + time.Duration(dockerCPU)*time.Second,
-		Stdout:   state.stdout.FlushCompressed(),
-		Stderr:   state.stderr.FlushCompressed(),
+		CPUtime:  cpuTime,
+		Stdout:   stdout,
+		Stderr:   stderr,
 	}
+}
+
+func liveSnapshotHasOutput(stdout, stderr []byte) bool {
+	return len(stdout) != 0 || len(stderr) != 0
+}
+
+func (state *executeLiveState) snapshotCwd(hasOutput bool) string {
+	if state.cwdSent && !hasOutput && !state.dirty {
+		return ""
+	}
+
+	state.cwdSent = true
+
+	return state.cwd
+}
+
+func (state *executeLiveState) snapshotResources(hasOutput bool) (int, int64, time.Duration) {
+	if !state.dirty && !hasOutput {
+		return 0, 0, 0
+	}
+
+	state.dirty = false
+
+	return state.peakRAM, state.peakDisk, state.cpuTime
 }
 
 func currentProcessTreeCPUtime(pid int) time.Duration {
@@ -1201,7 +1226,6 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	}
 
 	clog.Info(ctx, "started executing", "cmd", job.Cmd, "pid", cmd.Process.Pid)
-	liveState.setPid(cmd.Process.Pid)
 
 	var oomMonitor *cgroupOOMMonitor
 
@@ -1465,7 +1489,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 					peakdisk = disk
 				}
 
-				liveState.updateResources(peakmem, peakdisk, dockerCPU)
+				cpuTime := currentProcessTreeCPUtime(cmd.Process.Pid) + time.Duration(dockerCPU)*time.Second
+				liveState.updateResources(peakmem, peakdisk, cpuTime)
 				stateMutex.Unlock()
 			case <-stopChecking:
 				closeReaders()

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -265,8 +265,6 @@ type executeLiveState struct {
 	peakRAM  int
 	peakDisk int64
 	cpuTime  time.Duration
-	cwdSent  bool
-	dirty    bool
 }
 
 func newExecuteLiveState(cwd string, stdout, stderr *liveTailSaver) *executeLiveState {
@@ -288,52 +286,23 @@ func (state *executeLiveState) updateResources(peakRAM int, peakDisk int64, cpuT
 	state.peakRAM = peakRAM
 	state.peakDisk = peakDisk
 	state.cpuTime = cpuTime
-	state.dirty = true
 }
 
 func (state *executeLiveState) snapshot() *JobEndState {
 	stdout := state.stdout.FlushCompressed()
 	stderr := state.stderr.FlushCompressed()
-	hasOutput := liveSnapshotHasOutput(stdout, stderr)
 
 	state.Lock()
 	defer state.Unlock()
 
-	cwd := state.snapshotCwd(hasOutput)
-	peakRAM, peakDisk, cpuTime := state.snapshotResources(hasOutput)
-
 	return &JobEndState{
-		Cwd:      cwd,
-		PeakRAM:  peakRAM,
-		PeakDisk: peakDisk,
-		CPUtime:  cpuTime,
+		Cwd:      state.cwd,
+		PeakRAM:  state.peakRAM,
+		PeakDisk: state.peakDisk,
+		CPUtime:  state.cpuTime,
 		Stdout:   stdout,
 		Stderr:   stderr,
 	}
-}
-
-func liveSnapshotHasOutput(stdout, stderr []byte) bool {
-	return len(stdout) != 0 || len(stderr) != 0
-}
-
-func (state *executeLiveState) snapshotCwd(hasOutput bool) string {
-	if state.cwdSent && !hasOutput && !state.dirty {
-		return ""
-	}
-
-	state.cwdSent = true
-
-	return state.cwd
-}
-
-func (state *executeLiveState) snapshotResources(hasOutput bool) (int, int64, time.Duration) {
-	if !state.dirty && !hasOutput {
-		return 0, 0, 0
-	}
-
-	state.dirty = false
-
-	return state.peakRAM, state.peakDisk, state.cpuTime
 }
 
 func currentProcessTreeCPUtime(pid int) time.Duration {

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -156,6 +156,18 @@ func touchEndState(job *Job) *JobEndState {
 	}
 }
 
+func cloneJobEndState(endState *JobEndState) *JobEndState {
+	if endState == nil {
+		return nil
+	}
+
+	clone := *endState
+	clone.Stdout = slices.Clone(endState.Stdout)
+	clone.Stderr = slices.Clone(endState.Stderr)
+
+	return &clone
+}
+
 // clientRequest is the struct that clients send to the server over the network
 // to request it do something. (The properties are only exported so the
 // encoder doesn't ignore them.)
@@ -244,6 +256,85 @@ func (state *serverContactState) schedulerMemoryFallbackAllowed() bool {
 	return !state.lost.Load()
 }
 
+type executeLiveState struct {
+	sync.Mutex
+	stdout    *liveTailSaver
+	stderr    *liveTailSaver
+	cwd       string
+	pid       int
+	peakRAM   int
+	peakDisk  int64
+	dockerCPU int
+}
+
+func newExecuteLiveState(cwd string, stdout, stderr *liveTailSaver) *executeLiveState {
+	return &executeLiveState{
+		stdout: stdout,
+		stderr: stderr,
+		cwd:    cwd,
+	}
+}
+
+func (state *executeLiveState) setPid(pid int) {
+	state.Lock()
+	defer state.Unlock()
+
+	state.pid = pid
+}
+
+func (state *executeLiveState) updateResources(peakRAM int, peakDisk int64, dockerCPU int) {
+	state.Lock()
+	defer state.Unlock()
+
+	state.peakRAM = peakRAM
+	state.peakDisk = peakDisk
+	state.dockerCPU = dockerCPU
+}
+
+func (state *executeLiveState) snapshot() *JobEndState {
+	state.Lock()
+	cwd := state.cwd
+	pid := state.pid
+	peakRAM := state.peakRAM
+	peakDisk := state.peakDisk
+	dockerCPU := state.dockerCPU
+	state.Unlock()
+
+	return &JobEndState{
+		Cwd:      cwd,
+		PeakRAM:  peakRAM,
+		PeakDisk: peakDisk,
+		CPUtime:  currentProcessTreeCPUtime(pid) + time.Duration(dockerCPU)*time.Second,
+		Stdout:   state.stdout.FlushCompressed(),
+		Stderr:   state.stderr.FlushCompressed(),
+	}
+}
+
+func currentProcessTreeCPUtime(pid int) time.Duration {
+	pid32, ok := processPID(pid)
+	if !ok {
+		return 0
+	}
+
+	root, err := process.NewProcess(pid32)
+	if err != nil {
+		return 0
+	}
+
+	total := currentProcessCPUtime(root)
+
+	children, err := getChildProcesses(pid32)
+	if err != nil {
+		return total
+	}
+
+	for _, child := range children {
+		total += currentProcessCPUtime(child)
+	}
+
+	return total
+}
+
 // Client represents the client side of the socket that the jobqueue server is
 // Serve()ing, specific to a particular queue.
 type Client struct {
@@ -272,6 +363,10 @@ type Client struct {
 	// command may use before we kill it. Defaults to ClientPercentMemoryKill,
 	// but may be overridden locally before Execute() (used by tests).
 	percentMemoryKill int
+
+	// liveTouchHook is used by in-package tests to inspect the live touch state
+	// assembled during Execute().
+	liveTouchHook func(*JobEndState)
 }
 
 // envStr holds the []string from os.Environ(), for codec compatibility.
@@ -746,13 +841,15 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return fmt.Errorf("failed to create a pipe for STDERR from cmd [%s]: %w", jc, err)
 	}
 	stderr := &prefixSuffixSaver{N: 4096}
-	stderrWait := stdFilter(errReader, stderr)
+	liveStderr := &liveTailSaver{}
+	stderrWait := stdFilter(errReader, io.MultiWriter(stderr, liveStderr))
 	outReader, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("failed to create a pipe for STDOUT from cmd [%s]: %w", jc, err)
 	}
 	stdout := &prefixSuffixSaver{N: 4096}
-	stdoutWait := stdFilter(outReader, stdout)
+	liveStdout := &liveTailSaver{}
+	stdoutWait := stdFilter(outReader, io.MultiWriter(stdout, liveStdout))
 
 	// we'll run the command from the desired directory, which must exist or
 	// it will fail
@@ -792,6 +889,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	// before doing any other pre-start tasks, which might take time, start
 	// touching the job, and keep doing so until after we've run the job and
 	// carried out post-exit tasks
+	liveState := newExecuteLiveState(cmd.Dir, liveStdout, liveStderr)
 	touchTicker := time.NewTicker(c.touchInterval) // server-provided default (< its ItemTTR), overridable per client
 
 	var wkbsMutex sync.RWMutex
@@ -807,7 +905,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		for {
 			select {
 			case <-touchTicker.C:
-				kc, errf := c.Touch(job)
+				kc, errf := c.touch(job, liveState.snapshot())
 				if kc {
 					wkbsMutex.RLock()
 					defer wkbsMutex.RUnlock()
@@ -1102,6 +1200,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	}
 
 	clog.Info(ctx, "started executing", "cmd", job.Cmd, "pid", cmd.Process.Pid)
+	liveState.setPid(cmd.Process.Pid)
 
 	var oomMonitor *cgroupOOMMonitor
 
@@ -1364,6 +1463,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				if errd == nil && disk > peakdisk {
 					peakdisk = disk
 				}
+
+				liveState.updateResources(peakmem, peakdisk, dockerCPU)
 				stateMutex.Unlock()
 			case <-stopChecking:
 				closeReaders()
@@ -1868,23 +1969,11 @@ func keyOnlyJob(job *Job) *Job {
 // is true, you stop doing what you're doing and bury the job, since this means
 // that Kill() has been called for this job.
 func (c *Client) Touch(job *Job) (bool, error) {
-	c.teMutex.Lock()
-	defer c.teMutex.Unlock()
-
 	job.Lock()
-	key := job.Key()
 	endState := touchEndState(job)
 	job.Unlock()
 
-	resp, err := c.request(&clientRequest{
-		Method:      "jtouch",
-		Keys:        []string{key},
-		JobEndState: endState,
-	})
-	if err != nil {
-		return false, err
-	}
-	return resp.KillCalled, err
+	return c.touch(job, endState)
 }
 
 // JobEndState is used to describe the state of a job after it has (tried to)
@@ -1904,6 +1993,36 @@ type JobEndState struct {
 	Stdout   []byte
 	Stderr   []byte
 	Exited   bool
+}
+
+func (c *Client) touch(job *Job, endState *JobEndState) (bool, error) {
+	c.teMutex.Lock()
+	defer c.teMutex.Unlock()
+
+	job.Lock()
+	key := job.Key()
+	job.Unlock()
+
+	c.inspectLiveTouch(endState)
+
+	resp, err := c.request(&clientRequest{
+		Method:      "jtouch",
+		Keys:        []string{key},
+		JobEndState: endState,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return resp.KillCalled, err
+}
+
+func (c *Client) inspectLiveTouch(endState *JobEndState) {
+	if c.liveTouchHook == nil {
+		return
+	}
+
+	c.liveTouchHook(cloneJobEndState(endState))
 }
 
 // ended updates a Job for the benefit of the client only: this has no effect on
@@ -2383,6 +2502,25 @@ func (c *Client) CompressEnv(envars []string) ([]byte, error) {
 		return nil, err
 	}
 	return compress(encoded)
+}
+
+func processPID(pid int) (int32, bool) {
+	const maxProcessPID = int(^uint32(0) >> 1)
+
+	if pid <= 0 || pid > maxProcessPID {
+		return 0, false
+	}
+
+	return int32(pid), true
+}
+
+func currentProcessCPUtime(proc *process.Process) time.Duration {
+	times, err := proc.Times()
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration((times.User + times.System) * float64(time.Second))
 }
 
 func cloneMountConfigs(mountConfigs MountConfigs) MountConfigs {

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -29,18 +29,34 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/gofrs/uuid/v5"
+	"github.com/kballard/go-shellquote"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/ugorji/go/codec"
 	"go.nanomsg.org/mangos/v3"
 )
 
 var errCaptureSocketUnsupported = errors.New("unsupported capture socket operation")
+
+const (
+	liveExecuteTouchInterval = 100 * time.Millisecond
+	liveExecuteRetryWait     = 10 * time.Millisecond
+	liveExecuteRetryTime     = time.Second
+	liveExecuteTimeLimit     = 10 * time.Second
+	liveExecuteOutputSize    = 128 * 1024
+	liveExecuteFileMode      = 0o600
+	liveExecuteDirMode       = 0o755
+)
 
 type captureSocket struct {
 	ch      codec.Handle
@@ -187,6 +203,41 @@ func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
 	})
 }
 
+func TestClientTouchSendsLiveEndState(t *testing.T) {
+	Convey("Touch sends a key-only jtouch request with current live end state fields", t, func() {
+		client, sock := newCaptureClient()
+		stdout := compressStd([]byte("out\n"))
+		stderr := compressStd([]byte("err\n"))
+		job := &Job{
+			Cmd:        "echo live",
+			PeakRAM:    123,
+			PeakDisk:   456,
+			CPUtime:    7 * time.Second,
+			StdOutC:    stdout,
+			StdErrC:    stderr,
+			ReservedBy: client.clientid,
+		}
+		key := job.Key()
+
+		killCalled, err := client.Touch(job)
+		So(err, ShouldBeNil)
+		So(killCalled, ShouldBeFalse)
+
+		req := sock.request()
+		So(req.Method, ShouldEqual, "jtouch")
+		So(req.Keys, ShouldResemble, []string{key})
+		So(req.Job, ShouldBeNil)
+		So(req.JobEndState, ShouldNotBeNil)
+		So(req.JobEndState.PeakRAM, ShouldEqual, 123)
+		So(req.JobEndState.PeakDisk, ShouldEqual, int64(456))
+		So(req.JobEndState.CPUtime, ShouldEqual, 7*time.Second)
+		So(req.JobEndState.Stdout, ShouldResemble, stdout)
+		So(req.JobEndState.Stderr, ShouldResemble, stderr)
+		So(req.JobEndState.Cwd, ShouldEqual, "")
+		So(req.JobEndState.Exited, ShouldBeFalse)
+	})
+}
+
 func TestServerRejectsKeyOnlyStartedRequest(t *testing.T) {
 	Convey("A malformed key-only jstart request is rejected instead of panicking", t, func() {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -263,4 +314,230 @@ func assertTrimmedLifecycleRequest(req *clientRequest, method, key, failReason s
 	So(req.JobEndState.CPUtime, ShouldEqual, endState.CPUtime)
 	So(req.JobEndState.Stdout, ShouldResemble, endState.Stdout)
 	So(req.JobEndState.Stderr, ShouldResemble, endState.Stderr)
+}
+
+func newLiveExecuteCaptureClient(capture *liveTouchCapture) *Client {
+	client, _ := newCaptureClient()
+	client.touchInterval = liveExecuteTouchInterval
+	client.retryWait = liveExecuteRetryWait
+	client.retryTime = liveExecuteRetryTime
+	client.percentMemoryKill = ClientPercentMemoryKill
+	client.liveTouchHook = capture.record
+
+	return client
+}
+
+type liveTouchCapture struct {
+	sync.Mutex
+	states []*JobEndState
+}
+
+func (c *liveTouchCapture) record(state *JobEndState) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.states = append(c.states, cloneTestJobEndState(state))
+}
+
+func (c *liveTouchCapture) matching(match func(*JobEndState) bool) []*JobEndState {
+	c.Lock()
+	defer c.Unlock()
+
+	var states []*JobEndState
+	for _, state := range c.states {
+		if match(state) {
+			states = append(states, cloneTestJobEndState(state))
+		}
+	}
+
+	return states
+}
+
+func (c *liveTouchCapture) firstWithMarkers(stdoutMarker, stderrMarker string) (*JobEndState, string, string) {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, state := range c.states {
+		stdout := decompressLiveTouch(state.Stdout)
+
+		stderr := decompressLiveTouch(state.Stderr)
+		if strings.Contains(stdout, stdoutMarker) && strings.Contains(stderr, stderrMarker) {
+			return cloneTestJobEndState(state), stdout, stderr
+		}
+	}
+
+	return nil, "", ""
+}
+
+func decompressLiveTouch(compressed []byte) string {
+	if len(compressed) == 0 {
+		return ""
+	}
+
+	decompressed, err := decompress(compressed)
+	if err != nil {
+		return ""
+	}
+
+	return string(decompressed)
+}
+
+func cloneTestJobEndState(state *JobEndState) *JobEndState {
+	if state == nil {
+		return nil
+	}
+
+	clone := *state
+	clone.Stdout = append([]byte(nil), state.Stdout...)
+	clone.Stderr = append([]byte(nil), state.Stderr...)
+
+	return &clone
+}
+
+func TestClientExecuteLiveTouchPayloads(t *testing.T) {
+	Convey("Execute sends stdout tails once per touch from the actual cwd", t, func() {
+		capture := &liveTouchCapture{}
+		client := newLiveExecuteCaptureClient(capture)
+		cwd := liveExecuteCwd(t)
+		job := liveExecuteJob(client, cwd, "printf 'alpha\\n'; sleep 0.6; printf 'beta\\n'; sleep 0.6")
+
+		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
+
+		states := capture.matching(func(state *JobEndState) bool {
+			return len(state.Stdout) != 0
+		})
+		So(len(states), ShouldBeGreaterThanOrEqualTo, 2)
+		So(decompressLiveTouch(states[0].Stdout), ShouldEqual, "alpha\n")
+		So(states[0].Cwd, ShouldEqual, cwd)
+		So(decompressLiveTouch(states[1].Stdout), ShouldEqual, "beta\n")
+		So(states[1].Cwd, ShouldEqual, cwd)
+	})
+
+	Convey("Execute sends stderr tails once per touch", t, func() {
+		capture := &liveTouchCapture{}
+		client := newLiveExecuteCaptureClient(capture)
+		cwd := liveExecuteCwd(t)
+		job := liveExecuteJob(client, cwd, "printf 'err-alpha\\n' >&2; sleep 0.6; printf 'err-beta\\n' >&2; sleep 0.6")
+
+		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
+
+		states := capture.matching(func(state *JobEndState) bool {
+			return len(state.Stderr) != 0
+		})
+		So(len(states), ShouldBeGreaterThanOrEqualTo, 2)
+		So(decompressLiveTouch(states[0].Stderr), ShouldEqual, "err-alpha\n")
+		So(decompressLiveTouch(states[1].Stderr), ShouldEqual, "err-beta\n")
+	})
+
+	Convey("Execute sends cumulative CPU time and observed peak RAM", t, func() {
+		capture := &liveTouchCapture{}
+		client := newLiveExecuteCaptureClient(capture)
+		cwd := liveExecuteCwd(t)
+		job := liveExecuteJob(client, cwd, strings.Join([]string{
+			"python3 - <<'PY'",
+			"import time",
+			"x = bytearray(2 * 1024 * 1024)",
+			"end = time.time() + 1.5",
+			"while time.time() < end:",
+			"    x[0] = (x[0] + 1) % 256",
+			"PY",
+		}, "\n"))
+
+		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
+
+		states := capture.matching(func(state *JobEndState) bool {
+			return state.CPUtime >= time.Millisecond && state.PeakRAM >= 1
+		})
+		So(len(states), ShouldBeGreaterThanOrEqualTo, 1)
+	})
+
+	Convey("Execute bounds live output tails without truncating final archives", t, func() {
+		capture := &liveTouchCapture{}
+		client := newLiveExecuteCaptureClient(capture)
+		cwd := liveExecuteCwd(t)
+		stdoutStream := liveMarkedStream("OUT-OLD\n", "OUT-NEW\n")
+		stderrStream := liveMarkedStream("ERR-OLD\n", "ERR-NEW\n")
+		stdoutFile := filepath.Join(cwd, "stdout.bin")
+		stderrFile := filepath.Join(cwd, "stderr.bin")
+
+		So(os.WriteFile(stdoutFile, stdoutStream, liveExecuteFileMode), ShouldBeNil)
+		So(os.WriteFile(stderrFile, stderrStream, liveExecuteFileMode), ShouldBeNil)
+
+		cmd := fmt.Sprintf(
+			"cat %s; cat %s >&2; sleep 0.6",
+			shellquote.Join(stdoutFile),
+			shellquote.Join(stderrFile),
+		)
+		job := liveExecuteJob(client, cwd, cmd)
+
+		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
+
+		state, liveStdout, liveStderr := capture.firstWithMarkers("OUT-NEW\n", "ERR-NEW\n")
+		So(state, ShouldNotBeNil)
+		So(state.Stdout, ShouldNotBeNil)
+		So(state.Stderr, ShouldNotBeNil)
+		So(len(state.Stdout), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+		So(len(state.Stderr), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+		So(liveStdout, ShouldContainSubstring, "OUT-NEW\n")
+		So(liveStdout, ShouldNotContainSubstring, "OUT-OLD\n")
+		So(liveStderr, ShouldContainSubstring, "ERR-NEW\n")
+		So(liveStderr, ShouldNotContainSubstring, "ERR-OLD\n")
+
+		finalStdout, err := job.StdOut()
+		So(err, ShouldBeNil)
+		So(finalStdout, ShouldEqual, expectedPrefixSuffixOutput(stdoutStream))
+
+		finalStderr, err := job.StdErr()
+		So(err, ShouldBeNil)
+		So(finalStderr, ShouldEqual, expectedPrefixSuffixOutput(stderrStream))
+	})
+}
+
+func liveExecuteCwd(t *testing.T) string {
+	t.Helper()
+
+	cwd := filepath.Join(t.TempDir(), "job1")
+	So(os.MkdirAll(cwd, liveExecuteDirMode), ShouldBeNil)
+
+	return cwd
+}
+
+func liveExecuteJob(client *Client, cwd string, cmd string) *Job {
+	return &Job{
+		Cmd:        cmd,
+		Cwd:        cwd,
+		CwdMatters: true,
+		ReqGroup:   "live-execute",
+		Requirements: &scheduler.Requirements{
+			RAM:  4096,
+			Time: liveExecuteTimeLimit,
+		},
+		ReservedBy: client.clientid,
+	}
+}
+
+func liveMarkedStream(prefix, suffix string) []byte {
+	stream := append([]byte(prefix), deterministicLiveASCII(liveExecuteOutputSize)...)
+	stream = append(stream, suffix...)
+
+	return stream
+}
+
+func deterministicLiveASCII(size int) []byte {
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	data := deterministicLiveBytes(size)
+	for i := range data {
+		data[i] = alphabet[int(data[i])%len(alphabet)]
+	}
+
+	return data
+}
+
+func expectedPrefixSuffixOutput(data []byte) string {
+	saver := &prefixSuffixSaver{N: 4096}
+	_, err := saver.Write(data)
+	So(err, ShouldBeNil)
+
+	return string(bytes.TrimSpace(saver.Bytes()))
 }

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -365,20 +365,18 @@ func (c *liveTouchCapture) matching(match func(*JobEndState) bool) []*JobEndStat
 	return states
 }
 
-func (c *liveTouchCapture) firstWithMarkers(stdoutMarker, stderrMarker string) (*JobEndState, string, string) {
+func (c *liveTouchCapture) firstStdoutWithMarker(marker string) (*JobEndState, string) {
 	c.Lock()
 	defer c.Unlock()
 
 	for _, state := range c.states {
 		stdout := decompressLiveTouch(state.Stdout)
-
-		stderr := decompressLiveTouch(state.Stderr)
-		if strings.Contains(stdout, stdoutMarker) && strings.Contains(stderr, stderrMarker) {
-			return cloneTestJobEndState(state), stdout, stderr
+		if strings.Contains(stdout, marker) {
+			return cloneTestJobEndState(state), stdout
 		}
 	}
 
-	return nil, "", ""
+	return nil, ""
 }
 
 func decompressLiveTouch(compressed []byte) string {
@@ -404,6 +402,20 @@ func cloneTestJobEndState(state *JobEndState) *JobEndState {
 	clone.Stderr = append([]byte(nil), state.Stderr...)
 
 	return &clone
+}
+
+func (c *liveTouchCapture) firstStderrWithMarker(marker string) (*JobEndState, string) {
+	c.Lock()
+	defer c.Unlock()
+
+	for _, state := range c.states {
+		stderr := decompressLiveTouch(state.Stderr)
+		if strings.Contains(stderr, marker) {
+			return cloneTestJobEndState(state), stderr
+		}
+	}
+
+	return nil, ""
 }
 
 func TestClientExecuteLiveTouchPayloads(t *testing.T) {
@@ -453,7 +465,7 @@ func TestClientExecuteLiveTouchPayloads(t *testing.T) {
 			"python3 - <<'PY'",
 			"import time",
 			"x = bytearray(2 * 1024 * 1024)",
-			"end = time.time() + 1.5",
+			"end = time.time() + 3",
 			"while time.time() < end:",
 			"    x[0] = (x[0] + 1) % 256",
 			"PY",
@@ -480,7 +492,7 @@ func TestClientExecuteLiveTouchPayloads(t *testing.T) {
 		So(os.WriteFile(stderrFile, stderrStream, liveExecuteFileMode), ShouldBeNil)
 
 		cmd := fmt.Sprintf(
-			"cat %s; cat %s >&2; sleep 0.6",
+			"cat %s; cat %s >&2; sleep 2",
 			shellquote.Join(stdoutFile),
 			shellquote.Join(stderrFile),
 		)
@@ -488,12 +500,15 @@ func TestClientExecuteLiveTouchPayloads(t *testing.T) {
 
 		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
 
-		state, liveStdout, liveStderr := capture.firstWithMarkers("OUT-NEW\n", "ERR-NEW\n")
-		So(state, ShouldNotBeNil)
-		So(state.Stdout, ShouldNotBeNil)
-		So(state.Stderr, ShouldNotBeNil)
-		So(len(state.Stdout), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
-		So(len(state.Stderr), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+		stdoutState, liveStdout := capture.firstStdoutWithMarker("OUT-NEW\n")
+		stderrState, liveStderr := capture.firstStderrWithMarker("ERR-NEW\n")
+
+		So(stdoutState, ShouldNotBeNil)
+		So(stderrState, ShouldNotBeNil)
+		So(stdoutState.Stdout, ShouldNotBeNil)
+		So(stderrState.Stderr, ShouldNotBeNil)
+		So(len(stdoutState.Stdout), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+		So(len(stderrState.Stderr), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
 		So(liveStdout, ShouldContainSubstring, "OUT-NEW\n")
 		So(liveStdout, ShouldNotContainSubstring, "OUT-OLD\n")
 		So(liveStderr, ShouldContainSubstring, "ERR-NEW\n")

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -457,27 +458,31 @@ func TestClientExecuteLiveTouchPayloads(t *testing.T) {
 		So(decompressLiveTouch(states[1].Stderr), ShouldEqual, "err-beta\n")
 	})
 
-	Convey("Execute sends cumulative CPU time and observed peak RAM", t, func() {
-		capture := &liveTouchCapture{}
-		client := newLiveExecuteCaptureClient(capture)
-		cwd := liveExecuteCwd(t)
-		job := liveExecuteJob(client, cwd, strings.Join([]string{
-			"python3 - <<'PY'",
-			"import time",
-			"x = bytearray(2 * 1024 * 1024)",
-			"end = time.time() + 3",
-			"while time.time() < end:",
-			"    x[0] = (x[0] + 1) % 256",
-			"PY",
-		}, "\n"))
+	if _, err := exec.LookPath("python3"); err != nil {
+		SkipConvey("Execute sends cumulative CPU time and observed peak RAM", t, func() {})
+	} else {
+		Convey("Execute sends cumulative CPU time and observed peak RAM", t, func() {
+			capture := &liveTouchCapture{}
+			client := newLiveExecuteCaptureClient(capture)
+			cwd := liveExecuteCwd(t)
+			job := liveExecuteJob(client, cwd, strings.Join([]string{
+				"python3 - <<'PY'",
+				"import time",
+				"x = bytearray(2 * 1024 * 1024)",
+				"end = time.time() + 3",
+				"while time.time() < end:",
+				"    x[0] = (x[0] + 1) % 256",
+				"PY",
+			}, "\n"))
 
-		So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
+			So(client.Execute(context.Background(), job, "/bin/sh"), ShouldBeNil)
 
-		states := capture.matching(func(state *JobEndState) bool {
-			return state.CPUtime >= time.Millisecond && state.PeakRAM >= 1
+			states := capture.matching(func(state *JobEndState) bool {
+				return state.CPUtime >= time.Millisecond && state.PeakRAM >= 1
+			})
+			So(len(states), ShouldBeGreaterThanOrEqualTo, 1)
 		})
-		So(len(states), ShouldBeGreaterThanOrEqualTo, 1)
-	})
+	}
 
 	Convey("Execute bounds live output tails without truncating final archives", t, func() {
 		capture := &liveTouchCapture{}

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -165,6 +165,10 @@ func (s *captureSocket) response() *serverResponse {
 }
 
 func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("Lifecycle methods send only keys and required state, not whole jobs", t, func() {
 		client, sock := newCaptureClient()
 		job := newLargePayloadJob(client.clientid)
@@ -204,6 +208,10 @@ func TestClientLifecycleRequestsTrimJobPayload(t *testing.T) {
 }
 
 func TestClientTouchSendsLiveEndState(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("Touch sends a key-only jtouch request with current live end state fields", t, func() {
 		client, sock := newCaptureClient()
 		stdout := compressStd([]byte("out\n"))
@@ -239,6 +247,10 @@ func TestClientTouchSendsLiveEndState(t *testing.T) {
 }
 
 func TestServerRejectsKeyOnlyStartedRequest(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("A malformed key-only jstart request is rejected instead of panicking", t, func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -395,6 +407,10 @@ func cloneTestJobEndState(state *JobEndState) *JobEndState {
 }
 
 func TestClientExecuteLiveTouchPayloads(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("Execute sends stdout tails once per touch from the actual cwd", t, func() {
 		capture := &liveTouchCapture{}
 		client := newLiveExecuteCaptureClient(capture)

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -80,6 +80,23 @@ func TestExecuteLiveStateSnapshots(t *testing.T) {
 		So(second.PeakDisk, ShouldEqual, int64(456))
 		So(second.CPUtime, ShouldEqual, 7*time.Second)
 	})
+
+	Convey("Live execute resource snapshots keep maximum observed values", t, func() {
+		state := newExecuteLiveState("/work/actual", &liveTailSaver{}, &liveTailSaver{})
+		state.updateResources(123, 456, 7*time.Second)
+		state.updateResources(111, 400, 6*time.Second)
+
+		snapshot := state.snapshot()
+		So(snapshot.PeakRAM, ShouldEqual, 123)
+		So(snapshot.PeakDisk, ShouldEqual, int64(456))
+		So(snapshot.CPUtime, ShouldEqual, 7*time.Second)
+
+		state.updateResources(124, 457, 8*time.Second)
+		snapshot = state.snapshot()
+		So(snapshot.PeakRAM, ShouldEqual, 124)
+		So(snapshot.PeakDisk, ShouldEqual, int64(457))
+		So(snapshot.CPUtime, ShouldEqual, 8*time.Second)
+	})
 }
 
 type captureSocket struct {

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -59,6 +59,29 @@ const (
 	liveExecuteDirMode       = 0o755
 )
 
+func TestExecuteLiveStateSnapshots(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Live execute snapshots keep cwd and resources on repeated touches", t, func() {
+		state := newExecuteLiveState("/work/actual", &liveTailSaver{}, &liveTailSaver{})
+		state.updateResources(123, 456, 7*time.Second)
+
+		first := state.snapshot()
+		second := state.snapshot()
+
+		So(first.Cwd, ShouldEqual, "/work/actual")
+		So(first.PeakRAM, ShouldEqual, 123)
+		So(first.PeakDisk, ShouldEqual, int64(456))
+		So(first.CPUtime, ShouldEqual, 7*time.Second)
+		So(second.Cwd, ShouldEqual, "/work/actual")
+		So(second.PeakRAM, ShouldEqual, 123)
+		So(second.PeakDisk, ShouldEqual, int64(456))
+		So(second.CPUtime, ShouldEqual, 7*time.Second)
+	})
+}
+
 type captureSocket struct {
 	ch      codec.Handle
 	sent    []byte

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -48,6 +48,7 @@ import (
 	"github.com/VertebrateResequencing/wr/queue"
 	"github.com/gofrs/uuid/v5"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/kballard/go-shellquote"
 	"github.com/ugorji/go/codec"
 )
 
@@ -102,6 +103,33 @@ var itemsStateToJobState = map[queue.ItemState]JobState{
 	queue.ItemStateBury:      JobStateBuried,
 	queue.ItemStateDependent: JobStateDependent,
 	queue.ItemStateRemoved:   JobStateComplete,
+}
+
+func sshCommandForRunningJob(state JobState, reqs *scheduler.Requirements, host, hostIP, actualCwd string) string {
+	if state != JobStateRunning || actualCwd == "" {
+		return ""
+	}
+
+	target := sshTarget(reqs, host, hostIP)
+	if target == "" {
+		return ""
+	}
+
+	remote := "cd " + shellquote.Join(actualCwd) + " && exec ${SHELL:-/bin/sh} -l"
+
+	return "ssh " + shellquote.Join(target, remote)
+}
+
+func sshTarget(reqs *scheduler.Requirements, host, hostIP string) string {
+	if hostIP == "" {
+		return host
+	}
+
+	if reqs != nil && reqs.Other["cloud_user"] != "" && hostIP != "" {
+		return reqs.Other["cloud_user"] + "@" + hostIP
+	}
+
+	return hostIP
 }
 
 // Job is a struct that represents a command that needs to be run and some

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -115,9 +115,9 @@ func sshCommandForRunningJob(state JobState, reqs *scheduler.Requirements, host,
 		return ""
 	}
 
-	remote := "cd " + shellquote.Join(actualCwd) + " && exec ${SHELL:-/bin/sh} -l"
+	remote := "cd " + quoteRemoteCwd(actualCwd) + " && exec ${SHELL:-/bin/sh} -l"
 
-	return "ssh " + shellquote.Join(target, remote)
+	return "ssh " + shellquote.Join(target) + " " + singleQuoteShellArg(remote)
 }
 
 func sshTarget(reqs *scheduler.Requirements, host, hostIP string) string {
@@ -1056,6 +1056,7 @@ func (j *Job) ToStatus() (JStatus, error) {
 		Host:                j.Host,
 		HostID:              j.HostID,
 		HostIP:              j.HostIP,
+		SSHCommand:          sshCommandForRunningJob(state, j.Requirements, j.Host, j.HostIP, j.ActualCwd),
 		Walltime:            j.WallTime().Seconds(),
 		CPUtime:             j.CPUtime.Seconds(),
 		Attempts:            j.Attempts,
@@ -1535,4 +1536,31 @@ func (j *JobModifier) Modify(jobs []*Job, server *Server) (map[string]string, er
 		job.Unlock()
 	}
 	return keys, nil
+}
+
+func quoteRemoteCwd(cwd string) string {
+	if isShellSafeUnquoted(cwd) {
+		return cwd
+	}
+
+	return singleQuoteShellArg(cwd)
+}
+
+func isShellSafeUnquoted(arg string) bool {
+	if arg == "" {
+		return false
+	}
+
+	const safe = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_+-./:=@%"
+	for _, char := range arg {
+		if !strings.ContainsRune(safe, char) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func singleQuoteShellArg(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
 }

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -117,7 +117,7 @@ func sshCommandForRunningJob(state JobState, reqs *scheduler.Requirements, host,
 
 	remote := "cd " + quoteRemoteCwd(actualCwd) + " && exec ${SHELL:-/bin/sh} -l"
 
-	return "ssh " + shellquote.Join(target) + " " + singleQuoteShellArg(remote)
+	return "ssh -- " + shellquote.Join(target) + " " + singleQuoteShellArg(remote)
 }
 
 func sshTarget(reqs *scheduler.Requirements, host, hostIP string) string {

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -329,4 +329,91 @@ func TestJob(t *testing.T) {
 		wg.Wait()
 		So(readErrors, ShouldEqual, 0)
 	})
+
+	Convey("ToStatus() includes live fields and an SSH command for running jobs", t, func() {
+		job := liveStatusJob(JobStateRunning)
+		job.Requirements.Other["cloud_user"] = "ubuntu"
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.CwdBase, ShouldEqual, "/tmp/wr")
+		So(status.Cwd, ShouldEqual, "/job1")
+		So(status.PeakRAM, ShouldEqual, 321)
+		So(status.CPUtime, ShouldEqual, 4)
+		So(status.StdOut, ShouldEqual, "out\n")
+		So(status.StdErr, ShouldEqual, "err\n")
+		So(status.SSHCommand, ShouldEqual,
+			"ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+	})
+
+	Convey("ToStatus() uses Host when a running job has no HostIP", t, func() {
+		job := liveStatusJob(JobStateRunning)
+		job.HostIP = ""
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.SSHCommand, ShouldEqual,
+			"ssh worker1 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+	})
+
+	Convey("ToStatus() leaves SSHCommand empty without a running host or cwd", t, func() {
+		job := liveStatusJob(JobStateRunning)
+		job.Host = ""
+		job.HostIP = ""
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.SSHCommand, ShouldEqual, "")
+
+		job = liveStatusJob(JobStateRunning)
+		job.ActualCwd = ""
+
+		status, err = job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.SSHCommand, ShouldEqual, "")
+	})
+
+	Convey("ToStatus() shell-quotes a running job's actual cwd in SSHCommand", t, func() {
+		job := liveStatusJob(JobStateRunning)
+		job.HostIP = ""
+		job.ActualCwd = "/tmp/wr/live jobs/it's-ok"
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.SSHCommand, ShouldEqual,
+			`ssh worker1 'cd '"'"'/tmp/wr/live jobs/it'"'"'"'"'"'"'"'"'s-ok'"'"' `+
+				`&& exec ${SHELL:-/bin/sh} -l'`)
+	})
+
+	Convey("ToStatus() hides SSHCommand for non-running status details", t, func() {
+		for _, state := range []JobState{JobStateComplete, JobStateBuried, JobStateLost} {
+			job := liveStatusJob(state)
+
+			status, err := job.ToStatus()
+			So(err, ShouldBeNil)
+			So(status.SSHCommand, ShouldEqual, "")
+		}
+	})
+}
+
+func liveStatusJob(state JobState) *Job {
+	return &Job{
+		Cmd:       "echo live status",
+		Cwd:       "/tmp/wr",
+		ActualCwd: "/tmp/wr/job1",
+		Requirements: &scheduler.Requirements{
+			RAM:   1,
+			Time:  time.Minute,
+			Cores: 1,
+			Other: map[string]string{},
+		},
+		State:   state,
+		Host:    liveStatusHost,
+		HostIP:  liveStatusHostIP,
+		Pid:     44,
+		PeakRAM: 321,
+		CPUtime: 4 * time.Second,
+		StdOutC: compressStd([]byte("out\n")),
+		StdErrC: compressStd([]byte("err\n")),
+	}
 }

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -343,7 +343,7 @@ func TestJob(t *testing.T) {
 		So(status.StdOut, ShouldEqual, "out\n")
 		So(status.StdErr, ShouldEqual, "err\n")
 		So(status.SSHCommand, ShouldEqual,
-			"ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+			"ssh -- ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
 	})
 
 	Convey("ToStatus() uses Host when a running job has no HostIP", t, func() {
@@ -353,7 +353,18 @@ func TestJob(t *testing.T) {
 		status, err := job.ToStatus()
 		So(err, ShouldBeNil)
 		So(status.SSHCommand, ShouldEqual,
-			"ssh worker1 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+			"ssh -- worker1 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+	})
+
+	Convey("ToStatus() separates ssh options from a target that starts with a hyphen", t, func() {
+		job := liveStatusJob(JobStateRunning)
+		job.Host = "-worker1"
+		job.HostIP = ""
+
+		status, err := job.ToStatus()
+		So(err, ShouldBeNil)
+		So(status.SSHCommand, ShouldEqual,
+			"ssh -- -worker1 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
 	})
 
 	Convey("ToStatus() leaves SSHCommand empty without a running host or cwd", t, func() {
@@ -381,7 +392,7 @@ func TestJob(t *testing.T) {
 		status, err := job.ToStatus()
 		So(err, ShouldBeNil)
 		So(status.SSHCommand, ShouldEqual,
-			`ssh worker1 'cd '"'"'/tmp/wr/live jobs/it'"'"'"'"'"'"'"'"'s-ok'"'"' `+
+			`ssh -- worker1 'cd '"'"'/tmp/wr/live jobs/it'"'"'"'"'"'"'"'"'s-ok'"'"' `+
 				`&& exec ${SHELL:-/bin/sh} -l'`)
 	})
 

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -477,6 +477,32 @@ func TestManagerLiveJTouch(t *testing.T) {
 		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 321, 9, 4*time.Second, "out\n", "err\n")
 	})
 
+	Convey("An authenticated resource-only live jtouch preserves existing output tails", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte("out\n")),
+			Stderr:   compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+
+		resp, err = fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  654,
+			PeakDisk: 12,
+			CPUtime:  7 * time.Second,
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 654, 12, 7*time.Second, "out\n", "err\n")
+	})
+
 	Convey("An older runner jtouch with no live fields only extends TTR", t, func() {
 		ctx := context.Background()
 		fixture := newLiveJTouchFixture(ctx, "1234")

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -453,6 +453,10 @@ func assertLiveJTouchFields(
 }
 
 func TestManagerLiveJTouch(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("An authenticated live jtouch stores a live snapshot behind the secure gate", t, func() {
 		ctx := context.Background()
 		fixture := newLiveJTouchFixture(ctx, "1234")

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -59,13 +59,10 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
-	"github.com/gofrs/uuid/v5"
 	"github.com/phayes/freeport"
 	"github.com/shirou/gopsutil/v4/process"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/ugorji/go/codec"
 	bolt "go.etcd.io/bbolt"
-	"go.nanomsg.org/mangos/v3"
 )
 
 const (
@@ -330,341 +327,6 @@ func waitForFileToDisappear(path string, maxWait time.Duration) error {
 	}
 
 	return fmt.Errorf("%w: expected %s to disappear", errFileStillExists, path)
-}
-
-const (
-	liveJTouchActualCwd = "/tmp/wr/job1"
-	liveJTouchTTR       = time.Second
-	liveStatusCloudUser = "cloud_user"
-	liveStatusHost      = "worker1"
-	liveStatusHostIP    = "10.0.0.8"
-)
-
-type liveJTouchFixture struct {
-	server *Server
-	sock   *captureSocket
-	job    *Job
-	item   *queue.Item
-	token  []byte
-	key    string
-	client uuid.UUID
-}
-
-func newLiveJTouchFixture(ctx context.Context, webPort string) *liveJTouchFixture {
-	ch := new(codec.BincHandle)
-	sock := &captureSocket{ch: ch}
-	clientID, err := uuid.NewV4()
-	So(err, ShouldBeNil)
-
-	token := []byte(strings.Repeat("x", tokenLength))
-	job := &Job{
-		Cmd:          "echo live jtouch",
-		Cwd:          testCwd,
-		RepGroup:     "live-jtouch",
-		Requirements: &jqs.Requirements{RAM: 1, Time: time.Minute, Cores: 1},
-		ReservedBy:   clientID,
-		State:        JobStateRunning,
-		StartTime:    time.Now(),
-	}
-	key := job.Key()
-	q := queue.New(ctx, "live-jtouch")
-	item, err := q.Add(ctx, key, "", job, 0, 0, liveJTouchTTR, queue.SubQueueRun)
-	So(err, ShouldBeNil)
-
-	return &liveJTouchFixture{
-		server: &Server{
-			ch:         ch,
-			sock:       sock,
-			token:      token,
-			q:          q,
-			up:         true,
-			ServerInfo: &ServerInfo{WebPort: webPort},
-		},
-		sock:   sock,
-		job:    job,
-		item:   item,
-		token:  token,
-		key:    key,
-		client: clientID,
-	}
-}
-
-func (fixture *liveJTouchFixture) touch(
-	ctx context.Context,
-	token []byte,
-	endState *JobEndState,
-) (*serverResponse, error) {
-	var encoded []byte
-
-	enc := codec.NewEncoderBytes(&encoded, fixture.server.ch)
-	err := enc.Encode(&clientRequest{
-		Method:      requestMethodTouch,
-		Token:       token,
-		Keys:        []string{fixture.key},
-		ClientID:    fixture.client,
-		JobEndState: endState,
-	})
-	So(err, ShouldBeNil)
-
-	err = fixture.server.handleRequest(ctx, &mangos.Message{Body: encoded})
-
-	return fixture.sock.response(), err
-}
-
-func (fixture *liveJTouchFixture) remainingTTRAfterDelay() time.Duration {
-	time.Sleep(20 * time.Millisecond)
-
-	return fixture.item.Stats().Remaining
-}
-
-func assertLiveJTouchExtendedTTR(before, after time.Duration) {
-	So(after.Nanoseconds(), ShouldBeGreaterThan, before.Nanoseconds())
-}
-
-func assertLiveJTouchDidNotExtendTTR(before, after time.Duration) {
-	So(after.Nanoseconds(), ShouldBeLessThanOrEqualTo, before.Nanoseconds())
-}
-
-func assertLiveJTouchFields(
-	job *Job,
-	actualCwd string,
-	peakRAM int,
-	peakDisk int64,
-	cpuTime time.Duration,
-	stdout string,
-	stderr string,
-) {
-	job.RLock()
-	So(job.State, ShouldEqual, JobStateRunning)
-	So(job.Exited, ShouldBeFalse)
-	So(job.ActualCwd, ShouldEqual, actualCwd)
-	So(job.PeakRAM, ShouldEqual, peakRAM)
-	So(job.PeakDisk, ShouldEqual, peakDisk)
-	So(job.CPUtime, ShouldEqual, cpuTime)
-	job.RUnlock()
-
-	out, err := job.StdOut()
-	So(err, ShouldBeNil)
-	So(out, ShouldEqual, stdout)
-
-	errOut, err := job.StdErr()
-	So(err, ShouldBeNil)
-	So(errOut, ShouldEqual, stderr)
-}
-
-func TestManagerLiveJTouch(t *testing.T) {
-	if runnermode || servermode {
-		return
-	}
-
-	Convey("An authenticated live jtouch stores a live snapshot behind the secure gate", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-		before := fixture.remainingTTRAfterDelay()
-		endState := &JobEndState{
-			Cwd:      liveJTouchActualCwd,
-			PeakRAM:  321,
-			PeakDisk: 9,
-			CPUtime:  4 * time.Second,
-			Stdout:   compressStd([]byte("out\n")),
-			Stderr:   compressStd([]byte("err\n")),
-		}
-
-		resp, err := fixture.touch(ctx, fixture.token, endState)
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 321, 9, 4*time.Second, "out\n", "err\n")
-	})
-
-	Convey("An authenticated resource-only live jtouch preserves existing output tails", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
-			Cwd:      liveJTouchActualCwd,
-			PeakRAM:  321,
-			PeakDisk: 9,
-			CPUtime:  4 * time.Second,
-			Stdout:   compressStd([]byte("out\n")),
-			Stderr:   compressStd([]byte("err\n")),
-		})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-
-		resp, err = fixture.touch(ctx, fixture.token, &JobEndState{
-			Cwd:      liveJTouchActualCwd,
-			PeakRAM:  654,
-			PeakDisk: 12,
-			CPUtime:  7 * time.Second,
-		})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 654, 12, 7*time.Second, "out\n", "err\n")
-	})
-
-	Convey("An authenticated reserved live jtouch is visible through itemToJob", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-		fixture.job.Lock()
-		fixture.job.State = JobStateReserved
-		fixture.job.StartTime = time.Time{}
-		fixture.job.Unlock()
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
-			Cwd:     liveJTouchActualCwd,
-			PeakRAM: 321,
-			CPUtime: 4 * time.Second,
-			Stdout:  compressStd([]byte("out\n")),
-			Stderr:  compressStd([]byte("err\n")),
-		})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-
-		job := fixture.server.itemToJob(ctx, fixture.item, true, false)
-		So(job.State, ShouldEqual, JobStateReserved)
-
-		stdout, err := job.StdOut()
-		So(err, ShouldBeNil)
-		So(stdout, ShouldEqual, "out\n")
-
-		stderr, err := job.StdErr()
-		So(err, ShouldBeNil)
-		So(stderr, ShouldEqual, "err\n")
-	})
-
-	Convey("An older runner jtouch with no live fields only extends TTR", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-		setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-	})
-
-	Convey("An authenticated live jtouch with no HTTPS web port only extends TTR", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "")
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
-			Cwd:     liveJTouchActualCwd,
-			PeakRAM: 321,
-			CPUtime: 4 * time.Second,
-			Stdout:  compressStd([]byte("out\n")),
-			Stderr:  compressStd([]byte("err\n")),
-		})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
-	})
-
-	Convey("A live jtouch with an invalid token is denied without touching TTR or live fields", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, []byte(strings.Repeat("y", tokenLength)), &JobEndState{
-			Cwd:     liveJTouchActualCwd,
-			PeakRAM: 321,
-			CPUtime: 4 * time.Second,
-			Stdout:  compressStd([]byte("out\n")),
-			Stderr:  compressStd([]byte("err\n")),
-		})
-		So(err, ShouldNotBeNil)
-		So(resp.Err, ShouldEqual, ErrPermissionDenied)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
-	})
-
-	Convey("A live jtouch with no token is denied before a KillCalled response", t, func() {
-		ctx := context.Background()
-		fixture := newLiveJTouchFixture(ctx, "1234")
-		setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-		fixture.job.Lock()
-		fixture.job.killCalled = true
-		fixture.job.Unlock()
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, nil, &JobEndState{
-			Cwd:     liveJTouchActualCwd,
-			PeakRAM: 321,
-			CPUtime: 4 * time.Second,
-			Stdout:  compressStd([]byte("out\n")),
-			Stderr:  compressStd([]byte("err\n")),
-		})
-		So(err, ShouldNotBeNil)
-		So(resp.Err, ShouldEqual, ErrPermissionDenied)
-		So(resp.KillCalled, ShouldBeFalse)
-		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-	})
-
-	Convey("An authenticated live jtouch preserves KillCalled jobs and existing live fields", t, func() {
-		ctx := context.Background()
-		fixture := newKillCalledLiveJTouchFixture(ctx)
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
-			Cwd:      liveJTouchActualCwd,
-			PeakRAM:  321,
-			PeakDisk: 9,
-			CPUtime:  4 * time.Second,
-			Stdout:   compressStd([]byte("out\n")),
-			Stderr:   compressStd([]byte("err\n")),
-		})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeTrue)
-		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-	})
-
-	Convey("An authenticated older-runner jtouch preserves KillCalled jobs and existing live fields", t, func() {
-		ctx := context.Background()
-		fixture := newKillCalledLiveJTouchFixture(ctx)
-		before := fixture.remainingTTRAfterDelay()
-
-		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
-		So(err, ShouldBeNil)
-		So(resp.KillCalled, ShouldBeTrue)
-		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
-		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-	})
-}
-
-func newKillCalledLiveJTouchFixture(ctx context.Context) *liveJTouchFixture {
-	fixture := newLiveJTouchFixture(ctx, "1234")
-	setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
-	fixture.job.Lock()
-	fixture.job.killCalled = true
-	fixture.job.Unlock()
-
-	return fixture
-}
-
-func setLiveJTouchFields(
-	job *Job,
-	actualCwd string,
-	peakRAM int,
-	peakDisk int64,
-	cpuTime time.Duration,
-	stdout string,
-	stderr string,
-) {
-	job.Lock()
-	job.ActualCwd = actualCwd
-	job.PeakRAM = peakRAM
-	job.PeakDisk = peakDisk
-	job.CPUtime = cpuTime
-	job.StdOutC = compressStd([]byte(stdout))
-	job.StdErrC = compressStd([]byte(stderr))
-	job.Unlock()
 }
 
 func configureFastTestBackups(db *db) {
@@ -1597,32 +1259,27 @@ func TestJobqueueSignal(t *testing.T) {
 		if alreadyKilled[serverPid] {
 			return
 		}
-
 		errd := jq.Disconnect()
 		if errd != nil && !isClosedSocketError(errd) {
-			t.Logf("failed to disconnect: %s", errd)
+			fmt.Printf("failed to disconnect: %s\n", errd)
 		}
 
 		waited := make(chan bool)
-
 		go func() {
 			errw := serverCmd.Wait()
 			if errw != nil {
-				t.Logf("failed to reap server pid: %s", errw)
+				fmt.Printf("failed to reap server pid: %s\n", errw)
 			}
-
 			waited <- true
 		}()
 
 		<-time.After(500 * time.Millisecond)
-
 		errk := syscall.Kill(serverPid, syscall.SIGTERM)
 		if errk != nil {
-			t.Logf("failed to send SIGTERM to server: %s", errk)
+			fmt.Printf("failed to send SIGTERM to server: %s\n", errk)
 		}
 
 		<-waited
-
 		alreadyKilled[serverPid] = true
 	}
 
@@ -1633,7 +1290,6 @@ func TestJobqueueSignal(t *testing.T) {
 
 		jq, token, serverCmd, errf := startServer(serverExe, false, false, config, addr)
 		serverPid := serverCmd.Process.Pid
-
 		So(errf, ShouldBeNil)
 
 		defer killServer(jq, serverPid, serverCmd)
@@ -1643,25 +1299,9 @@ func TestJobqueueSignal(t *testing.T) {
 		Convey("You can set up a long-running job for execution", func() {
 			cmd := "perl -e 'for (1..3) { sleep(1) }'"
 			cmd2 := "perl -e 'for (2..4) { sleep(1) }'"
-
-			jobs := []*Job{
-				{
-					Cmd:          cmd,
-					Cwd:          testCwd,
-					ReqGroup:     reqGroupFake,
-					Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1},
-					Retries:      uint8(0),
-					RepGroup:     "3secs_pass",
-				},
-				{
-					Cmd:          cmd2,
-					Cwd:          testCwd,
-					ReqGroup:     reqGroupFake,
-					Requirements: &jqs.Requirements{RAM: 10, Time: time.Second, Cores: 1},
-					Retries:      uint8(0),
-					RepGroup:     "3secs_fail",
-				},
-			}
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}, Retries: uint8(0), RepGroup: "3secs_pass"})
+			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 10, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), RepGroup: "3secs_fail"})
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 2)
@@ -1707,7 +1347,6 @@ func TestJobqueueSignal(t *testing.T) {
 				defer cancelSig()
 
 				j1worked := make(chan bool, 1)
-
 				go func() {
 					err := jq.Execute(ctx, job, config.RunnerExecShell)
 					if err != nil {
@@ -1722,12 +1361,10 @@ func TestJobqueueSignal(t *testing.T) {
 							return
 						}
 					}
-
 					j1worked <- false
 				}()
 
 				j2worked := make(chan bool, 1)
-
 				go func() {
 					err := jq.Execute(ctx, job2, config.RunnerExecShell)
 					if err != nil {
@@ -1742,7 +1379,6 @@ func TestJobqueueSignal(t *testing.T) {
 							return
 						}
 					}
-
 					j2worked <- false
 				}()
 
@@ -1755,9 +1391,7 @@ func TestJobqueueSignal(t *testing.T) {
 
 				jq2, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldBeNil)
-
 				defer disconnect(jq2)
-
 				job, err = jq2.GetByEssence(&JobEssence{Cmd: cmd}, false, false)
 				So(err, ShouldBeNil)
 				So(job, ShouldNotBeNil)
@@ -1777,7 +1411,6 @@ func TestJobqueueSignal(t *testing.T) {
 				kicked, err := jq.Kick([]*JobEssence{job2.ToEssense()})
 				So(err, ShouldBeNil)
 				So(kicked, ShouldEqual, 1)
-
 				job2, err = jq.Reserve(50 * time.Millisecond)
 				So(err, ShouldBeNil)
 				So(job2, ShouldNotBeNil)
@@ -1793,28 +1426,10 @@ func TestJobqueueSignal(t *testing.T) {
 
 		Convey("Running jobs are recovered after a hard server crash", func() {
 			cmd := "sleep 10"
-			// We want to kill this part way, but sleep processes do not seem to
-			// die straight away when killed.
-			cmd2 := "perl -e 'for (1..10) { sleep(1) }'"
-
-			jobs := []*Job{
-				{
-					Cmd:          cmd,
-					Cwd:          testCwd,
-					ReqGroup:     reqGroupFake,
-					Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0},
-					Retries:      uint8(0),
-					RepGroup:     "recover",
-				},
-				{
-					Cmd:          cmd2,
-					Cwd:          testCwd,
-					ReqGroup:     reqGroupFake,
-					Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0},
-					Retries:      uint8(0),
-					RepGroup:     "buried",
-				},
-			}
+			cmd2 := "perl -e 'for (1..10) { sleep(1) }'" // we want to kill this part way, but `sleep` processes don't seem to die straight away when killed
+			var jobs []*Job
+			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "recover"})
+			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "buried"})
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 2)
@@ -1831,25 +1446,18 @@ func TestJobqueueSignal(t *testing.T) {
 			So(job2.State, ShouldEqual, JobStateReserved)
 
 			serverCmdCh := make(chan *exec.Cmd)
-			killRecoveredJob := func(gotJob *Job) {
-				<-time.After(2 * time.Second)
-
-				errk := syscall.Kill(gotJob.Pid, syscall.SIGKILL)
-				if errk != nil {
-					t.Logf("failed to send SIGKILL to job: %s", errk)
-				}
-			}
-
 			go func() {
 				<-time.After(2 * time.Second)
-
 				gotJob, errg := jq.GetByEssence(&JobEssence{Cmd: cmd2}, false, false)
 				killServer(jq, serverPid, serverCmd)
-
-				if errg != nil || gotJob == nil {
-					log.Printf("failed to get job: %s\n", errg)
+				if errg == nil && gotJob != nil {
+					<-time.After(2 * time.Second)
+					errk := syscall.Kill(gotJob.Pid, syscall.SIGKILL)
+					if errk != nil {
+						fmt.Printf("failed to send SIGKILL to job: %s\n", errk)
+					}
 				} else {
-					killRecoveredJob(gotJob)
+					log.Printf("failed to get job: %s\n", errg)
 				}
 				<-time.After(4 * time.Second)
 				newJQ, _, newServerCmd, errf := startServer(serverExe, true, false, config, addr)
@@ -1858,7 +1466,7 @@ func TestJobqueueSignal(t *testing.T) {
 				} else if newJQ != nil {
 					errd := newJQ.Disconnect()
 					if errd != nil {
-						t.Logf("failed to disconnect after making a new server: %s", errd)
+						fmt.Printf("failed to disconnect after making a new server: %s\n", errd)
 					}
 				}
 				serverCmdCh <- newServerCmd
@@ -2645,11 +2253,10 @@ func TestJobqueueBasics(t *testing.T) {
 
 				errk := syscall.Kill(os.Getpid(), syscall.SIGTERM)
 				if errk != nil {
-					t.Logf("failed to send SIGTERM: %s", errk)
+					fmt.Printf("failed to send SIGTERM: %s\n", errk)
 				}
 
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
-
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
 
@@ -2669,11 +2276,10 @@ func TestJobqueueBasics(t *testing.T) {
 
 				errk = syscall.Kill(os.Getpid(), syscall.SIGINT)
 				if errk != nil {
-					t.Logf("failed to send SIGINT: %s", errk)
+					fmt.Printf("failed to send SIGINT: %s\n", errk)
 				}
 
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
-
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
 				ok = errors.As(err, &jqerr)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -59,10 +59,13 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
+	"github.com/gofrs/uuid/v5"
 	"github.com/phayes/freeport"
 	"github.com/shirou/gopsutil/v4/process"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ugorji/go/codec"
 	bolt "go.etcd.io/bbolt"
+	"go.nanomsg.org/mangos/v3"
 )
 
 const (
@@ -327,6 +330,278 @@ func waitForFileToDisappear(path string, maxWait time.Duration) error {
 	}
 
 	return fmt.Errorf("%w: expected %s to disappear", errFileStillExists, path)
+}
+
+const (
+	liveJTouchActualCwd = "/tmp/wr/job1"
+	liveJTouchTTR       = time.Second
+)
+
+type liveJTouchFixture struct {
+	server *Server
+	sock   *captureSocket
+	job    *Job
+	item   *queue.Item
+	token  []byte
+	key    string
+	client uuid.UUID
+}
+
+func newLiveJTouchFixture(ctx context.Context, webPort string) *liveJTouchFixture {
+	ch := new(codec.BincHandle)
+	sock := &captureSocket{ch: ch}
+	clientID, err := uuid.NewV4()
+	So(err, ShouldBeNil)
+
+	token := []byte(strings.Repeat("x", tokenLength))
+	job := &Job{
+		Cmd:          "echo live jtouch",
+		Cwd:          testCwd,
+		RepGroup:     "live-jtouch",
+		Requirements: &jqs.Requirements{RAM: 1, Time: time.Minute, Cores: 1},
+		ReservedBy:   clientID,
+		State:        JobStateRunning,
+		StartTime:    time.Now(),
+	}
+	key := job.Key()
+	q := queue.New(ctx, "live-jtouch")
+	item, err := q.Add(ctx, key, "", job, 0, 0, liveJTouchTTR, queue.SubQueueRun)
+	So(err, ShouldBeNil)
+
+	return &liveJTouchFixture{
+		server: &Server{
+			ch:         ch,
+			sock:       sock,
+			token:      token,
+			q:          q,
+			up:         true,
+			ServerInfo: &ServerInfo{WebPort: webPort},
+		},
+		sock:   sock,
+		job:    job,
+		item:   item,
+		token:  token,
+		key:    key,
+		client: clientID,
+	}
+}
+
+func (fixture *liveJTouchFixture) touch(
+	ctx context.Context,
+	token []byte,
+	endState *JobEndState,
+) (*serverResponse, error) {
+	var encoded []byte
+
+	enc := codec.NewEncoderBytes(&encoded, fixture.server.ch)
+	err := enc.Encode(&clientRequest{
+		Method:      requestMethodTouch,
+		Token:       token,
+		Keys:        []string{fixture.key},
+		ClientID:    fixture.client,
+		JobEndState: endState,
+	})
+	So(err, ShouldBeNil)
+
+	err = fixture.server.handleRequest(ctx, &mangos.Message{Body: encoded})
+
+	return fixture.sock.response(), err
+}
+
+func (fixture *liveJTouchFixture) remainingTTRAfterDelay() time.Duration {
+	time.Sleep(20 * time.Millisecond)
+
+	return fixture.item.Stats().Remaining
+}
+
+func assertLiveJTouchExtendedTTR(before, after time.Duration) {
+	So(after.Nanoseconds(), ShouldBeGreaterThan, before.Nanoseconds())
+}
+
+func assertLiveJTouchDidNotExtendTTR(before, after time.Duration) {
+	So(after.Nanoseconds(), ShouldBeLessThanOrEqualTo, before.Nanoseconds())
+}
+
+func assertLiveJTouchFields(
+	job *Job,
+	actualCwd string,
+	peakRAM int,
+	peakDisk int64,
+	cpuTime time.Duration,
+	stdout string,
+	stderr string,
+) {
+	job.RLock()
+	So(job.State, ShouldEqual, JobStateRunning)
+	So(job.Exited, ShouldBeFalse)
+	So(job.ActualCwd, ShouldEqual, actualCwd)
+	So(job.PeakRAM, ShouldEqual, peakRAM)
+	So(job.PeakDisk, ShouldEqual, peakDisk)
+	So(job.CPUtime, ShouldEqual, cpuTime)
+	job.RUnlock()
+
+	out, err := job.StdOut()
+	So(err, ShouldBeNil)
+	So(out, ShouldEqual, stdout)
+
+	errOut, err := job.StdErr()
+	So(err, ShouldBeNil)
+	So(errOut, ShouldEqual, stderr)
+}
+
+func TestManagerLiveJTouch(t *testing.T) {
+	Convey("An authenticated live jtouch stores a live snapshot behind the secure gate", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+		before := fixture.remainingTTRAfterDelay()
+		endState := &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte("out\n")),
+			Stderr:   compressStd([]byte("err\n")),
+		}
+
+		resp, err := fixture.touch(ctx, fixture.token, endState)
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 321, 9, 4*time.Second, "out\n", "err\n")
+	})
+
+	Convey("An older runner jtouch with no live fields only extends TTR", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+		setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+	})
+
+	Convey("An authenticated live jtouch with no HTTPS web port only extends TTR", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "")
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
+	})
+
+	Convey("A live jtouch with an invalid token is denied without touching TTR or live fields", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, []byte(strings.Repeat("y", tokenLength)), &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldNotBeNil)
+		So(resp.Err, ShouldEqual, ErrPermissionDenied)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
+	})
+
+	Convey("A live jtouch with no token is denied before a KillCalled response", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+		setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+		fixture.job.Lock()
+		fixture.job.killCalled = true
+		fixture.job.Unlock()
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, nil, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldNotBeNil)
+		So(resp.Err, ShouldEqual, ErrPermissionDenied)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+	})
+
+	Convey("An authenticated live jtouch preserves KillCalled jobs and existing live fields", t, func() {
+		ctx := context.Background()
+		fixture := newKillCalledLiveJTouchFixture(ctx)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte("out\n")),
+			Stderr:   compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeTrue)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+	})
+
+	Convey("An authenticated older-runner jtouch preserves KillCalled jobs and existing live fields", t, func() {
+		ctx := context.Background()
+		fixture := newKillCalledLiveJTouchFixture(ctx)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeTrue)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+	})
+}
+
+func newKillCalledLiveJTouchFixture(ctx context.Context) *liveJTouchFixture {
+	fixture := newLiveJTouchFixture(ctx, "1234")
+	setLiveJTouchFields(fixture.job, "/tmp/old", 111, 7, 2*time.Second, "old\n", "olderr\n")
+	fixture.job.Lock()
+	fixture.job.killCalled = true
+	fixture.job.Unlock()
+
+	return fixture
+}
+
+func setLiveJTouchFields(
+	job *Job,
+	actualCwd string,
+	peakRAM int,
+	peakDisk int64,
+	cpuTime time.Duration,
+	stdout string,
+	stderr string,
+) {
+	job.Lock()
+	job.ActualCwd = actualCwd
+	job.PeakRAM = peakRAM
+	job.PeakDisk = peakDisk
+	job.CPUtime = cpuTime
+	job.StdOutC = compressStd([]byte(stdout))
+	job.StdErrC = compressStd([]byte(stderr))
+	job.Unlock()
 }
 
 func configureFastTestBackups(db *db) {
@@ -1259,27 +1534,32 @@ func TestJobqueueSignal(t *testing.T) {
 		if alreadyKilled[serverPid] {
 			return
 		}
+
 		errd := jq.Disconnect()
 		if errd != nil && !isClosedSocketError(errd) {
-			fmt.Printf("failed to disconnect: %s\n", errd)
+			t.Logf("failed to disconnect: %s", errd)
 		}
 
 		waited := make(chan bool)
+
 		go func() {
 			errw := serverCmd.Wait()
 			if errw != nil {
-				fmt.Printf("failed to reap server pid: %s\n", errw)
+				t.Logf("failed to reap server pid: %s", errw)
 			}
+
 			waited <- true
 		}()
 
 		<-time.After(500 * time.Millisecond)
+
 		errk := syscall.Kill(serverPid, syscall.SIGTERM)
 		if errk != nil {
-			fmt.Printf("failed to send SIGTERM to server: %s\n", errk)
+			t.Logf("failed to send SIGTERM to server: %s", errk)
 		}
 
 		<-waited
+
 		alreadyKilled[serverPid] = true
 	}
 
@@ -1290,6 +1570,7 @@ func TestJobqueueSignal(t *testing.T) {
 
 		jq, token, serverCmd, errf := startServer(serverExe, false, false, config, addr)
 		serverPid := serverCmd.Process.Pid
+
 		So(errf, ShouldBeNil)
 
 		defer killServer(jq, serverPid, serverCmd)
@@ -1299,9 +1580,25 @@ func TestJobqueueSignal(t *testing.T) {
 		Convey("You can set up a long-running job for execution", func() {
 			cmd := "perl -e 'for (1..3) { sleep(1) }'"
 			cmd2 := "perl -e 'for (2..4) { sleep(1) }'"
-			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1}, Retries: uint8(0), RepGroup: "3secs_pass"})
-			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 10, Time: 1 * time.Second, Cores: 1}, Retries: uint8(0), RepGroup: "3secs_fail"})
+
+			jobs := []*Job{
+				{
+					Cmd:          cmd,
+					Cwd:          testCwd,
+					ReqGroup:     reqGroupFake,
+					Requirements: &jqs.Requirements{RAM: 10, Time: 4 * time.Second, Cores: 1},
+					Retries:      uint8(0),
+					RepGroup:     "3secs_pass",
+				},
+				{
+					Cmd:          cmd2,
+					Cwd:          testCwd,
+					ReqGroup:     reqGroupFake,
+					Requirements: &jqs.Requirements{RAM: 10, Time: time.Second, Cores: 1},
+					Retries:      uint8(0),
+					RepGroup:     "3secs_fail",
+				},
+			}
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 2)
@@ -1347,6 +1644,7 @@ func TestJobqueueSignal(t *testing.T) {
 				defer cancelSig()
 
 				j1worked := make(chan bool, 1)
+
 				go func() {
 					err := jq.Execute(ctx, job, config.RunnerExecShell)
 					if err != nil {
@@ -1361,10 +1659,12 @@ func TestJobqueueSignal(t *testing.T) {
 							return
 						}
 					}
+
 					j1worked <- false
 				}()
 
 				j2worked := make(chan bool, 1)
+
 				go func() {
 					err := jq.Execute(ctx, job2, config.RunnerExecShell)
 					if err != nil {
@@ -1379,6 +1679,7 @@ func TestJobqueueSignal(t *testing.T) {
 							return
 						}
 					}
+
 					j2worked <- false
 				}()
 
@@ -1391,7 +1692,9 @@ func TestJobqueueSignal(t *testing.T) {
 
 				jq2, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldBeNil)
+
 				defer disconnect(jq2)
+
 				job, err = jq2.GetByEssence(&JobEssence{Cmd: cmd}, false, false)
 				So(err, ShouldBeNil)
 				So(job, ShouldNotBeNil)
@@ -1411,6 +1714,7 @@ func TestJobqueueSignal(t *testing.T) {
 				kicked, err := jq.Kick([]*JobEssence{job2.ToEssense()})
 				So(err, ShouldBeNil)
 				So(kicked, ShouldEqual, 1)
+
 				job2, err = jq.Reserve(50 * time.Millisecond)
 				So(err, ShouldBeNil)
 				So(job2, ShouldNotBeNil)
@@ -1426,10 +1730,28 @@ func TestJobqueueSignal(t *testing.T) {
 
 		Convey("Running jobs are recovered after a hard server crash", func() {
 			cmd := "sleep 10"
-			cmd2 := "perl -e 'for (1..10) { sleep(1) }'" // we want to kill this part way, but `sleep` processes don't seem to die straight away when killed
-			var jobs []*Job
-			jobs = append(jobs, &Job{Cmd: cmd, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "recover"})
-			jobs = append(jobs, &Job{Cmd: cmd2, Cwd: "/tmp", ReqGroup: "fake_group", Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0}, Retries: uint8(0), RepGroup: "buried"})
+			// We want to kill this part way, but sleep processes do not seem to
+			// die straight away when killed.
+			cmd2 := "perl -e 'for (1..10) { sleep(1) }'"
+
+			jobs := []*Job{
+				{
+					Cmd:          cmd,
+					Cwd:          testCwd,
+					ReqGroup:     reqGroupFake,
+					Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0},
+					Retries:      uint8(0),
+					RepGroup:     "recover",
+				},
+				{
+					Cmd:          cmd2,
+					Cwd:          testCwd,
+					ReqGroup:     reqGroupFake,
+					Requirements: &jqs.Requirements{RAM: 100, Time: 10 * time.Second, Cores: 0},
+					Retries:      uint8(0),
+					RepGroup:     "buried",
+				},
+			}
 			inserts, already, err := jq.Add(jobs, envVars, true)
 			So(err, ShouldBeNil)
 			So(inserts, ShouldEqual, 2)
@@ -1446,18 +1768,25 @@ func TestJobqueueSignal(t *testing.T) {
 			So(job2.State, ShouldEqual, JobStateReserved)
 
 			serverCmdCh := make(chan *exec.Cmd)
+			killRecoveredJob := func(gotJob *Job) {
+				<-time.After(2 * time.Second)
+
+				errk := syscall.Kill(gotJob.Pid, syscall.SIGKILL)
+				if errk != nil {
+					t.Logf("failed to send SIGKILL to job: %s", errk)
+				}
+			}
+
 			go func() {
 				<-time.After(2 * time.Second)
+
 				gotJob, errg := jq.GetByEssence(&JobEssence{Cmd: cmd2}, false, false)
 				killServer(jq, serverPid, serverCmd)
-				if errg == nil && gotJob != nil {
-					<-time.After(2 * time.Second)
-					errk := syscall.Kill(gotJob.Pid, syscall.SIGKILL)
-					if errk != nil {
-						fmt.Printf("failed to send SIGKILL to job: %s\n", errk)
-					}
-				} else {
+
+				if errg != nil || gotJob == nil {
 					log.Printf("failed to get job: %s\n", errg)
+				} else {
+					killRecoveredJob(gotJob)
 				}
 				<-time.After(4 * time.Second)
 				newJQ, _, newServerCmd, errf := startServer(serverExe, true, false, config, addr)
@@ -1466,7 +1795,7 @@ func TestJobqueueSignal(t *testing.T) {
 				} else if newJQ != nil {
 					errd := newJQ.Disconnect()
 					if errd != nil {
-						fmt.Printf("failed to disconnect after making a new server: %s\n", errd)
+						t.Logf("failed to disconnect after making a new server: %s", errd)
 					}
 				}
 				serverCmdCh <- newServerCmd
@@ -2253,10 +2582,11 @@ func TestJobqueueBasics(t *testing.T) {
 
 				errk := syscall.Kill(os.Getpid(), syscall.SIGTERM)
 				if errk != nil {
-					fmt.Printf("failed to send SIGTERM: %s\n", errk)
+					t.Logf("failed to send SIGTERM: %s", errk)
 				}
 
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
+
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
 
@@ -2276,10 +2606,11 @@ func TestJobqueueBasics(t *testing.T) {
 
 				errk = syscall.Kill(os.Getpid(), syscall.SIGINT)
 				if errk != nil {
-					fmt.Printf("failed to send SIGINT: %s\n", errk)
+					t.Logf("failed to send SIGINT: %s", errk)
 				}
 
 				<-time.After(serverShutDownTime(serverConfig.Timings.TouchInterval))
+
 				_, err = Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
 				So(err, ShouldNotBeNil)
 				ok = errors.As(err, &jqerr)

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -335,6 +335,9 @@ func waitForFileToDisappear(path string, maxWait time.Duration) error {
 const (
 	liveJTouchActualCwd = "/tmp/wr/job1"
 	liveJTouchTTR       = time.Second
+	liveStatusCloudUser = "cloud_user"
+	liveStatusHost      = "worker1"
+	liveStatusHostIP    = "10.0.0.8"
 )
 
 type liveJTouchFixture struct {

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -503,6 +503,36 @@ func TestManagerLiveJTouch(t *testing.T) {
 		assertLiveJTouchFields(fixture.job, liveJTouchActualCwd, 654, 12, 7*time.Second, "out\n", "err\n")
 	})
 
+	Convey("An authenticated reserved live jtouch is visible through itemToJob", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "1234")
+		fixture.job.Lock()
+		fixture.job.State = JobStateReserved
+		fixture.job.StartTime = time.Time{}
+		fixture.job.Unlock()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+
+		job := fixture.server.itemToJob(ctx, fixture.item, true, false)
+		So(job.State, ShouldEqual, JobStateReserved)
+
+		stdout, err := job.StdOut()
+		So(err, ShouldBeNil)
+		So(stdout, ShouldEqual, "out\n")
+
+		stderr, err := job.StdErr()
+		So(err, ShouldBeNil)
+		So(stderr, ShouldEqual, "err\n")
+	})
+
 	Convey("An older runner jtouch with no live fields only extends TTR", t, func() {
 		ctx := context.Background()
 		fixture := newLiveJTouchFixture(ctx, "1234")

--- a/jobqueue/live_jtouch_test.go
+++ b/jobqueue/live_jtouch_test.go
@@ -1,0 +1,454 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	"github.com/VertebrateResequencing/wr/queue"
+	"github.com/gofrs/uuid/v5"
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ugorji/go/codec"
+	"go.nanomsg.org/mangos/v3"
+)
+
+const (
+	liveJTouchActualCwd      = "/tmp/wr/job1"
+	liveJTouchPreviousCwd    = "/tmp/old"
+	liveJTouchPreviousStderr = "olderr\n"
+	liveJTouchPreviousStdout = "old\n"
+	liveJTouchQueue          = "live-jtouch"
+	liveJTouchStderr         = "err\n"
+	liveJTouchStdout         = "out\n"
+	liveJTouchTTR            = time.Second
+	liveJTouchWebPort        = "1234"
+	liveStatusCloudUser      = "cloud_user"
+	liveStatusHost           = "worker1"
+	liveStatusHostIP         = "10.0.0.8"
+)
+
+type liveJTouchFixture struct {
+	server *Server
+	sock   *captureSocket
+	job    *Job
+	item   *queue.Item
+	token  []byte
+	key    string
+	client uuid.UUID
+}
+
+func newLiveJTouchFixture(ctx context.Context, webPort string) *liveJTouchFixture {
+	ch := new(codec.BincHandle)
+	sock := &captureSocket{ch: ch}
+	clientID, err := uuid.NewV4()
+	So(err, ShouldBeNil)
+
+	token := []byte(strings.Repeat("x", tokenLength))
+	job := &Job{
+		Cmd:          "echo live jtouch",
+		Cwd:          testCwd,
+		RepGroup:     liveJTouchQueue,
+		Requirements: &jqs.Requirements{RAM: 1, Time: time.Minute, Cores: 1},
+		ReservedBy:   clientID,
+		State:        JobStateRunning,
+		StartTime:    time.Now(),
+	}
+	key := job.Key()
+	q := queue.New(ctx, liveJTouchQueue)
+	item, err := q.Add(ctx, key, "", job, 0, 0, liveJTouchTTR, queue.SubQueueRun)
+	So(err, ShouldBeNil)
+
+	return &liveJTouchFixture{
+		server: &Server{
+			ch:         ch,
+			sock:       sock,
+			token:      token,
+			q:          q,
+			up:         true,
+			ServerInfo: &ServerInfo{WebPort: webPort},
+		},
+		sock:   sock,
+		job:    job,
+		item:   item,
+		token:  token,
+		key:    key,
+		client: clientID,
+	}
+}
+
+func newKillCalledLiveJTouchFixture(ctx context.Context) *liveJTouchFixture {
+	fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+	setLiveJTouchFields(
+		fixture.job,
+		liveJTouchPreviousCwd,
+		111,
+		7,
+		2*time.Second,
+		liveJTouchPreviousStdout,
+		liveJTouchPreviousStderr,
+	)
+	fixture.job.Lock()
+	fixture.job.killCalled = true
+	fixture.job.Unlock()
+
+	return fixture
+}
+
+func (fixture *liveJTouchFixture) touch(
+	ctx context.Context,
+	token []byte,
+	endState *JobEndState,
+) (*serverResponse, error) {
+	var encoded []byte
+
+	enc := codec.NewEncoderBytes(&encoded, fixture.server.ch)
+	err := enc.Encode(&clientRequest{
+		Method:      requestMethodTouch,
+		Token:       token,
+		Keys:        []string{fixture.key},
+		ClientID:    fixture.client,
+		JobEndState: endState,
+	})
+	So(err, ShouldBeNil)
+
+	err = fixture.server.handleRequest(ctx, &mangos.Message{Body: encoded})
+
+	return fixture.sock.response(), err
+}
+
+func (fixture *liveJTouchFixture) remainingTTRAfterDelay() time.Duration {
+	time.Sleep(20 * time.Millisecond)
+
+	return fixture.item.Stats().Remaining
+}
+
+func TestManagerLiveJTouch(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("An authenticated live jtouch stores a live snapshot behind the secure gate", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+		before := fixture.remainingTTRAfterDelay()
+		endState := &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte(liveJTouchStdout)),
+			Stderr:   compressStd([]byte(liveJTouchStderr)),
+		}
+
+		resp, err := fixture.touch(ctx, fixture.token, endState)
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchActualCwd,
+			321,
+			9,
+			4*time.Second,
+			liveJTouchStdout,
+			liveJTouchStderr,
+		)
+	})
+
+	Convey("An authenticated resource-only live jtouch preserves existing output tails", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte(liveJTouchStdout)),
+			Stderr:   compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+
+		resp, err = fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  654,
+			PeakDisk: 12,
+			CPUtime:  7 * time.Second,
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchActualCwd,
+			654,
+			12,
+			7*time.Second,
+			liveJTouchStdout,
+			liveJTouchStderr,
+		)
+	})
+
+	Convey("An authenticated reserved live jtouch is visible through itemToJob", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+		fixture.job.Lock()
+		fixture.job.State = JobStateReserved
+		fixture.job.StartTime = time.Time{}
+		fixture.job.Unlock()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte(liveJTouchStdout)),
+			Stderr:  compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+
+		job := fixture.server.itemToJob(ctx, fixture.item, true, false)
+		So(job.State, ShouldEqual, JobStateReserved)
+
+		stdout, err := job.StdOut()
+		So(err, ShouldBeNil)
+		So(stdout, ShouldEqual, liveJTouchStdout)
+
+		stderr, err := job.StdErr()
+		So(err, ShouldBeNil)
+		So(stderr, ShouldEqual, liveJTouchStderr)
+	})
+
+	Convey("An older runner jtouch with no live fields only extends TTR", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+		setLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+	})
+
+	Convey("An authenticated live jtouch with no HTTPS web port only extends TTR", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, "")
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte(liveJTouchStdout)),
+			Stderr:  compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchExtendedTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
+	})
+
+	Convey("A live jtouch with an invalid token is denied without touching TTR or live fields", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, []byte(strings.Repeat("y", tokenLength)), &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte(liveJTouchStdout)),
+			Stderr:  compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldNotBeNil)
+		So(resp.Err, ShouldEqual, ErrPermissionDenied)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(fixture.job, "", 0, 0, 0, "", "")
+	})
+
+	Convey("A live jtouch with no token is denied before a KillCalled response", t, func() {
+		ctx := context.Background()
+		fixture := newLiveJTouchFixture(ctx, liveJTouchWebPort)
+		setLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+		fixture.job.Lock()
+		fixture.job.killCalled = true
+		fixture.job.Unlock()
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, nil, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte(liveJTouchStdout)),
+			Stderr:  compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldNotBeNil)
+		So(resp.Err, ShouldEqual, ErrPermissionDenied)
+		So(resp.KillCalled, ShouldBeFalse)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+	})
+
+	Convey("An authenticated live jtouch preserves KillCalled jobs and existing live fields", t, func() {
+		ctx := context.Background()
+		fixture := newKillCalledLiveJTouchFixture(ctx)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{
+			Cwd:      liveJTouchActualCwd,
+			PeakRAM:  321,
+			PeakDisk: 9,
+			CPUtime:  4 * time.Second,
+			Stdout:   compressStd([]byte(liveJTouchStdout)),
+			Stderr:   compressStd([]byte(liveJTouchStderr)),
+		})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeTrue)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+	})
+
+	Convey("An authenticated older-runner jtouch preserves KillCalled jobs and existing live fields", t, func() {
+		ctx := context.Background()
+		fixture := newKillCalledLiveJTouchFixture(ctx)
+		before := fixture.remainingTTRAfterDelay()
+
+		resp, err := fixture.touch(ctx, fixture.token, &JobEndState{})
+		So(err, ShouldBeNil)
+		So(resp.KillCalled, ShouldBeTrue)
+		assertLiveJTouchDidNotExtendTTR(before, fixture.item.Stats().Remaining)
+		assertLiveJTouchFields(
+			fixture.job,
+			liveJTouchPreviousCwd,
+			111,
+			7,
+			2*time.Second,
+			liveJTouchPreviousStdout,
+			liveJTouchPreviousStderr,
+		)
+	})
+}
+
+func assertLiveJTouchExtendedTTR(before, after time.Duration) {
+	So(after.Nanoseconds(), ShouldBeGreaterThan, before.Nanoseconds())
+}
+
+func assertLiveJTouchFields(
+	job *Job,
+	actualCwd string,
+	peakRAM int,
+	peakDisk int64,
+	cpuTime time.Duration,
+	stdout string,
+	stderr string,
+) {
+	job.RLock()
+	So(job.State, ShouldEqual, JobStateRunning)
+	So(job.Exited, ShouldBeFalse)
+	So(job.ActualCwd, ShouldEqual, actualCwd)
+	So(job.PeakRAM, ShouldEqual, peakRAM)
+	So(job.PeakDisk, ShouldEqual, peakDisk)
+	So(job.CPUtime, ShouldEqual, cpuTime)
+	job.RUnlock()
+
+	out, err := job.StdOut()
+	So(err, ShouldBeNil)
+	So(out, ShouldEqual, stdout)
+
+	errOut, err := job.StdErr()
+	So(err, ShouldBeNil)
+	So(errOut, ShouldEqual, stderr)
+}
+
+func setLiveJTouchFields(
+	job *Job,
+	actualCwd string,
+	peakRAM int,
+	peakDisk int64,
+	cpuTime time.Duration,
+	stdout string,
+	stderr string,
+) {
+	job.Lock()
+	job.ActualCwd = actualCwd
+	job.PeakRAM = peakRAM
+	job.PeakDisk = peakDisk
+	job.CPUtime = cpuTime
+	job.StdOutC = compressStd([]byte(stdout))
+	job.StdErrC = compressStd([]byte(stderr))
+	job.Unlock()
+}
+
+func assertLiveJTouchDidNotExtendTTR(before, after time.Duration) {
+	So(after.Nanoseconds(), ShouldBeLessThanOrEqualTo, before.Nanoseconds())
+}

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -1028,7 +1028,7 @@ func TestREST(t *testing.T) {
 			So(jstati[0].StdOut, ShouldEqual, "out\n")
 			So(jstati[0].StdErr, ShouldEqual, "err\n")
 			So(jstati[0].SSHCommand, ShouldEqual,
-				"ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+				"ssh -- ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
 
 			req, err = http.NewRequestWithContext(ctx, http.MethodGet, liveURL, nil)
 			So(err, ShouldBeNil)

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -1016,12 +1016,11 @@ func TestREST(t *testing.T) {
 			response, err := client.Do(req)
 			So(err, ShouldBeNil)
 
-			defer response.Body.Close()
-
 			var jstati []JStatus
 
 			err = json.NewDecoder(response.Body).Decode(&jstati)
 			So(err, ShouldBeNil)
+			So(response.Body.Close(), ShouldBeNil)
 			So(jstati, ShouldHaveLength, 1)
 			So(jstati[0].PeakRAM, ShouldEqual, 321)
 			So(jstati[0].CPUtime, ShouldEqual, 4)

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -958,6 +958,93 @@ func TestREST(t *testing.T) {
 			So(response.StatusCode, ShouldEqual, http.StatusUnauthorized)
 		})
 
+		Convey("Authenticated GET returns running job live fields and SSH command", func() {
+			reqs := &jqs.Requirements{
+				RAM:   1,
+				Time:  time.Minute,
+				Cores: 1,
+				Other: map[string]string{liveStatusCloudUser: "ubuntu"},
+			}
+			input := &Job{
+				Cmd:          "echo rest live status",
+				Cwd:          "/tmp/wr",
+				ReqGroup:     "rest-live-status",
+				Requirements: reqs,
+				RepGroup:     "rest-live-status",
+			}
+
+			ids, err := jq.AddAndReturnIDs([]*Job{input}, envVars, true)
+			So(err, ShouldBeNil)
+			So(ids, ShouldHaveLength, 1)
+
+			running, err := jq.Reserve(2 * time.Second)
+			So(err, ShouldBeNil)
+			So(running, ShouldNotBeNil)
+
+			if running == nil {
+				return
+			}
+
+			So(running.Key(), ShouldEqual, ids[0])
+			So(jq.Started(running, 44), ShouldBeNil)
+
+			item, err := server.q.Get(running.Key())
+			So(err, ShouldBeNil)
+
+			serverJob, ok := item.Data().(*Job)
+			So(ok, ShouldBeTrue)
+			serverJob.Lock()
+			serverJob.Host = liveStatusHost
+			serverJob.HostIP = liveStatusHostIP
+			serverJob.Pid = 44
+			serverJob.Unlock()
+
+			killCalled, err := jq.touch(running, &JobEndState{
+				Cwd:     "/tmp/wr/job1",
+				PeakRAM: 321,
+				CPUtime: 4 * time.Second,
+				Stdout:  compressStd([]byte("out\n")),
+				Stderr:  compressStd([]byte("err\n")),
+			})
+			So(err, ShouldBeNil)
+			So(killCalled, ShouldBeFalse)
+
+			liveURL := jobsEndPoint + "/" + running.Key() + "?std=true"
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, liveURL, nil)
+			So(err, ShouldBeNil)
+			req.Header.Add("Authorization", bearer)
+			response, err := client.Do(req)
+			So(err, ShouldBeNil)
+
+			defer response.Body.Close()
+
+			var jstati []JStatus
+
+			err = json.NewDecoder(response.Body).Decode(&jstati)
+			So(err, ShouldBeNil)
+			So(jstati, ShouldHaveLength, 1)
+			So(jstati[0].PeakRAM, ShouldEqual, 321)
+			So(jstati[0].CPUtime, ShouldEqual, 4)
+			So(jstati[0].StdOut, ShouldEqual, "out\n")
+			So(jstati[0].StdErr, ShouldEqual, "err\n")
+			So(jstati[0].SSHCommand, ShouldEqual,
+				"ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+
+			req, err = http.NewRequestWithContext(ctx, http.MethodGet, liveURL, nil)
+			So(err, ShouldBeNil)
+			response, err = client.Do(req)
+			So(err, ShouldBeNil)
+
+			defer response.Body.Close()
+
+			So(response.StatusCode, ShouldEqual, http.StatusUnauthorized)
+
+			responseData, err := io.ReadAll(response.Body)
+			So(err, ShouldBeNil)
+			err = json.Unmarshal(responseData, &jstati)
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("Initial GET queries return nothing", func() {
 			req, err := http.NewRequest(http.MethodGet, jobsEndPoint, nil)
 			So(err, ShouldBeNil)

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -3315,7 +3315,7 @@ func (s *Server) getJobsByKeys(ctx context.Context, keys []string, getStd bool, 
 		item, err := s.q.Get(jobkey)
 		var job *Job
 		if err == nil && item != nil {
-			job = s.itemToJob(ctx, item, false, false)
+			job = s.itemToJob(ctx, item, getStd, false)
 		} else {
 			notfound = append(notfound, jobkey)
 		}
@@ -3398,7 +3398,7 @@ func (s *Server) getJobsByRepGroup(ctx context.Context, opts repGroupOptions) (j
 
 	for i := range rgs {
 		rg := rgs[i]
-		queueJobs := s.getQueueJobsByRepGroup(ctx, rg)
+		queueJobs := s.getQueueJobsByRepGroup(ctx, rg, opts.GetStd)
 		jobs = append(jobs, queueJobs...)
 
 		complete := s.getDBJobsByRepGroup(rg, opts.State, &srerr, &qerr)
@@ -3435,13 +3435,13 @@ func (s *Server) getRepGroupsList(repGroup string, match RepGroupMatch) ([]strin
 
 // getQueueJobsByRepGroup gets jobs from the in-memory queue for a given
 // RepGroup.
-func (s *Server) getQueueJobsByRepGroup(ctx context.Context, repGroup string) []*Job {
+func (s *Server) getQueueJobsByRepGroup(ctx context.Context, repGroup string, getStd bool) []*Job {
 	var jobs []*Job
 
 	for _, key := range s.rpl.Values(repGroup) {
 		item, _ := s.q.Get(key) //nolint:errcheck
 		if item != nil {
-			job := s.itemToJob(ctx, item, false, false)
+			job := s.itemToJob(ctx, item, getStd, false)
 			jobs = append(jobs, job)
 		}
 	}
@@ -3507,7 +3507,7 @@ func (s *Server) getLastCompletionTimeByRepGroup(repGroup string,
 // returned.
 func (s *Server) getJobsCurrent(ctx context.Context, repGroup string, match RepGroupMatch,
 	limit int, state JobState, getStd bool, getEnv bool, waitingForDepGroups bool) []*Job {
-	jobs := s.getQueueJobsCurrent(ctx, repGroup, match)
+	jobs := s.getQueueJobsCurrent(ctx, repGroup, match, getStd)
 
 	jobs = s.limitJobs(ctx, jobs, limitJobsOptions{
 		Limit:               limit,
@@ -3520,36 +3520,36 @@ func (s *Server) getJobsCurrent(ctx context.Context, repGroup string, match RepG
 	return jobs
 }
 
-func (s *Server) getQueueJobsCurrent(ctx context.Context, repGroup string, match RepGroupMatch) []*Job {
+func (s *Server) getQueueJobsCurrent(ctx context.Context, repGroup string, match RepGroupMatch, getStd bool) []*Job {
 	if repGroup == "" {
-		return s.getAllQueueJobs(ctx)
+		return s.getAllQueueJobs(ctx, getStd)
 	}
 
 	if match == RepGroupMatchExact {
-		return s.getQueueJobsByRepGroup(ctx, repGroup)
+		return s.getQueueJobsByRepGroup(ctx, repGroup, getStd)
 	}
 
-	return s.getQueueJobsByRepGroupMatch(ctx, repGroup, match)
+	return s.getQueueJobsByRepGroupMatch(ctx, repGroup, match, getStd)
 }
 
-func (s *Server) getAllQueueJobs(ctx context.Context) []*Job {
+func (s *Server) getAllQueueJobs(ctx context.Context, getStd bool) []*Job {
 	allItems := s.q.AllItems()
 	jobs := make([]*Job, 0, len(allItems))
 
 	for _, item := range allItems {
-		jobs = append(jobs, s.itemToJob(ctx, item, false, false))
+		jobs = append(jobs, s.itemToJob(ctx, item, getStd, false))
 	}
 
 	return jobs
 }
 
 func (s *Server) getQueueJobsByRepGroupMatch(ctx context.Context, repGroup string,
-	match RepGroupMatch) []*Job {
+	match RepGroupMatch, getStd bool) []*Job {
 	allItems := s.q.AllItems()
 	jobs := make([]*Job, 0, len(allItems))
 
 	for _, item := range allItems {
-		job := s.itemToJob(ctx, item, false, false)
+		job := s.itemToJob(ctx, item, getStd, false)
 		if job == nil || !RepGroupMatches(job.RepGroup, repGroup, match) {
 			continue
 		}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -1307,6 +1307,8 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 		HostID:                sjob.HostID,
 		HostIP:                sjob.HostIP,
 		CPUtime:               sjob.CPUtime,
+		StdErrC:               sjob.StdErrC,
+		StdOutC:               sjob.StdOutC,
 		State:                 state,
 		Attempts:              sjob.Attempts,
 		UntilBuried:           sjob.UntilBuried,

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -33,6 +33,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -245,6 +247,78 @@ func subscriptionCatchUpRepGroupUpdate(repGroup string, records map[string]subsc
 	return update
 }
 
+type liveJobUpdateData struct {
+	update  *JobUpdate
+	stdoutC []byte
+	stderrC []byte
+}
+
+func liveJobUpdateDataFromJob(job *Job) (*liveJobUpdateData, error) {
+	job.RLock()
+	defer job.RUnlock()
+
+	cwdLeaf, err := liveJobCwdLeaf(job.Cwd, job.ActualCwd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &liveJobUpdateData{
+		update: &JobUpdate{
+			Kind:       JobUpdateLive,
+			Key:        job.Key(),
+			RepGroup:   job.RepGroup,
+			State:      job.State,
+			PeakRAM:    job.PeakRAM,
+			PeakDisk:   job.PeakDisk,
+			Pid:        job.Pid,
+			CPUtime:    job.CPUtime,
+			Host:       job.Host,
+			HostID:     job.HostID,
+			HostIP:     job.HostIP,
+			CwdBase:    job.Cwd,
+			Cwd:        cwdLeaf,
+			SSHCommand: sshCommandForRunningJob(job.State, job.Requirements, job.Host, job.HostIP, job.ActualCwd),
+		},
+		stdoutC: slices.Clone(job.StdOutC),
+		stderrC: slices.Clone(job.StdErrC),
+	}, nil
+}
+
+func jobUpdateFromLiveJob(job *Job) (*JobUpdate, error) {
+	data, err := liveJobUpdateDataFromJob(job)
+	if err != nil {
+		return nil, err
+	}
+
+	stdout, err := compressedStdString(data.stdoutC)
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := compressedStdString(data.stderrC)
+	if err != nil {
+		return nil, err
+	}
+
+	data.update.StdOut = stdout
+	data.update.StdErr = stderr
+
+	return data.update, nil
+}
+
+func compressedStdString(compressed []byte) (string, error) {
+	if len(compressed) == 0 {
+		return "", nil
+	}
+
+	decompressed, err := decompress(compressed)
+	if err != nil {
+		return "", err
+	}
+
+	return string(decompressed), nil
+}
+
 func liveSnapshotPresent(jes *JobEndState) bool {
 	if jes == nil {
 		return false
@@ -271,6 +345,23 @@ func applyLiveSnapshot(job *Job, jes *JobEndState) {
 	job.CPUtime = jes.CPUtime
 	job.StdOutC = jes.Stdout
 	job.StdErrC = jes.Stderr
+}
+
+func liveJobCwdLeaf(cwdBase, cwd string) (string, error) {
+	if cwd == "" {
+		return "", nil
+	}
+
+	if cwdBase == "" {
+		return cwd, nil
+	}
+
+	rel, err := filepath.Rel(cwdBase, cwd)
+	if err != nil {
+		return "", err
+	}
+
+	return "/" + rel, nil
 }
 
 func (s *Server) subscriptionCatchUpByRepGroup(ctx context.Context, repGroup string) ([]*JobUpdate, error) {
@@ -666,6 +757,13 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 
 					if srerr == "" && s.liveJTouchEnabled() && liveSnapshotPresent(cr.JobEndState) {
 						applyLiveSnapshot(job, cr.JobEndState)
+
+						update, err := jobUpdateFromLiveJob(job)
+						if err != nil {
+							clog.Warn(ctx, "failed to build live subscription update", "err", err)
+						} else {
+							s.enqueueSubscriptionUpdate(update)
+						}
 					}
 				}
 				sr = &serverResponse{KillCalled: killCalled}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -361,6 +361,14 @@ func liveJobCwdLeaf(cwdBase, cwd string) (string, error) {
 		return "", err
 	}
 
+	if rel == "." {
+		return "/", nil
+	}
+
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return cwd, nil
+	}
+
 	return "/" + rel, nil
 }
 

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -343,8 +343,14 @@ func applyLiveSnapshot(job *Job, jes *JobEndState) {
 	job.PeakRAM = jes.PeakRAM
 	job.PeakDisk = jes.PeakDisk
 	job.CPUtime = jes.CPUtime
-	job.StdOutC = jes.Stdout
-	job.StdErrC = jes.Stderr
+
+	if len(jes.Stdout) != 0 {
+		job.StdOutC = jes.Stdout
+	}
+
+	if len(jes.Stderr) != 0 {
+		job.StdErrC = jes.Stderr
+	}
 }
 
 func liveJobCwdLeaf(cwdBase, cwd string) (string, error) {

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -1343,7 +1343,7 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 		job.State = JobStateRunning
 	}
 
-	if getStd && (job.State == JobStateRunning || job.State == JobStateLost) {
+	if getStd && (job.State == JobStateReserved || job.State == JobStateRunning || job.State == JobStateLost) {
 		job.StdErrC = sjob.StdErrC
 		job.StdOutC = sjob.StdOutC
 	}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -245,6 +245,34 @@ func subscriptionCatchUpRepGroupUpdate(repGroup string, records map[string]subsc
 	return update
 }
 
+func liveSnapshotPresent(jes *JobEndState) bool {
+	if jes == nil {
+		return false
+	}
+
+	return jes.Cwd != "" ||
+		jes.PeakRAM != 0 ||
+		jes.PeakDisk != 0 ||
+		jes.CPUtime != 0 ||
+		len(jes.Stdout) != 0 ||
+		len(jes.Stderr) != 0
+}
+
+func applyLiveSnapshot(job *Job, jes *JobEndState) {
+	job.Lock()
+	defer job.Unlock()
+
+	if jes.Cwd != "" {
+		job.ActualCwd = jes.Cwd
+	}
+
+	job.PeakRAM = jes.PeakRAM
+	job.PeakDisk = jes.PeakDisk
+	job.CPUtime = jes.CPUtime
+	job.StdOutC = jes.Stdout
+	job.StdErrC = jes.Stderr
+}
+
 func (s *Server) subscriptionCatchUpByRepGroup(ctx context.Context, repGroup string) ([]*JobUpdate, error) {
 	records, allTerminal, err := s.subscriptionCatchUpRepGroupRecords(ctx, repGroup)
 	if err != nil {
@@ -599,7 +627,7 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 					s.db.updateJobAfterChange(ctx, job)
 				}
 			}
-		case "jtouch":
+		case requestMethodTouch:
 			var job *Job
 			var item *queue.Item
 			item, job, srerr = s.getij(cr, true)
@@ -634,6 +662,10 @@ func (s *Server) handleRequest(ctx context.Context, m *mangos.Message) error {
 						// this transition from lost to running state
 						s.statusCaster.Send(&jstateCount{"+all+", JobStateLost, JobStateRunning, 1})
 						s.statusCaster.Send(&jstateCount{job.RepGroup, JobStateLost, JobStateRunning, 1})
+					}
+
+					if srerr == "" && s.liveJTouchEnabled() && liveSnapshotPresent(cr.JobEndState) {
+						applyLiveSnapshot(job, cr.JobEndState)
 					}
 				}
 				sr = &serverResponse{KillCalled: killCalled}
@@ -1099,6 +1131,13 @@ func (s *Server) getij(cr *clientRequest, checkRunning bool) (*queue.Item, *Job,
 	}
 
 	return item, job, ""
+}
+
+func (s *Server) liveJTouchEnabled() bool {
+	s.ssmutex.RLock()
+	defer s.ssmutex.RUnlock()
+
+	return s.ServerInfo != nil && s.ServerInfo.WebPort != ""
 }
 
 func (s *Server) itemStateToJobState(itemState queue.ItemState, lost bool) JobState {

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -116,7 +116,7 @@ func (s *Server) subscriptionCatchUpRepGroupRecords(ctx context.Context,
 	repGroup string,
 ) (map[string]subscriptionCatchUpRecord, bool, error) {
 	records := make(map[string]subscriptionCatchUpRecord)
-	queueTerminal := addSubscriptionCatchUpRepGroupRecords(records, s.getQueueJobsByRepGroup(ctx, repGroup))
+	queueTerminal := addSubscriptionCatchUpRepGroupRecords(records, s.getQueueJobsByRepGroup(ctx, repGroup, false))
 
 	complete, err := s.db.retrieveCompleteJobsByRepGroup(repGroup)
 	if err != nil {
@@ -1315,8 +1315,6 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 		HostID:                sjob.HostID,
 		HostIP:                sjob.HostIP,
 		CPUtime:               sjob.CPUtime,
-		StdErrC:               sjob.StdErrC,
-		StdOutC:               sjob.StdOutC,
 		State:                 state,
 		Attempts:              sjob.Attempts,
 		UntilBuried:           sjob.UntilBuried,
@@ -1337,6 +1335,11 @@ func (s *Server) itemToJob(ctx context.Context, item *queue.Item, getStd bool, g
 
 	if state == JobStateReserved && !sjob.StartTime.IsZero() {
 		job.State = JobStateRunning
+	}
+
+	if getStd && (job.State == JobStateRunning || job.State == JobStateLost) {
+		job.StdErrC = sjob.StdErrC
+		job.StdOutC = sjob.StdOutC
 	}
 	sjob.RUnlock()
 	s.jobPopulateStdEnv(ctx, job, getStd, getEnv)

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -1315,11 +1315,17 @@ func restJobs(ctx context.Context, s *Server) http.HandlerFunc {
 
 		// convert jobs to jstatus
 		jstati := make([]JStatus, len(jobs))
+		includeStd := r.Form.Get("std") == restFormTrue
 		for i, job := range jobs {
 			jstati[i], err = job.ToStatus()
 			if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 				http.Error(w, err.Error(), status)
 				return
+			}
+
+			if !includeStd {
+				jstati[i].StdErr = ""
+				jstati[i].StdOut = ""
 			}
 		}
 

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -1315,7 +1315,7 @@ func restJobs(ctx context.Context, s *Server) http.HandlerFunc {
 
 		// convert jobs to jstatus
 		jstati := make([]JStatus, len(jobs))
-		includeStd := r.Form.Get("std") == restFormTrue
+		includeStd := r.URL.Query().Get("std") == restFormTrue
 		for i, job := range jobs {
 			jstati[i], err = job.ToStatus()
 			if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
@@ -1355,27 +1355,32 @@ func restJobsStatus(ctx context.Context, r *http.Request, s *Server) ([]*Job, in
 	var state JobState
 	var err error
 
-	if r.Form.Get("search") == restFormTrue {
+	query := r.URL.Query()
+
+	if query.Get("search") == restFormTrue {
 		search = true
 	}
-	if r.Form.Get("std") == restFormTrue {
+
+	if query.Get("std") == restFormTrue {
 		getStd = true
 	}
-	if r.Form.Get("env") == restFormTrue {
+
+	if query.Get("env") == restFormTrue {
 		getEnv = true
 	}
 
-	if r.Form.Get("waiting_deps") == restFormTrue {
+	if query.Get("waiting_deps") == restFormTrue {
 		waitingForDepGroups = true
 	}
-	if r.Form.Get("limit") != "" {
-		limit, err = strconv.Atoi(r.Form.Get("limit"))
+	if query.Get("limit") != "" {
+		limit, err = strconv.Atoi(query.Get("limit"))
 		if err != nil {
 			return nil, http.StatusBadRequest, err
 		}
 	}
-	if r.Form.Get("state") != "" {
-		switch r.Form.Get("state") {
+
+	if query.Get("state") != "" {
+		switch query.Get("state") {
 		case "delayed":
 			state = JobStateDelayed
 		case "ready":

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -1372,6 +1372,7 @@ func restJobsStatus(ctx context.Context, r *http.Request, s *Server) ([]*Job, in
 	if query.Get("waiting_deps") == restFormTrue {
 		waitingForDepGroups = true
 	}
+
 	if query.Get("limit") != "" {
 		limit, err = strconv.Atoi(query.Get("limit"))
 		if err != nil {

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -215,10 +215,6 @@ func (s *Server) statusFromSubscriptionUpdate(ctx context.Context, update *JobUp
 		return nil
 	}
 
-	if update.Kind == JobUpdateLive {
-		return statusFromJobUpdate(update)
-	}
-
 	jobs, _, errstr := s.getJobsByKeys(ctx, []string{update.Key}, true, true)
 	if errstr != "" || len(jobs) != 1 {
 		return statusFromJobUpdate(update)

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -190,8 +190,20 @@ func statusFromJobUpdate(update *JobUpdate) *JStatus {
 		Key:          update.Key,
 		RepGroup:     update.RepGroup,
 		State:        update.State,
+		Cwd:          update.Cwd,
+		CwdBase:      update.CwdBase,
 		FailReason:   update.FailReason,
+		Host:         update.Host,
+		HostID:       update.HostID,
+		HostIP:       update.HostIP,
+		SSHCommand:   update.SSHCommand,
+		StdErr:       update.StdErr,
+		StdOut:       update.StdOut,
+		PeakRAM:      update.PeakRAM,
+		PeakDisk:     update.PeakDisk,
 		Exitcode:     update.Exitcode,
+		Pid:          update.Pid,
+		CPUtime:      update.CPUtime.Seconds(),
 		Started:      statusTimeFromJobUpdateTime(update.Started),
 		Ended:        statusTimeFromJobUpdateTime(update.Ended),
 		IsPushUpdate: true,
@@ -201,6 +213,10 @@ func statusFromJobUpdate(update *JobUpdate) *JStatus {
 func (s *Server) statusFromSubscriptionUpdate(ctx context.Context, update *JobUpdate) *JStatus {
 	if update == nil || update.Key == "" {
 		return nil
+	}
+
+	if update.Kind == JobUpdateLive {
+		return statusFromJobUpdate(update)
 	}
 
 	jobs, _, errstr := s.getJobsByKeys(ctx, []string{update.Key}, true, true)

--- a/jobqueue/serverWebI.go
+++ b/jobqueue/serverWebI.go
@@ -157,6 +157,7 @@ type JStatus struct {
 	Host                string
 	HostID              string
 	HostIP              string
+	SSHCommand          string
 	StdErr              string
 	StdOut              string
 	ExpectedRAM         int     // ExpectedRAM is in Megabytes.

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1268,6 +1268,119 @@ func assertEditableStatusFields(status JStatus) {
 	So(status.EnvOverrides, ShouldResemble, []string{"WEB_ONLY=old"})
 }
 
+func TestStatusDetailsLiveCompatibility(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Status details preserve compatibility without active live data", t, func() {
+		ctx := context.Background()
+		serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		testServer := httptest.NewServer(webInterfaceStatusWS(ctx, server))
+		defer testServer.Close()
+
+		wsURL := "ws" + strings.TrimPrefix(testServer.URL, "http")
+		header := http.Header{}
+		header.Add("Authorization", "Bearer "+string(token))
+
+		ws, err := drainWebSocket(wsURL, header)
+		So(err, ShouldBeNil)
+
+		defer ws.Close()
+
+		addRunningJob := func(repGroup, cmd string) *Job {
+			ids, erra := jq.AddAndReturnIDs([]*Job{{
+				Cmd:          cmd,
+				Cwd:          testCwd,
+				ReqGroup:     repGroup,
+				Requirements: standardReqs,
+				RepGroup:     repGroup,
+			}}, envVars, true)
+			So(erra, ShouldBeNil)
+			So(ids, ShouldHaveLength, 1)
+
+			job, errr := jq.Reserve(2 * time.Second)
+			So(errr, ShouldBeNil)
+			So(job, ShouldNotBeNil)
+
+			if job == nil {
+				return &Job{}
+			}
+
+			So(job.Key(), ShouldEqual, ids[0])
+			So(jq.Started(job, os.Getpid()), ShouldBeNil)
+
+			return job
+		}
+
+		requestDetails := func(repGroup string, state JobState, key string) JStatus {
+			errw := ws.WriteJSON(jstatusReq{
+				Request:  jstatusRequestDetails,
+				RepGroup: repGroup,
+				State:    state,
+			})
+			So(errw, ShouldBeNil)
+
+			status, ok := readJStatusMatching(ws, func(s JStatus) bool { return s.Key == key })
+			So(ok, ShouldBeTrue)
+
+			return status
+		}
+
+		noLiveJob := addRunningJob("status-details-no-live", "echo status details no live")
+		noLiveStatus := requestDetails(noLiveJob.RepGroup, JobStateRunning, noLiveJob.Key())
+
+		So(noLiveStatus.PeakRAM, ShouldEqual, 0)
+		So(noLiveStatus.CPUtime, ShouldEqual, 0)
+		So(noLiveStatus.StdOut, ShouldEqual, "")
+		So(noLiveStatus.StdErr, ShouldEqual, "")
+		So(noLiveStatus.SSHCommand, ShouldEqual, "")
+		So(noLiveStatus.Started, ShouldNotBeNil)
+		So(noLiveStatus.Ended, ShouldBeNil)
+		So(noLiveStatus.Walltime, ShouldBeGreaterThanOrEqualTo, 0)
+
+		completeJob := addRunningJob("status-details-live-archive", "echo status details live archive")
+		completeJob.ActualCwd = liveJTouchActualCwd
+		completeJob.PeakRAM = 321
+		completeJob.CPUtime = 4 * time.Second
+		completeJob.StdOutC = compressStd([]byte("live\n"))
+		completeJob.StdErrC = compressStd([]byte("stale\n"))
+
+		killCalled, errt := jq.Touch(completeJob)
+		So(errt, ShouldBeNil)
+		So(killCalled, ShouldBeFalse)
+
+		So(jq.Archive(completeJob, &JobEndState{
+			Exited:   true,
+			Exitcode: 0,
+			PeakRAM:  654,
+			CPUtime:  8 * time.Second,
+			EndTime:  time.Now(),
+			Stdout:   compressStd([]byte("final\n")),
+			Stderr:   compressStd([]byte("done\n")),
+		}), ShouldBeNil)
+
+		completeStatus := requestDetails(completeJob.RepGroup, JobStateComplete, completeJob.Key())
+
+		So(completeStatus.StdOut, ShouldEqual, "final\n")
+		So(completeStatus.StdErr, ShouldEqual, "done\n")
+		So(completeStatus.Exited, ShouldBeTrue)
+		So(completeStatus.PeakRAM, ShouldEqual, 654)
+		So(completeStatus.CPUtime, ShouldEqual, 8)
+		So(completeStatus.SSHCommand, ShouldEqual, "")
+	})
+}
+
 func clearReadDeadlineBestEffort(ws *websocket.Conn) {
 	if err := ws.SetReadDeadline(time.Time{}); err != nil {
 		return

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1434,7 +1434,7 @@ func TestStatusDetailsLiveFields(t *testing.T) {
 		So(status.StdOut, ShouldEqual, "out\n")
 		So(status.StdErr, ShouldEqual, "err\n")
 		So(status.SSHCommand, ShouldEqual,
-			"ssh cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+			"ssh -- cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
 	})
 }
 
@@ -1475,7 +1475,7 @@ func TestStatusDetailsLivePushUpdates(t *testing.T) {
 		So(status.StdOut, ShouldEqual, "out\n")
 		So(status.StdErr, ShouldEqual, "err\n")
 		So(status.SSHCommand, ShouldEqual,
-			"ssh cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+			"ssh -- cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
 	})
 }
 
@@ -2549,7 +2549,7 @@ function assert(condition, message) {
     }
 }
 
-const sshCommand = "ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'";
+const sshCommand = "ssh -- ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'";
 const existing = {
     Key: 'k',
     RepGroup: 'rg1',

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -2483,6 +2483,145 @@ func readStaticText(path string) string {
 	return string(data)
 }
 
+func TestStatusPageLivePushUpdateBehaviour(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required to exercise the status page JavaScript")
+	}
+
+	Convey("Status page job details push updates replace visible live data", t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		//nolint:gosec // The Node script is a constant test harness.
+		cmd := exec.CommandContext(ctx, "node", "-e", statusPageLivePushUpdateScript())
+		output, err := cmd.CombinedOutput()
+		So(string(output), ShouldBeBlank)
+		So(err, ShouldBeNil)
+	})
+}
+
+func statusPageLivePushUpdateScript() string {
+	return `
+const fs = require('fs');
+const vm = require('vm');
+
+let source = fs.readFileSync('static/js/wr/websocket-handler.js', 'utf8');
+source = source
+    .replace(/^import .*;\n/gm, '')
+    .replace(/export function /g, 'function ');
+
+const context = {
+    console,
+    createRepGroupTracker() {
+        return {};
+    },
+    setupLiveWalltime(job, walltime) {
+        job.LiveWalltime = () => walltime;
+    }
+};
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(source + '\nglobalThis.handleJobDetailsMessage = handleJobDetailsMessage;', context,
+    { filename: 'websocket-handler.js' });
+
+function observableArray(initial) {
+    const values = initial.slice();
+    function observable(next) {
+        if (arguments.length > 0) {
+            values.splice(0, values.length, ...next);
+            return values;
+        }
+
+        return values;
+    }
+    observable.push = value => values.push(value);
+    observable.splice = (...args) => values.splice(...args);
+    return observable;
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+const sshCommand = "ssh ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'";
+const existing = {
+    Key: 'k',
+    RepGroup: 'rg1',
+    State: 'running',
+    Exited: false,
+    PeakRAM: 0,
+    CPUtime: 0,
+    StdOut: '',
+    StdErr: '',
+    SSHCommand: '',
+    Walltime: 12,
+    Started: 123,
+    Cmd: 'sleep 60',
+    ExpectedRAM: 100,
+    ExpectedTime: 60,
+    RequestedDisk: 0,
+    Cores: 1,
+    Attempts: 1
+};
+const viewModel = {
+    detailsRepgroup: 'rg1',
+    detailsOA: observableArray([existing]),
+    isSearchMode: () => false,
+    repGroups: [{ id: 'rg1' }],
+    newJobsInfo: {}
+};
+
+context.handleJobDetailsMessage(viewModel, {
+    Key: 'k',
+    RepGroup: 'rg1',
+    State: 'running',
+    IsPushUpdate: true,
+    PeakRAM: 321,
+    CPUtime: 4,
+    StdOut: 'alpha-out\n',
+    StdErr: 'alpha-err\n',
+    SSHCommand: sshCommand
+});
+
+let job = viewModel.detailsOA()[0];
+assert(viewModel.detailsOA().length === 1, 'push update must replace the existing detail row');
+assert(job.PeakRAM === 321, 'first push PeakRAM was not applied');
+assert(job.CPUtime === 4, 'first push CPUtime was not applied');
+assert(job.StdOut === 'alpha-out\n', 'first push stdout was not applied');
+assert(job.StdErr === 'alpha-err\n', 'first push stderr was not applied');
+assert(job.SSHCommand === sshCommand, 'first push SSH command was not applied');
+assert(job.Cmd === 'sleep 60', 'push update should preserve existing command text');
+assert(job.LiveWalltime() === 12, 'push update should preserve live walltime fallback');
+
+context.handleJobDetailsMessage(viewModel, {
+    Key: 'k',
+    RepGroup: 'rg1',
+    State: 'running',
+    IsPushUpdate: true,
+    PeakRAM: 654,
+    CPUtime: 8,
+    StdOut: 'beta-out\n',
+    StdErr: 'beta-err\n',
+    SSHCommand: sshCommand
+});
+
+job = viewModel.detailsOA()[0];
+assert(viewModel.detailsOA().length === 1, 'second push update must keep one detail row');
+assert(job.PeakRAM === 654, 'second push PeakRAM was not applied');
+assert(job.CPUtime === 8, 'second push CPUtime was not applied');
+assert(job.StdOut === 'beta-out\n', 'second push stdout was not applied');
+assert(job.StdErr === 'beta-err\n', 'second push stderr was not applied');
+assert(!job.StdOut.includes('alpha-out'), 'old stdout should not remain visible');
+assert(!job.StdErr.includes('alpha-err'), 'old stderr should not remain visible');
+`
+}
+
 func readTextAsset(t *testing.T, path string) string {
 	t.Helper()
 

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -2602,6 +2602,31 @@ assert(job.LiveWalltime() === 12, 'push update should preserve live walltime fal
 context.handleJobDetailsMessage(viewModel, {
     Key: 'k',
     RepGroup: 'rg1',
+    State: 'reserved',
+    IsPushUpdate: true,
+    PeakRAM: 222,
+    CPUtime: 5,
+    Cmd: '',
+    ExpectedRAM: 0,
+    ExpectedTime: 0,
+    RequestedDisk: 0,
+    Cores: 0,
+    Attempts: 0
+});
+
+job = viewModel.detailsOA()[0];
+assert(job.State === 'reserved', 'reserved push State was not applied');
+assert(job.PeakRAM === 222, 'reserved push PeakRAM was not applied');
+assert(job.CPUtime === 5, 'reserved push CPUtime was not applied');
+assert(job.Cmd === 'sleep 60', 'reserved push should preserve existing command text');
+assert(job.ExpectedRAM === 100, 'reserved push should preserve expected RAM');
+assert(job.ExpectedTime === 60, 'reserved push should preserve expected time');
+assert(job.Cores === 1, 'reserved push should preserve cores');
+assert(job.Attempts === 1, 'reserved push should preserve attempts');
+
+context.handleJobDetailsMessage(viewModel, {
+    Key: 'k',
+    RepGroup: 'rg1',
     State: 'running',
     IsPushUpdate: true,
     PeakRAM: 654,

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -1381,6 +1381,104 @@ func TestStatusDetailsLiveCompatibility(t *testing.T) {
 	})
 }
 
+func TestStatusDetailsLiveFields(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Status details include running job live fields and SSH command", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job := addAndStartLiveSubscriptionJob(server, jq, runner, standardReqs, "status-details-c1-live")
+		killCalled, err := runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(killCalled, ShouldBeFalse)
+
+		testServer := httptest.NewServer(webInterfaceStatusWS(ctx, server))
+		defer testServer.Close()
+
+		wsURL := "ws" + strings.TrimPrefix(testServer.URL, "http")
+		header := http.Header{}
+		header.Add("Authorization", "Bearer "+string(token))
+
+		ws, err := drainWebSocket(wsURL, header)
+		So(err, ShouldBeNil)
+
+		defer ws.Close()
+
+		err = ws.WriteJSON(jstatusReq{
+			Request:  jstatusRequestDetails,
+			RepGroup: job.RepGroup,
+			State:    JobStateRunning,
+		})
+		So(err, ShouldBeNil)
+
+		status, ok := readJStatusMatching(ws, func(status JStatus) bool {
+			return status.Key == job.Key() && !status.IsPushUpdate
+		})
+		So(ok, ShouldBeTrue)
+		So(status.State, ShouldEqual, JobStateRunning)
+		So(status.PeakRAM, ShouldEqual, 321)
+		So(status.CPUtime, ShouldEqual, 4)
+		So(status.StdOut, ShouldEqual, "out\n")
+		So(status.StdErr, ShouldEqual, "err\n")
+		So(status.SSHCommand, ShouldEqual,
+			"ssh cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+	})
+}
+
+func TestStatusDetailsLivePushUpdates(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Status details websocket pushes running job live fields and SSH command", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job := addAndStartLiveSubscriptionJob(server, jq, runner, standardReqs, "status-details-c2-live")
+
+		ws, cleanup := openStatusDetailsSubscription(ctx, server, token, job.RepGroup, job.Key())
+		defer cleanup()
+
+		killCalled, err := runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+		So(killCalled, ShouldBeFalse)
+
+		status, ok := readJStatusMatching(ws, func(status JStatus) bool {
+			return status.Key == job.Key() && status.IsPushUpdate && status.PeakRAM == 321
+		})
+		So(ok, ShouldBeTrue)
+		So(status.State, ShouldEqual, JobStateRunning)
+		So(status.CPUtime, ShouldEqual, 4)
+		So(status.StdOut, ShouldEqual, "out\n")
+		So(status.StdErr, ShouldEqual, "err\n")
+		So(status.SSHCommand, ShouldEqual,
+			"ssh cloud_user@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'")
+	})
+}
+
 func clearReadDeadlineBestEffort(ws *websocket.Conn) {
 	if err := ws.SetReadDeadline(time.Time{}); err != nil {
 		return
@@ -2346,8 +2444,49 @@ assert.equal(errorVM.detailsOA()[0].Priority, 1);
 	})
 }
 
+func TestStatusPageLiveIntrospectionAssets(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Status page assets render live introspection without an embedded terminal", t, func() {
+		html := readTextAsset(t, "static/status.html")
+		handler := readTextAsset(t, "static/js/wr/websocket-handler.js")
+		utility := readTextAsset(t, "static/js/wr/utility.js")
+		css := readTextAsset(t, "static/css/wr-0.36.0.css")
+
+		So(html, ShouldContainSubstring, "!Exited && (State == 'running' || State == 'reserved') && PeakRAM > 0")
+		So(html, ShouldContainSubstring, "text: window.wrUtils.mbIEC(PeakRAM)")
+		So(html, ShouldContainSubstring, "!Exited && (State == 'running' || State == 'reserved') && CPUtime > 0")
+		So(html, ShouldContainSubstring, "text: 'CPU: ' + window.wrUtils.toDuration(CPUtime)")
+		So(html, ShouldContainSubstring, "ko if: StdOut")
+		So(html, ShouldContainSubstring, "ko if: StdErr")
+		So(html, ShouldContainSubstring, "ko if: SSHCommand")
+		So(html, ShouldContainSubstring, "data-clipboard-text': SSHCommand")
+		So(html, ShouldContainSubstring, "ssh-command-text")
+		So(html, ShouldNotContainSubstring, "xterm")
+		So(html, ShouldNotContainSubstring, "web-terminal")
+
+		So(handler, ShouldContainSubstring, "mergeJobDetailsPushUpdate")
+		So(handler, ShouldContainSubstring, "viewModel.detailsOA.splice(index, 1, merged)")
+		So(utility, ShouldContainSubstring, "copyTextToClipboard")
+		So(utility, ShouldContainSubstring, "navigator.clipboard.writeText")
+		So(css, ShouldContainSubstring, ".ssh-command-control")
+		So(css, ShouldContainSubstring, ".ssh-command-text")
+	})
+}
+
 func readStaticText(path string) string {
 	data, err := staticFS.ReadFile(path)
+	So(err, ShouldBeNil)
+
+	return string(data)
+}
+
+func readTextAsset(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
 	So(err, ShouldBeNil)
 
 	return string(data)

--- a/jobqueue/static/css/wr-0.36.0.css
+++ b/jobqueue/static/css/wr-0.36.0.css
@@ -129,6 +129,39 @@
     cursor: default;
 }
 
+.ssh-command-control {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    background-color: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(91, 192, 222, 0.35);
+    border-radius: 3px;
+}
+
+.ssh-copy-button {
+    flex: 0 0 auto;
+    padding: 1px 6px;
+    line-height: 1.4;
+}
+
+.ssh-command-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: #d9edf7;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    white-space: nowrap;
+    overflow-x: auto;
+}
+
+.live-value {
+    color: #31708f;
+    font-weight: 500;
+}
+
 u.dotted {
     border-bottom: 1px dashed #999;
     text-decoration: none;
@@ -602,6 +635,15 @@ u.dotted {
 @media (max-width: 480px) {
     .command-path {
         font-size: 0.7em;
+    }
+
+    .ssh-command-control {
+        align-items: flex-start;
+    }
+
+    .ssh-command-text {
+        white-space: pre-wrap;
+        word-break: break-word;
     }
 
     .keyvals dl {

--- a/jobqueue/static/js/wr/status-viewmodel.js
+++ b/jobqueue/static/js/wr/status-viewmodel.js
@@ -7,7 +7,8 @@ import {
     toDate,
     mbIEC,
     capitalizeFirstLetter,
-    setupLiveWalltime
+    setupLiveWalltime,
+    copyTextToClipboard
 } from '/js/wr/utility.js';
 import { setupInflightTracking, createRepGroupTracker } from '/js/wr/inflight-tracking.js';
 import { setupWebSocket } from '/js/wr/websocket-handler.js';
@@ -622,6 +623,10 @@ export function StatusViewModel() {
     };
     self.submitModifyJob = function () {
         return modalHandlers.submitModifyJob(self);
+    };
+    self.copySSHCommand = function (job) {
+        copyTextToClipboard(job.SSHCommand);
+        return false;
     };
 
     self.actionModalVisible = ko.observable(false);

--- a/jobqueue/static/js/wr/utility.js
+++ b/jobqueue/static/js/wr/utility.js
@@ -184,7 +184,7 @@ export function copyTextToClipboard(text) {
     }
 
     if (navigator.clipboard && window.isSecureContext) {
-        return navigator.clipboard.writeText(value).then(() => true);
+        return navigator.clipboard.writeText(value).then(() => true).catch(() => false);
     }
 
     const textArea = document.createElement('textarea');
@@ -198,6 +198,8 @@ export function copyTextToClipboard(text) {
 
     try {
         return Promise.resolve(document.execCommand('copy'));
+    } catch {
+        return Promise.resolve(false);
     } finally {
         document.body.removeChild(textArea);
     }

--- a/jobqueue/static/js/wr/utility.js
+++ b/jobqueue/static/js/wr/utility.js
@@ -173,6 +173,37 @@ export function capitalizeFirstLetter(str) {
 }
 
 /**
+ * Copy text to the clipboard.
+ * @param {string} text - The text to copy
+ * @returns {Promise<boolean>} Whether the copy action was attempted successfully
+ */
+export function copyTextToClipboard(text) {
+    const value = text || '';
+    if (value === '') {
+        return Promise.resolve(false);
+    }
+
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(value).then(() => true);
+    }
+
+    const textArea = document.createElement('textarea');
+    textArea.value = value;
+    textArea.setAttribute('readonly', '');
+    textArea.style.position = 'fixed';
+    textArea.style.top = '-1000px';
+    textArea.style.left = '-1000px';
+    document.body.appendChild(textArea);
+    textArea.select();
+
+    try {
+        return Promise.resolve(document.execCommand('copy'));
+    } finally {
+        document.body.removeChild(textArea);
+    }
+}
+
+/**
  * Setup Knockout custom bindings
  */
 export function initKnockoutBindings() {

--- a/jobqueue/static/js/wr/websocket-handler.js
+++ b/jobqueue/static/js/wr/websocket-handler.js
@@ -254,7 +254,7 @@ function livePushValue(value, fallback) {
 function mergeJobDetailsPushUpdate(existing, update) {
     const merged = Object.assign({}, existing, update);
 
-    if (update.State === 'running') {
+    if (update.State === 'running' || update.State === 'reserved') {
         merged.Walltime = update.Walltime > 0 ? update.Walltime : existing.Walltime;
         merged.Started = livePushValue(update.Started, existing.Started);
         merged.Cmd = update.Cmd || existing.Cmd;

--- a/jobqueue/static/js/wr/websocket-handler.js
+++ b/jobqueue/static/js/wr/websocket-handler.js
@@ -243,6 +243,31 @@ function jobExists(detailsArray, key) {
     return detailsArray().some(job => job.Key === key);
 }
 
+function livePushValue(value, fallback) {
+    if (value === null || value === undefined) {
+        return fallback;
+    }
+
+    return value;
+}
+
+function mergeJobDetailsPushUpdate(existing, update) {
+    const merged = Object.assign({}, existing, update);
+
+    if (update.State === 'running') {
+        merged.Walltime = update.Walltime > 0 ? update.Walltime : existing.Walltime;
+        merged.Started = livePushValue(update.Started, existing.Started);
+        merged.Cmd = update.Cmd || existing.Cmd;
+        merged.ExpectedRAM = update.ExpectedRAM > 0 ? update.ExpectedRAM : existing.ExpectedRAM;
+        merged.ExpectedTime = update.ExpectedTime > 0 ? update.ExpectedTime : existing.ExpectedTime;
+        merged.RequestedDisk = update.RequestedDisk > 0 ? update.RequestedDisk : existing.RequestedDisk;
+        merged.Cores = update.Cores > 0 ? update.Cores : existing.Cores;
+        merged.Attempts = update.Attempts > 0 ? update.Attempts : existing.Attempts;
+    }
+
+    return merged;
+}
+
 /**
  * Handles job details messages from the WebSocket
  * @param {StatusViewModel} viewModel - The main view model
@@ -293,12 +318,14 @@ function handleJobDetailsMessage(viewModel, json) {
             const jobs = viewModel.detailsOA();
             for (const job of jobs) {
                 if (job.Key === json.Key) {
+                    const merged = mergeJobDetailsPushUpdate(job, json);
+
                     // Set up LiveWalltime for the job
-                    setupLiveWalltime(json, json['Walltime'], viewModel);
+                    setupLiveWalltime(merged, merged['Walltime'], viewModel);
 
                     // Simply replace the job at the same index
                     const index = jobs.indexOf(job);
-                    viewModel.detailsOA.splice(index, 1, json);
+                    viewModel.detailsOA.splice(index, 1, merged);
                     return;
                 }
             }

--- a/jobqueue/static/status.html
+++ b/jobqueue/static/status.html
@@ -570,6 +570,17 @@
 
                                 <h5 style="margin: 0; padding: 0">$ <span data-bind="text: Cmd"></span></h5>
 
+                                <!-- ko if: SSHCommand -->
+                                <div class="ssh-command-control">
+                                    <button type="button" class="btn btn-xs btn-default ssh-copy-button"
+                                        data-bind="click: $root.copySSHCommand, attr: { 'data-clipboard-text': SSHCommand, title: SSHCommand }"
+                                        aria-label="Copy SSH command">
+                                        <span class="glyphicon glyphicon-copy"></span>
+                                    </button>
+                                    <code class="ssh-command-text" data-bind="text: SSHCommand"></code>
+                                </div>
+                                <!-- /ko -->
+
                                 <!-- ko if: StdOut -->
                                 <div class="output-divider">
                                     <span class="output-label stdout-label">STDOUT</span>
@@ -606,6 +617,11 @@
                                                 <span class="actual-value"
                                                     data-bind="text: window.wrUtils.mbIEC(PeakRAM), css: { 'over-limit': PeakRAM > ExpectedRAM }"></span>
                                                 <!-- /ko -->
+                                                <!-- ko if: !Exited && (State == 'running' || State == 'reserved') && PeakRAM > 0 -->
+                                                <span class="prop-separator">→</span>
+                                                <span class="actual-value live-value"
+                                                    data-bind="text: window.wrUtils.mbIEC(PeakRAM), css: { 'over-limit': PeakRAM > ExpectedRAM }"></span>
+                                                <!-- /ko -->
                                             </span>
                                         </div>
 
@@ -627,6 +643,11 @@
                                                 <span class="prop-separator">→</span>
                                                 <span class="actual-value"
                                                     data-bind="text: window.wrUtils.toDuration(LiveWalltime()), css: { 'over-limit': LiveWalltime() > ExpectedTime }"></span>
+                                                <!-- ko if: !Exited && (State == 'running' || State == 'reserved') && CPUtime > 0 -->
+                                                <span class="prop-separator">•</span>
+                                                <span class="live-value"
+                                                    data-bind="text: 'CPU: ' + window.wrUtils.toDuration(CPUtime)"></span>
+                                                <!-- /ko -->
                                                 <!-- /ko -->
 
                                                 <!-- ko if: !Exited && State == 'lost' -->

--- a/jobqueue/subscription.go
+++ b/jobqueue/subscription.go
@@ -71,6 +71,9 @@ const (
 	// state. Only server-side status websocket detail subscriptions request
 	// these updates.
 	JobUpdateStateChange
+	// JobUpdateLive means a subscribed running job has fresh live output or
+	// resource details.
+	JobUpdateLive
 )
 
 // JobUpdate is the single event type delivered on Subscription.
@@ -89,6 +92,18 @@ type JobUpdate struct {
 	Buried     int
 	Lost       int
 	Total      int
+	PeakRAM    int
+	PeakDisk   int64
+	Pid        int
+	CPUtime    time.Duration
+	Host       string
+	HostID     string
+	HostIP     string
+	CwdBase    string
+	Cwd        string
+	StdOut     string
+	StdErr     string
+	SSHCommand string
 }
 
 func receiveJobUpdate(ctx context.Context, updates <-chan *JobUpdate) (*JobUpdate, error) {

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -30,6 +30,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -42,6 +44,7 @@ import (
 
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
+	"github.com/gorilla/websocket"
 	gpnet "github.com/shirou/gopsutil/v4/net"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/ugorji/go/codec"
@@ -49,7 +52,10 @@ import (
 	"go.nanomsg.org/mangos/v3"
 )
 
-const subscriptionA1ReqGroup = "subscription-a1"
+const (
+	subscriptionA1ReqGroup          = "subscription-a1"
+	liveSubscriptionNoUpdateTimeout = 100 * time.Millisecond
+)
 
 var (
 	errAddAndWaitTimeout = errors.New("timed out waiting for AddAndWait")
@@ -517,6 +523,365 @@ func addAndWaitAsyncWithIgnoreComplete(
 	return resultCh
 }
 
+func TestLiveJobSubscriptions(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A live jtouch is delivered to key and status details subscribers", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job := addAndStartLiveSubscriptionJob(server, jq, runner, standardReqs, "subscription-b2-live")
+		sub, err := jq.SubscribeToJobKeys(ctx, []string{job.Key()})
+		So(err, ShouldBeNil)
+
+		defer sub.Unsubscribe()
+
+		ws, cleanup := openStatusDetailsSubscription(ctx, server, token, job.RepGroup, job.Key())
+		defer cleanup()
+
+		_, err = runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+			Stderr:  compressStd([]byte("err\n")),
+		})
+		So(err, ShouldBeNil)
+
+		updates, ok := collectSubscriptionUpdates(sub, 1)
+		So(ok, ShouldBeTrue)
+		So(updates, ShouldHaveLength, 1)
+		assertLiveJobUpdate(updates[0], job.Key())
+
+		status, ok := readJStatusMatching(ws, func(status JStatus) bool {
+			return status.Key == job.Key() && status.IsPushUpdate && status.PeakRAM == 321
+		})
+		So(ok, ShouldBeTrue)
+		So(status.State, ShouldEqual, JobStateRunning)
+		So(status.CPUtime, ShouldEqual, 4)
+		So(status.StdOut, ShouldEqual, "out\n")
+		So(status.StdErr, ShouldEqual, "err\n")
+	})
+
+	Convey("AddAndWait ignores live updates and waits for the terminal event", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, _, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		input := subscriptionTestJobs("subscription-b2-add-and-wait-live", standardReqs, 1)
+
+		waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+
+		resultCh := addAndWaitAsync(waitCtx, jq, input)
+
+		So(pollUntil(func() bool {
+			return server.hasClientSubscriptionsForJobUpdate(input[0].Key(), input[0].RepGroup, JobStateComplete)
+		}), ShouldBeTrue)
+
+		job := startNextAddAndWaitJob(runner)
+		_, err := runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			CPUtime: 4 * time.Second,
+			Stdout:  compressStd([]byte("out\n")),
+		})
+		So(err, ShouldBeNil)
+
+		select {
+		case result := <-resultCh:
+			So(result.err, ShouldNotBeNil)
+			So("AddAndWait returned after a live update", ShouldBeBlank)
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		So(runner.Archive(job, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()}), ShouldBeNil)
+
+		result := receiveAddAndWaitResult(resultCh, 3*time.Second)
+		So(result.err, ShouldBeNil)
+		So(result.jobs, ShouldHaveLength, 1)
+		So(result.jobs[0].State, ShouldEqual, JobStateComplete)
+		So(result.jobs[0].Key(), ShouldEqual, input[0].Key())
+	})
+
+	Convey("A RepGroup subscription does not complete from a live update", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, _, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job := addAndStartLiveSubscriptionJob(server, jq, runner, standardReqs, "subscription-b2-repgroup-live")
+		sub, err := jq.SubscribeToRepGroup(ctx, job.RepGroup)
+		So(err, ShouldBeNil)
+
+		defer sub.Unsubscribe()
+
+		_, err = runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			Stdout:  compressStd([]byte("out\n")),
+		})
+		So(err, ShouldBeNil)
+
+		assertNoJobUpdateKind(sub.Updates(), JobUpdateRepGroupDone)
+	})
+
+	Convey("An older runner touch sends no live subscription or status update", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job, sub, ws, cleanup := watchLiveSubscriptionJob(ctx, server, jq, runner, token, standardReqs,
+			"subscription-b2-older-runner")
+		defer sub.Unsubscribe()
+		defer cleanup()
+
+		_, err := runner.touch(job, &JobEndState{})
+		So(err, ShouldBeNil)
+
+		assertNoJobUpdateKind(sub.Updates(), JobUpdateLive)
+		assertNoPushedJStatus(ws, job.Key(), 100*time.Millisecond)
+	})
+
+	Convey("A live touch with the secure gate disabled sends no live updates", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job, sub, ws, cleanup := watchLiveSubscriptionJob(ctx, server, jq, runner, token, standardReqs,
+			"subscription-b2-disabled-live")
+		defer sub.Unsubscribe()
+		defer cleanup()
+
+		server.ssmutex.Lock()
+		server.ServerInfo.WebPort = ""
+		server.ssmutex.Unlock()
+
+		_, err := runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			Stdout:  compressStd([]byte("out\n")),
+		})
+		So(err, ShouldBeNil)
+
+		assertNoJobUpdateKind(sub.Updates(), JobUpdateLive)
+		assertNoPushedJStatus(ws, job.Key(), 100*time.Millisecond)
+	})
+
+	Convey("A live touch with an invalid token is denied without live updates", t, func() {
+		ctx := context.Background()
+
+		server, jq, runner, token, standardReqs := startSubscriptionIntegration(ctx, t)
+		defer server.Stop(ctx, true)
+		defer disconnect(jq)
+		defer disconnect(runner)
+
+		job, sub, ws, cleanup := watchLiveSubscriptionJob(ctx, server, jq, runner, token, standardReqs,
+			"subscription-b2-invalid-live")
+		defer sub.Unsubscribe()
+		defer cleanup()
+
+		runner.token = []byte(strings.Repeat("y", tokenLength))
+		_, err := runner.touch(job, &JobEndState{
+			Cwd:     liveJTouchActualCwd,
+			PeakRAM: 321,
+			Stdout:  compressStd([]byte("out\n")),
+		})
+		So(err, ShouldNotBeNil)
+
+		var jqErr Error
+		So(errors.As(err, &jqErr), ShouldBeTrue)
+		So(jqErr.Err, ShouldEqual, ErrPermissionDenied)
+		assertNoJobUpdateKind(sub.Updates(), JobUpdateLive)
+		assertNoPushedJStatus(ws, job.Key(), 100*time.Millisecond)
+	})
+}
+
+func startSubscriptionIntegration(
+	ctx context.Context,
+	t *testing.T,
+) (*Server, *Client, *Client, []byte, *jqs.Requirements) {
+	t.Helper()
+
+	serverConfig, addr, standardReqs, clientConnectTime := subscriptionTestConfig(t)
+	server, _, token, err := serve(ctx, serverConfig)
+	So(err, ShouldBeNil)
+
+	jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+	So(err, ShouldBeNil)
+
+	runner, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+	So(err, ShouldBeNil)
+
+	return server, jq, runner, token, standardReqs
+}
+
+func addAndStartLiveSubscriptionJob(
+	server *Server,
+	jq *Client,
+	runner *Client,
+	standardReqs *jqs.Requirements,
+	prefix string,
+) *Job {
+	reqs := *standardReqs
+	reqs.Other = map[string]string{"cloud_user": "cloud_user"}
+	job := &Job{
+		Cmd:          "echo " + prefix,
+		Cwd:          testCwd,
+		ReqGroup:     prefix,
+		Requirements: &reqs,
+		RepGroup:     prefix,
+	}
+
+	ids, err := jq.AddAndReturnIDs([]*Job{job}, envVars, true)
+	So(err, ShouldBeNil)
+	So(ids, ShouldHaveLength, 1)
+
+	running, err := runner.Reserve(2 * time.Second)
+	So(err, ShouldBeNil)
+	So(running, ShouldNotBeNil)
+
+	if running == nil {
+		return &Job{}
+	}
+
+	So(running.Key(), ShouldEqual, ids[0])
+	So(runner.Started(running, 44), ShouldBeNil)
+
+	running.Host = "worker1"
+	running.HostIP = "10.0.0.8"
+	running.Pid = 44
+	item, err := server.q.Get(running.Key())
+	So(err, ShouldBeNil)
+
+	serverJob, ok := item.Data().(*Job)
+	So(ok, ShouldBeTrue)
+	serverJob.Lock()
+	serverJob.Host = "worker1"
+	serverJob.HostIP = "10.0.0.8"
+	serverJob.Pid = 44
+	serverJob.Unlock()
+
+	return running
+}
+
+func openStatusDetailsSubscription(
+	ctx context.Context,
+	server *Server,
+	token []byte,
+	repGroup string,
+	key string,
+) (*websocket.Conn, func()) {
+	testServer := httptest.NewServer(webInterfaceStatusWS(ctx, server))
+	wsURL := "ws" + strings.TrimPrefix(testServer.URL, "http")
+	header := http.Header{}
+	header.Add("Authorization", "Bearer "+string(token))
+
+	ws, err := drainWebSocket(wsURL, header)
+	So(err, ShouldBeNil)
+
+	err = ws.WriteJSON(jstatusReq{
+		Request:  jstatusRequestDetails,
+		RepGroup: repGroup,
+		State:    JobStateRunning,
+	})
+	So(err, ShouldBeNil)
+
+	status, ok := readJStatusMatching(ws, func(status JStatus) bool {
+		return status.Key == key && !status.IsPushUpdate
+	})
+	So(ok, ShouldBeTrue)
+	So(status.State, ShouldEqual, JobStateRunning)
+
+	return ws, func() {
+		_ = ws.Close()
+		testServer.Close()
+	}
+}
+
+func assertLiveJobUpdate(update *JobUpdate, key string) {
+	So(update.Kind, ShouldEqual, JobUpdateLive)
+	So(update.Key, ShouldEqual, key)
+	So(update.State, ShouldEqual, JobStateRunning)
+	So(update.PeakRAM, ShouldEqual, 321)
+	So(update.CPUtime, ShouldEqual, 4*time.Second)
+	So(update.StdOut, ShouldEqual, "out\n")
+	So(update.StdErr, ShouldEqual, "err\n")
+	So(update.Host, ShouldEqual, "worker1")
+	So(update.HostIP, ShouldEqual, "10.0.0.8")
+	So(update.Pid, ShouldEqual, 44)
+	So(update.SSHCommand, ShouldNotBeBlank)
+}
+
+func assertNoJobUpdateKind(updates <-chan *JobUpdate, kind JobUpdateKind) {
+	timer := time.NewTimer(liveSubscriptionNoUpdateTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case update, ok := <-updates:
+			if !ok {
+				return
+			}
+
+			So(update.Kind, ShouldNotEqual, kind)
+		case <-timer.C:
+			return
+		}
+	}
+}
+
+func watchLiveSubscriptionJob(
+	ctx context.Context,
+	server *Server,
+	jq *Client,
+	runner *Client,
+	token []byte,
+	standardReqs *jqs.Requirements,
+	prefix string,
+) (*Job, *Subscription, *websocket.Conn, func()) {
+	job := addAndStartLiveSubscriptionJob(server, jq, runner, standardReqs, prefix)
+	sub, err := jq.SubscribeToJobKeys(ctx, []string{job.Key()})
+	So(err, ShouldBeNil)
+
+	ws, cleanup := openStatusDetailsSubscription(ctx, server, token, job.RepGroup, job.Key())
+
+	return job, sub, ws, cleanup
+}
+
+func assertNoPushedJStatus(ws *websocket.Conn, key string, timeout time.Duration) {
+	So(ws.SetReadDeadline(time.Now().Add(timeout)), ShouldBeNil)
+	defer clearReadDeadlineBestEffort(ws)
+
+	for {
+		var status JStatus
+
+		err := ws.ReadJSON(&status)
+		if err != nil {
+			return
+		}
+
+		So(status.Key == key && status.IsPushUpdate, ShouldBeFalse)
+	}
+}
+
 func TestSubscriptionLongPollOverExistingPort(t *testing.T) {
 	if runnermode || servermode {
 		return
@@ -889,7 +1254,7 @@ func TestSubscriptionAtLeastOnceDedup(t *testing.T) {
 
 		defer result.sub.Unsubscribe()
 
-		updates, ok := collectSubscriptionUpdates(result.sub, 1, 2*time.Second)
+		updates, ok := collectSubscriptionUpdates(result.sub, 1)
 		So(ok, ShouldBeTrue)
 		So(updates, ShouldHaveLength, 1)
 
@@ -1029,7 +1394,7 @@ func TestSubscriptionReconnectResync(t *testing.T) {
 
 		So(catchUpClient.Archive(job, &JobEndState{Exited: true, Exitcode: 0, EndTime: time.Now()}), ShouldBeNil)
 
-		updates, ok := collectSubscriptionUpdates(sub, 2, 2*time.Second)
+		updates, ok := collectSubscriptionUpdates(sub, 2)
 		So(ok, ShouldBeTrue)
 		So(updates, ShouldHaveLength, 2)
 		So(updates[0].Kind, ShouldEqual, JobUpdateResync)
@@ -1594,7 +1959,7 @@ func TestSubscriptionPerKeyTerminalEvents(t *testing.T) {
 			So(errr, ShouldBeNil)
 		}
 
-		updates, ok := collectSubscriptionUpdates(sub, 3, 2*time.Second)
+		updates, ok := collectSubscriptionUpdates(sub, 3)
 		So(ok, ShouldBeTrue)
 		So(updates, ShouldHaveLength, 3)
 
@@ -2505,8 +2870,8 @@ func subscriptionTestJobs(prefix string, standardReqs *jqs.Requirements, count i
 	return jobs
 }
 
-func collectSubscriptionUpdates(sub *Subscription, count int, timeout time.Duration) ([]*JobUpdate, bool) {
-	deadline := time.After(timeout)
+func collectSubscriptionUpdates(sub *Subscription, count int) ([]*JobUpdate, bool) {
+	deadline := time.After(2 * time.Second)
 	updates := make([]*JobUpdate, 0, count)
 
 	for len(updates) < count {

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -741,7 +741,7 @@ func addAndStartLiveSubscriptionJob(
 	prefix string,
 ) *Job {
 	reqs := *standardReqs
-	reqs.Other = map[string]string{"cloud_user": "cloud_user"}
+	reqs.Other = map[string]string{liveStatusCloudUser: liveStatusCloudUser}
 	job := &Job{
 		Cmd:          "echo " + prefix,
 		Cwd:          testCwd,
@@ -765,8 +765,8 @@ func addAndStartLiveSubscriptionJob(
 	So(running.Key(), ShouldEqual, ids[0])
 	So(runner.Started(running, 44), ShouldBeNil)
 
-	running.Host = "worker1"
-	running.HostIP = "10.0.0.8"
+	running.Host = liveStatusHost
+	running.HostIP = liveStatusHostIP
 	running.Pid = 44
 	item, err := server.q.Get(running.Key())
 	So(err, ShouldBeNil)
@@ -774,8 +774,8 @@ func addAndStartLiveSubscriptionJob(
 	serverJob, ok := item.Data().(*Job)
 	So(ok, ShouldBeTrue)
 	serverJob.Lock()
-	serverJob.Host = "worker1"
-	serverJob.HostIP = "10.0.0.8"
+	serverJob.Host = liveStatusHost
+	serverJob.HostIP = liveStatusHostIP
 	serverJob.Pid = 44
 	serverJob.Unlock()
 

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -63,6 +63,32 @@ var (
 	errAsyncDriverWait   = errors.New("timed out waiting for async job driver")
 )
 
+func TestLiveJobUpdateCwd(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Live job updates normalise cwd display paths", t, func() {
+		cwdBase := filepath.Dir(liveJTouchActualCwd)
+		outsideCwd := filepath.Join(filepath.Dir(cwdBase), "other", "job1")
+		job := &Job{
+			Cmd:       "echo cwd",
+			Cwd:       cwdBase,
+			ActualCwd: cwdBase,
+			State:     JobStateRunning,
+		}
+
+		update, err := jobUpdateFromLiveJob(job)
+		So(err, ShouldBeNil)
+		So(update.Cwd, ShouldEqual, "/")
+
+		job.ActualCwd = outsideCwd
+		update, err = jobUpdateFromLiveJob(job)
+		So(err, ShouldBeNil)
+		So(update.Cwd, ShouldEqual, outsideCwd)
+	})
+}
+
 type addAndWaitResult struct {
 	jobs []*Job
 	err  error
@@ -827,6 +853,8 @@ func assertLiveJobUpdate(update *JobUpdate, key string) {
 	So(update.Host, ShouldEqual, "worker1")
 	So(update.HostIP, ShouldEqual, "10.0.0.8")
 	So(update.Pid, ShouldEqual, 44)
+	So(update.CwdBase, ShouldEqual, testCwd)
+	So(update.Cwd, ShouldEqual, "/wr/job1")
 	So(update.SSHCommand, ShouldNotBeBlank)
 }
 

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -44,6 +44,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/VertebrateResequencing/wr/internal"
@@ -77,6 +78,12 @@ var (
 	cr       = []byte("\r")
 	lf       = []byte("\n")
 	ellipses = []byte("[...]\n")
+)
+
+const (
+	liveStdRawTailLimit    = 64 * 1024
+	liveStdCompressedLimit = 4096
+	binarySearchDivisor    = 2
 )
 
 // generateToken creates a cryptographically secure pseudorandom URL-safe base64
@@ -376,6 +383,66 @@ func minInt(a, b int) int {
 	return b
 }
 
+type liveTailSaver struct {
+	sync.Mutex
+	tail  []byte
+	dirty bool
+}
+
+func (w *liveTailSaver) Write(p []byte) (int, error) {
+	w.Lock()
+	defer w.Unlock()
+
+	lenp := len(p)
+	if lenp == 0 {
+		return 0, nil
+	}
+
+	w.dirty = true
+	if lenp >= liveStdRawTailLimit {
+		w.tail = append(w.tail[:0], p[lenp-liveStdRawTailLimit:]...)
+
+		return lenp, nil
+	}
+
+	if overage := len(w.tail) + lenp - liveStdRawTailLimit; overage > 0 {
+		copy(w.tail, w.tail[overage:])
+		w.tail = w.tail[:len(w.tail)-overage]
+	}
+
+	w.tail = append(w.tail, p...)
+
+	return lenp, nil
+}
+
+func (w *liveTailSaver) FlushCompressed() []byte {
+	w.Lock()
+	defer w.Unlock()
+
+	if !w.dirty {
+		return nil
+	}
+
+	tail := w.tail
+	w.tail = nil
+	w.dirty = false
+
+	return compressedLiveTail(tail)
+}
+
+func compressedLiveTail(tail []byte) []byte {
+	compressed, err := compress(tail)
+	if err != nil {
+		return nil
+	}
+
+	if len(compressed) <= liveStdCompressedLimit {
+		return compressed
+	}
+
+	return compressedLiveTailSuffix(tail)
+}
+
 // stdFilter keeps only the first and last line of any contiguous block of \r
 // terminated lines (to mostly eliminate progress bars), intended for use with
 // stdout/err streaming input, outputting to a prefixSuffixSaver. Because you
@@ -446,6 +513,33 @@ func envOverride(orig []string, over []string) []string {
 		env = append(env, envvar)
 	}
 	return env
+}
+
+func compressedLiveTailSuffix(tail []byte) []byte {
+	low := 1
+	high := len(tail)
+
+	var best []byte
+
+	for low <= high {
+		mid := low + (high-low)/binarySearchDivisor
+
+		compressed, err := compress(tail[len(tail)-mid:])
+		if err != nil {
+			return nil
+		}
+
+		if len(compressed) <= liveStdCompressedLimit {
+			best = compressed
+			low = mid + 1
+
+			continue
+		}
+
+		high = mid - 1
+	}
+
+	return best
 }
 
 // calculateHashedDir returns the hashed directory structure corresponding to

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -86,6 +86,8 @@ const (
 	binarySearchDivisor    = 2
 )
 
+var liveTailCompressor = compressedLiveTail //nolint:gochecknoglobals // Test hook for FlushCompressed contention.
+
 // generateToken creates a cryptographically secure pseudorandom URL-safe base64
 // encoded string 43 bytes long. Used by the server to create a token passed to
 // to the caller for subsequent client authentication. If the given file exists
@@ -417,17 +419,19 @@ func (w *liveTailSaver) Write(p []byte) (int, error) {
 
 func (w *liveTailSaver) FlushCompressed() []byte {
 	w.Lock()
-	defer w.Unlock()
 
 	if !w.dirty {
+		w.Unlock()
+
 		return nil
 	}
 
-	tail := w.tail
+	tail := append([]byte(nil), w.tail...)
 	w.tail = w.tail[:0]
 	w.dirty = false
+	w.Unlock()
 
-	return compressedLiveTail(tail)
+	return liveTailCompressor(tail)
 }
 
 func compressedLiveTail(tail []byte) []byte {

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -424,7 +424,7 @@ func (w *liveTailSaver) FlushCompressed() []byte {
 	}
 
 	tail := w.tail
-	w.tail = nil
+	w.tail = w.tail[:0]
 	w.dirty = false
 
 	return compressedLiveTail(tail)

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"math/rand"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -101,6 +102,60 @@ func TestLiveTailSaver(t *testing.T) {
 
 		_, err = saver.Write([]byte("new\n"))
 		So(err, ShouldBeNil)
+		So(decompressLiveTail(saver.FlushCompressed()), ShouldResemble, []byte("new\n"))
+	})
+
+	Convey("A live tail saver lets writes continue while flushing compressed output", t, func() {
+		saver := &liveTailSaver{}
+
+		_, err := saver.Write([]byte("old\n"))
+		So(err, ShouldBeNil)
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		originalCompressor := liveTailCompressor
+
+		liveTailCompressor = func(tail []byte) []byte {
+			close(started)
+			<-release
+
+			return originalCompressor(tail)
+		}
+		defer func() {
+			liveTailCompressor = originalCompressor
+		}()
+
+		flushed := make(chan []byte, 1)
+		go func() {
+			flushed <- saver.FlushCompressed()
+		}()
+
+		<-started
+
+		writeDone := make(chan error, 1)
+
+		go func() {
+			_, writeErr := saver.Write([]byte("new\n"))
+			writeDone <- writeErr
+		}()
+
+		writeCompleted := false
+
+		select {
+		case writeErr := <-writeDone:
+			So(writeErr, ShouldBeNil)
+
+			writeCompleted = true
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		close(release)
+		So(writeCompleted, ShouldBeTrue)
+
+		flushedCompressed := <-flushed
+		liveTailCompressor = originalCompressor
+
+		So(decompressLiveTail(flushedCompressed), ShouldResemble, []byte("old\n"))
 		So(decompressLiveTail(saver.FlushCompressed()), ShouldResemble, []byte("new\n"))
 	})
 }

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -34,6 +34,10 @@ import (
 )
 
 func TestLiveTailSaver(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
 	Convey("A live tail saver flushes a compressed recent tail", t, func() {
 		saver := &liveTailSaver{}
 

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestLiveTailSaver(t *testing.T) {
+	Convey("A live tail saver flushes a compressed recent tail", t, func() {
+		saver := &liveTailSaver{}
+
+		n, err := saver.Write([]byte("one\n"))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, len("one\n"))
+
+		compressed := saver.FlushCompressed()
+		So(compressed, ShouldNotBeNil)
+		So(len(compressed), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+		So(decompressLiveTail(compressed), ShouldResemble, []byte("one\n"))
+	})
+
+	Convey("A live tail saver returns nil when flushed twice without more writes", t, func() {
+		saver := &liveTailSaver{}
+
+		_, err := saver.Write([]byte("one\n"))
+		So(err, ShouldBeNil)
+		So(saver.FlushCompressed(), ShouldNotBeNil)
+		So(saver.FlushCompressed(), ShouldBeNil)
+	})
+
+	Convey("A live tail saver bounds incompressible output to a compressed suffix", t, func() {
+		written := deterministicLiveBytes(liveStdRawTailLimit)
+		saver := &liveTailSaver{}
+
+		n, err := saver.Write(written)
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, len(written))
+
+		compressed := saver.FlushCompressed()
+		So(compressed, ShouldNotBeNil)
+		So(len(compressed), ShouldBeLessThanOrEqualTo, liveStdCompressedLimit)
+
+		decompressed := decompressLiveTail(compressed)
+		So(decompressed, ShouldNotBeEmpty)
+		So(bytes.HasSuffix(written, decompressed), ShouldBeTrue)
+	})
+
+	Convey("A live tail saver keeps the newest marker and drops old output", t, func() {
+		saver := &liveTailSaver{}
+
+		_, err := saver.Write([]byte("UNIQUE-PREFIX\n"))
+		So(err, ShouldBeNil)
+		_, err = saver.Write(deterministicLiveBytes(2 * liveStdRawTailLimit))
+		So(err, ShouldBeNil)
+		_, err = saver.Write([]byte("UNIQUE-SUFFIX\n"))
+		So(err, ShouldBeNil)
+
+		decompressed := decompressLiveTail(saver.FlushCompressed())
+		So(string(decompressed), ShouldContainSubstring, "UNIQUE-SUFFIX\n")
+		So(string(decompressed), ShouldNotContainSubstring, "UNIQUE-PREFIX\n")
+	})
+
+	Convey("A live tail saver resets after each flush", t, func() {
+		saver := &liveTailSaver{}
+
+		_, err := saver.Write([]byte("old\n"))
+		So(err, ShouldBeNil)
+		So(saver.FlushCompressed(), ShouldNotBeNil)
+
+		_, err = saver.Write([]byte("new\n"))
+		So(err, ShouldBeNil)
+		So(decompressLiveTail(saver.FlushCompressed()), ShouldResemble, []byte("new\n"))
+	})
+}
+
+func decompressLiveTail(compressed []byte) []byte {
+	decompressed, err := decompress(compressed)
+	So(err, ShouldBeNil)
+
+	return decompressed
+}
+
+//nolint:gosec // deterministic test data must be reproducible.
+func deterministicLiveBytes(size int) []byte {
+	r := rand.New(rand.NewSource(1))
+
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(r.Intn(256))
+	}
+
+	return data
+}


### PR DESCRIPTION
Solves #98

## Summary
- Send live resource usage and bounded stdout/stderr tails through job touch/status/subscription paths.
- Surface live fields through REST and websocket status details with the requested auth/HTTPS gating.
- Add a copyable SSH command and live introspection display to the web UI.

## Spec and phases
- .docs/issue-98/spec.md
- .docs/issue-98/phase1.md
- .docs/issue-98/phase2.md
- .docs/issue-98/phase3.md
- .docs/issue-98/phase4.md

## Verification
- CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run 'TestJob$|TestREST$|TestManagerLiveJTouch$|TestLiveJobSubscriptions$|TestStatusDetailsLiveCompatibility$|TestStatusDetailsLiveFields$|TestStatusDetailsLivePushUpdates$|TestStatusPageLiveIntrospectionAssets$|TestStatusPageLivePushUpdateBehaviour$'
- golangci-lint run
