### PR TITLE
Fix a finished job showing as running for ever in the web UI

### DIFF
--- a/.docs/bugfixes/260829-2-incidental.md
+++ b/.docs/bugfixes/260829-2-incidental.md
@@ -22,7 +22,7 @@ Note the test-suite cleanup fixes (temp-dir reaping, fuse-mount reaping, the
 shared-`/tmp` deletion) live on the `reliable4` branch, not here, so a suite run
 in this clone leaks `/tmp/wrtest*` directories until those land.
 
-- [ ] The web UI can show a completed job as **running for ever**.
+- [x] The web UI can show a completed job as **running for ever**.
 
       A job that finishes within ~1-50 ms of starting can have its job-details row
       left in the running state after it has completed, until the user navigates
@@ -51,3 +51,43 @@ in this clone leaks `/tmp/wrtest*` directories until those land.
     `State` - was rejected because `hasClientSubscriptionsForJobUpdate` filters on
     the transition state, so a subscriber asking for `running` would start
     receiving `complete` payloads, changing subscription semantics.
+  - a worse symptom than first recorded: `handleJobDetailsMessage` then calls
+    `setupLiveWalltime`, and `utility.js:241` starts a 1-second ticker whenever
+    `job.State === "running"`. So the stale row does not merely say running - its
+    walltime counts up for ever.
+  - the chain was confirmed against the running product, not by reading alone:
+    `TestLateRunningSubscriptionUpdatePayload` drives a real server through
+    add/reserve/execute to completion, then asks `statusFromSubscriptionUpdate`
+    for a `running` update on that key. The payload comes back `State: running`
+    with `Exited: true` and a non-nil `Ended` - self-contradictory, exactly as
+    predicted.
+  - **The discriminator is payload self-consistency, not ordering:**
+    `update.State === 'running' && update.Exited === true`. `State` is the only
+    field taken from the transition; every other field is a fresh snapshot read at
+    write time, so when they disagree, believe the snapshot.
+  - "never leave a terminal state" was rejected: a job legitimately returns to
+    running on `wr retry`, a dependency re-run or a lost-job re-attempt.
+    `Attempts` was rejected because `resetCompletedJobForRerun` sets it to 0, so
+    it is not monotonic and would reject the legitimate case. `Started` was
+    rejected because heartbeat updates carry no `Started`/`Ended`, so the old
+    run's timestamp would persist. `Exited` works because
+    `resetJobForReservation` clears it at Reserve, before a job can be running
+    again - so running+Exited is unreachable for a genuine attempt and guaranteed
+    for the stale duplicate, since `archiveCompletedJob` writes to the DB before
+    `q.Remove` fires the complete callback.
+  - a gate on the EXISTING row being terminal was written and then removed: no
+    test justified it, and it makes a real case worse - a failed job released for
+    retry shows `ready`, and its own stale `running` should still be dropped.
+  - red: `go test -tags netgo ./jobqueue -run TestStatusPageStaleRunningPushUpdate`,
+    driving the real handler in a node `vm` context, which is the mechanism the
+    flicker fix used and so runs inside plain `make test`. Both clauses of the
+    predicate were mutation-tested: dropping the `State` check fails "the complete
+    push update was not applied"; dropping `Exited` fails "a genuine re-run must be
+    able to leave a terminal state".
+  - gates: `make test` 360 passed / 9 skipped, `make browser-test` all 8 fixtures,
+    `make lint` 0 issues.
+  - NOT fixed, recorded instead: a stale `running` after a job is **deleted**
+    mid-flight. That job is in neither the queue nor the complete bucket, so
+    `statusFromSubscriptionUpdate` falls back to `statusFromJobUpdate`, whose
+    payload has no `Exited` field at all. A rarer shape, and guessing at it would
+    have meant an unjustified clause.

--- a/.docs/bugfixes/260829-2-incidental.md
+++ b/.docs/bugfixes/260829-2-incidental.md
@@ -1,0 +1,53 @@
+# Incidental bugfixes (branch `incidental-fixes`)
+
+Bugs found while working on something else, kept off the LSF-scale reliability
+branch so that branch stays reviewable and this work is not held up behind it.
+
+**Filename convention for this branch.** The repo allocates checklists as
+`YYMMDD-N.md`, so several branches in flight will each reach for the same next
+number and collide as an add/add conflict on a file with no shared content - which
+is exactly what happened between `reliable4` and develop's `260828-1.md`. This
+file therefore carries a `-incidental` suffix that no sequence allocator will
+generate. Anything added here appends to this one file; it does not take a new
+number.
+
+Quality gates (run with ALL `OS_*` unset, or they take ~16 minutes and run the
+OpenStack tests):
+
+- `make test`
+- `make race` (needs `CGO_ENABLED=1`)
+- `make lint`
+
+Note the test-suite cleanup fixes (temp-dir reaping, fuse-mount reaping, the
+shared-`/tmp` deletion) live on the `reliable4` branch, not here, so a suite run
+in this clone leaks `/tmp/wrtest*` directories until those land.
+
+- [ ] The web UI can show a completed job as **running for ever**.
+
+      A job that finishes within ~1-50 ms of starting can have its job-details row
+      left in the running state after it has completed, until the user navigates
+      away. Nothing heals it: the only interval in the UI is a walltime ticker, and
+      no push update follows a terminal state.
+
+      Chain: `queue.changed` (`queue/queue.go:565`) runs each transition's change
+      callback in its own goroutine; only the `running` transition waits, in
+      `waitForJobStartTime` (`jobqueue/jobtransition.go` ~268, polling 1ms x 50),
+      so `complete` can overtake `running`. `statusFromSubscriptionUpdate`
+      (`jobqueue/serverWebI.go:305`) then sets `status.State` from the
+      **transition's** state rather than the fresh snapshot's, so the late message
+      really does say `running`, and `mergeJobDetailsPushUpdate`
+      (`jobqueue/static/js/wr/websocket-handler.js:431`) is `Object.assign`, so
+      `State` is last-write-wins.
+
+  - found while fixing a load flake in `TestJobSubscriptions` on the `reliable4`
+    branch (`.docs/bugfixes/260827-2.md` items 12 and 15 there). That test was the
+    product telling us the feed does not promise per-job ordering; the test fix
+    stopped asserting an ordering the product does not provide, and this is the
+    user-visible half.
+  - **fixed client-side, deliberately.** `DEVELOPERS.md` rule 10 is the precedent:
+    the web status-bar flicker/overcount was fixed purely client-side in this same
+    file with no server change, to keep the server's reliability constraints
+    untouched. The server-side alternative - not overwriting the snapshot's
+    `State` - was rejected because `hasClientSubscriptionsForJobUpdate` filters on
+    the transition state, so a subscriber asking for `running` would start
+    receiving `complete` payloads, changing subscription semantics.

--- a/.docs/bugfixes/260829-2-incidental.md
+++ b/.docs/bugfixes/260829-2-incidental.md
@@ -88,6 +88,8 @@ in this clone leaks `/tmp/wrtest*` directories until those land.
     `make lint` 0 issues.
   - NOT fixed, recorded instead: a stale `running` after a job is **deleted**
     mid-flight. That job is in neither the queue nor the complete bucket, so
-    `statusFromSubscriptionUpdate` falls back to `statusFromJobUpdate`, whose
-    payload has no `Exited` field at all. A rarer shape, and guessing at it would
-    have meant an unjustified clause.
+    `statusFromSubscriptionUpdate` falls back to `statusFromJobUpdate`, which
+    never sets `Exited` - the field is on `JStatus` (`serverWebI.go:232`) and so
+    is always sent, but at its zero value `false`. So the fallback payload cannot
+    report an exited snapshot, and the guard cannot fire on it. A rarer shape, and
+    guessing at it would have meant an unjustified clause.

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -160,6 +160,58 @@ func TestCaster(t *testing.T) {
 	})
 }
 
+// TestLateRunningSubscriptionUpdatePayload pins the payload a status page
+// receives when a running transition update is delivered after the job it
+// describes has already finished. Only State comes from the transition; every
+// other field is a fresh snapshot of the job taken when the update is sent, so
+// the payload contradicts itself, claiming a running job that has exited. That
+// contradiction is what the status page keys on to recognise the update as stale
+// (see TestStatusPageStaleRunningPushUpdate).
+func TestLateRunningSubscriptionUpdatePayload(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(true)
+
+	Convey("A running subscription update sent after its job finished reports an exited job", t, func() {
+		server, _, token, errs := serve(ctx, serverConfig)
+		So(errs, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		inserts, _, err := jq.Add([]*Job{{
+			Cmd: webiEcho1, Cwd: testCwd, ReqGroup: webiRG1,
+			Requirements: standardReqs, RepGroup: webiRG1,
+		}}, envVars, true)
+		So(err, ShouldBeNil)
+		So(inserts, ShouldEqual, 1)
+
+		job, err := jq.Reserve(50 * time.Millisecond)
+		So(err, ShouldBeNil)
+		So(jq.Execute(ctx, job, config.RunnerExecShell), ShouldBeNil)
+
+		status := server.statusFromSubscriptionUpdate(ctx, &JobUpdate{
+			Kind:     JobUpdateStateChange,
+			Key:      job.Key(),
+			RepGroup: webiRG1,
+			State:    JobStateRunning,
+			Started:  jobUnixNano(job.StartTime),
+			Ended:    jobUnixNano(job.EndTime),
+		})
+		So(status, ShouldNotBeNil)
+		So(status.State, ShouldEqual, JobStateRunning)
+		So(status.Exited, ShouldBeTrue)
+		So(status.Ended, ShouldNotBeNil)
+	})
+}
+
 type expectedJStateCount struct {
 	repGroup string
 	state    JobState
@@ -3277,50 +3329,7 @@ func TestStatusPageLivePushUpdateBehaviour(t *testing.T) {
 }
 
 func statusPageLivePushUpdateScript() string {
-	return `
-const fs = require('fs');
-const vm = require('vm');
-
-let source = fs.readFileSync('static/js/wr/websocket-handler.js', 'utf8');
-source = source
-    .replace(/^import .*;\n/gm, '')
-    .replace(/export function /g, 'function ');
-
-const context = {
-    console,
-    createRepGroupTracker() {
-        return {};
-    },
-    setupLiveWalltime(job, walltime) {
-        job.LiveWalltime = () => walltime;
-    }
-};
-context.globalThis = context;
-vm.createContext(context);
-vm.runInContext(source + '\nglobalThis.handleJobDetailsMessage = handleJobDetailsMessage;', context,
-    { filename: 'websocket-handler.js' });
-
-function observableArray(initial) {
-    const values = initial.slice();
-    function observable(next) {
-        if (arguments.length > 0) {
-            values.splice(0, values.length, ...next);
-            return values;
-        }
-
-        return values;
-    }
-    observable.push = value => values.push(value);
-    observable.splice = (...args) => values.splice(...args);
-    return observable;
-}
-
-function assert(condition, message) {
-    if (!condition) {
-        throw new Error(message);
-    }
-}
-
+	return statusPageHandlerHarnessPreamble() + `
 const sshCommand = "ssh -- ubuntu@10.0.0.8 'cd /tmp/wr/job1 && exec ${SHELL:-/bin/sh} -l'";
 const existing = {
     Key: 'k',
@@ -3510,4 +3519,217 @@ func repoRootForWebUITest(t *testing.T) string {
 	So(err, ShouldBeNil)
 
 	return filepath.Dir(wd)
+}
+
+// TestStatusPageStaleRunningPushUpdate guards a job details row against the
+// running push update that arrives AFTER the job's terminal one. The server runs
+// every transition's change callback in its own goroutine (queue.changed) and
+// delays only the running one, polling for the job's start time
+// (enqueueChangeCallbackSubscriptions -> waitForJobStartTime), so a job that
+// finishes within a few milliseconds of starting delivers complete first and
+// running second. Only the payload's State comes from the transition; every
+// other field is a fresh snapshot of the finished job
+// (statusFromSubscriptionUpdate), and no push update follows a terminal state,
+// so applying that late State left the row running for ever with its walltime
+// ticking up.
+func TestStatusPageStaleRunningPushUpdate(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node is required to exercise the status page JavaScript")
+	}
+
+	Convey("Status page details rows ignore a running push update from a run that already ended", t, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		//nolint:gosec // The Node script is a constant test harness.
+		cmd := exec.CommandContext(ctx, "node", "-e", statusPageStaleRunningPushUpdateScript())
+		output, err := cmd.CombinedOutput()
+		So(string(output), ShouldBeBlank)
+		So(err, ShouldBeNil)
+	})
+}
+
+func statusPageStaleRunningPushUpdateScript() string {
+	return statusPageHandlerHarnessPreamble() + `
+const started = 1750000000;
+const ended = started + 1;
+const rerunStarted = ended + 120;
+
+// The payload the status page receives for one transition: State comes from the
+// transition, every other field from the fresh snapshot taken when it was sent.
+function push(state, snapshot) {
+    return Object.assign({
+        Key: 'k',
+        RepGroup: 'rg1',
+        IsPushUpdate: true,
+        Cmd: 'true',
+        Attempts: 1,
+        Cores: 1,
+        ExpectedRAM: 100,
+        ExpectedTime: 60
+    }, snapshot, { State: state });
+}
+
+const finishedRun = {
+    Exited: true,
+    Exitcode: 0,
+    PeakRAM: 12,
+    CPUtime: 0.001,
+    Walltime: 0.004,
+    Started: started,
+    Ended: ended
+};
+const failedRun = Object.assign({}, finishedRun, { Exitcode: 1 });
+const freshAttempt = {
+    Exited: false,
+    Exitcode: 0,
+    PeakRAM: 0,
+    CPUtime: 0,
+    Walltime: 0,
+    Started: rerunStarted,
+    Ended: null
+};
+
+function viewModelShowing(state) {
+    const finished = state !== 'running';
+
+    return {
+        detailsRepgroup: 'rg1',
+        detailsOA: observableArray([{
+            Key: 'k',
+            RepGroup: 'rg1',
+            State: state,
+            Exited: finished,
+            Exitcode: 0,
+            Walltime: finished ? 0.004 : 0,
+            Started: started,
+            Ended: finished ? ended : null,
+            Cmd: 'true',
+            Attempts: 1,
+            LiveWalltimeIsTicking: !finished
+        }]),
+        isSearchMode: () => false,
+        repGroups: [{ id: 'rg1' }],
+        newJobsInfo: {}
+    };
+}
+
+function row(viewModel) {
+    return viewModel.detailsOA()[0];
+}
+
+// A job that finished within milliseconds of starting: its complete update
+// arrives first, then its own running update arrives carrying the same finished
+// snapshot.
+const fast = viewModelShowing('running');
+context.handleJobDetailsMessage(fast, push('complete', finishedRun));
+
+assert(row(fast).State === 'complete', 'the complete push update was not applied');
+assert(row(fast).LiveWalltimeIsTicking === false, 'a complete row must not tick its walltime');
+
+context.handleJobDetailsMessage(fast, push('running', finishedRun));
+
+assert(fast.detailsOA().length === 1, 'the late running push update must not add a row');
+assert(row(fast).State === 'complete',
+    'a running push update whose own snapshot says the job exited must not revive the row');
+assert(row(fast).Ended === ended, 'the completed row must keep its end time');
+assert(row(fast).LiveWalltimeIsTicking === false,
+    'a stale running push update must not restart the live walltime of a finished job');
+
+// The same late update against a job whose run ended buried instead of complete.
+const failed = viewModelShowing('running');
+context.handleJobDetailsMessage(failed, push('buried', failedRun));
+
+assert(row(failed).State === 'buried', 'the buried push update was not applied');
+
+context.handleJobDetailsMessage(failed, push('running', failedRun));
+
+assert(row(failed).State === 'buried',
+    'a running push update whose own snapshot says the job exited must not revive a buried row');
+
+// A failed job released for a retry reaches ready before its own late running
+// update arrives, and it is not running then either.
+const retried = viewModelShowing('running');
+context.handleJobDetailsMessage(retried, push('ready', failedRun));
+
+assert(row(retried).State === 'ready', 'the ready push update was not applied');
+
+context.handleJobDetailsMessage(retried, push('running', failedRun));
+
+assert(row(retried).State === 'ready',
+    'a running push update whose own snapshot says the job exited must not claim a queued job is running');
+
+// A genuine new attempt has its exited flag cleared when the job is reserved, so
+// its running update is applied and the row leaves the terminal state.
+const rerun = viewModelShowing('complete');
+context.handleJobDetailsMessage(rerun, push('running', freshAttempt));
+
+assert(row(rerun).State === 'running', 'a genuine re-run must be able to leave a terminal state');
+assert(row(rerun).Started === rerunStarted, 'a genuine re-run must show its own start time');
+assert(row(rerun).LiveWalltimeIsTicking === true, 'a genuine re-run must tick its live walltime');
+
+// A buried job kicked back onto the queue still carries the failed run's exited
+// flag until a runner reserves it, so its ready update must still be applied.
+const kicked = viewModelShowing('buried');
+context.handleJobDetailsMessage(kicked, push('ready', failedRun));
+
+assert(row(kicked).State === 'ready', 'a kicked buried job must be able to show as ready again');
+`
+}
+
+// statusPageHandlerHarnessPreamble loads the real websocket-handler.js into a
+// Node vm context that exposes handleJobDetailsMessage, plus the observableArray
+// and assert helpers the scripts driving it need. The stubbed setupLiveWalltime
+// records whether it started a live (running) walltime or a static one, so a
+// script can tell a revived row from a finished one.
+func statusPageHandlerHarnessPreamble() string {
+	return `
+const fs = require('fs');
+const vm = require('vm');
+
+let source = fs.readFileSync('static/js/wr/websocket-handler.js', 'utf8');
+source = source
+    .replace(/^import .*;\n/gm, '')
+    .replace(/export function /g, 'function ');
+
+const context = {
+    console,
+    createRepGroupTracker() {
+        return {};
+    },
+    setupLiveWalltime(job, walltime) {
+        job.LiveWalltime = () => walltime;
+        job.LiveWalltimeIsTicking = job.State === 'running';
+    }
+};
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(source + '\nglobalThis.handleJobDetailsMessage = handleJobDetailsMessage;', context,
+    { filename: 'websocket-handler.js' });
+
+function observableArray(initial) {
+    const values = initial.slice();
+    function observable(next) {
+        if (arguments.length > 0) {
+            values.splice(0, values.length, ...next);
+            return values;
+        }
+
+        return values;
+    }
+    observable.push = value => values.push(value);
+    observable.splice = (...args) => values.splice(...args);
+    return observable;
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+`
 }

--- a/jobqueue/static/js/wr/websocket-handler.js
+++ b/jobqueue/static/js/wr/websocket-handler.js
@@ -380,7 +380,44 @@ function livePushValue(value, fallback) {
     return value;
 }
 
+/**
+ * Reports whether a push update claims a job is running while its own snapshot
+ * says that job has already exited.
+ *
+ * The server runs every state transition's callback in its own goroutine and
+ * delays only the running one, polling for the job's start time to be recorded,
+ * so a job that finishes within milliseconds of starting delivers its terminal
+ * update first and its running update second. Only State comes from the
+ * transition; every other field is a fresh snapshot of the job taken when the
+ * update was sent, so that late update contradicts itself. Applying it leaves
+ * the row running for ever with its walltime ticking up, because no push update
+ * follows a terminal state.
+ *
+ * A job is reserved before it can run again, and being reserved clears its
+ * exited flag, so a genuine re-run (wr retry, a dependency re-run, a lost job
+ * re-attempt) never looks like this. Running is also the only live state a job
+ * reaches by being reserved: a job kicked or released back onto the queue still
+ * reports the failed run's exited flag while it is ready or delayed, so those
+ * updates must not be judged this way.
+ *
+ * @param {object} update - The incoming push update
+ * @returns {boolean} True if the update describes a run that already ended
+ */
+function runningPushUpdateOfExitedJob(update) {
+    return update.State === 'running' && update.Exited === true;
+}
+
+/**
+ * Applies a push update to the job details currently displayed for that job.
+ * @param {object} existing - The job details currently displayed
+ * @param {object} update - The incoming push update
+ * @returns {object} The merged details, or existing itself if nothing applied
+ */
 function mergeJobDetailsPushUpdate(existing, update) {
+    if (runningPushUpdateOfExitedJob(update)) {
+        return existing;
+    }
+
     const merged = Object.assign({}, existing, update);
 
     if (update.State === 'running' || update.State === 'reserved') {
@@ -448,6 +485,11 @@ function handleJobDetailsMessage(viewModel, json) {
             for (const job of jobs) {
                 if (job.Key === json.Key) {
                     const merged = mergeJobDetailsPushUpdate(job, json);
+                    if (merged === job) {
+                        // the update was rejected, so the row keeps the walltime
+                        // it already has and needs no re-render
+                        return;
+                    }
 
                     // Set up LiveWalltime for the job
                     setupLiveWalltime(merged, merged['Walltime'], viewModel);


### PR DESCRIPTION
A job that completes within ~1-50ms of starting can leave its web-UI job-details row in the **running** state permanently, with its walltime ticking up for ever.

Found while fixing a load flake in `TestJobSubscriptions` on the `reliable4` branch. That test was the product telling us the push feed does not promise per-job state ordering; the test fix stopped asserting an ordering the product does not provide, and this PR is the user-visible half.

This is the first PR on a branch for **incidental** bugs — ones found while working on something else — kept off the large LSF-scale reliability branch so neither holds the other up.

## The chain, confirmed against the running product

1. `queue.changed` (`queue/queue.go:537`) runs each transition's change callback in **its own goroutine**.
2. Only the `running` one is delayed: `jobqueue/jobtransition.go:267` calls `waitForJobStartTime`, polling 50 x 1ms. It fires at **Reserve**, while `StartTime` is only set later by the `Started` RPC.
3. So `complete` — which has no delay — can overtake `running`.
4. `statusFromSubscriptionUpdate` (`jobqueue/serverWebI.go:276`) takes a **fresh snapshot** and then overwrites `status.State` with the **transition's** state, so the late message genuinely says `running`.
5. `mergeJobDetailsPushUpdate` was `Object.assign({}, existing, update)` — last-write-wins on `State`. Nothing heals it: no push update follows a terminal state, and the only UI interval is a walltime ticker.
6. Worse, `handleJobDetailsMessage` then calls `setupLiveWalltime`, and `utility.js:241` starts a 1-second ticker whenever `State === "running"`.

Not reasoned alone: `TestLateRunningSubscriptionUpdatePayload` drives a real server through add/reserve/execute to completion, then asks `statusFromSubscriptionUpdate` for a `running` update on that key. The payload comes back `State: running` with `Exited: true` and a non-nil `Ended` — self-contradictory, exactly as predicted.

## Fixed client-side, deliberately

`DEVELOPERS.md` rule 10 is the precedent: the status-bar flicker/overcount was fixed purely client-side in this same file, with no server change, to keep the server's reliability constraints untouched.

The server-side alternative — not overwriting the snapshot's `State` — was rejected because `hasClientSubscriptionsForJobUpdate` filters on the transition state, so a subscriber asking for `running` would start receiving `complete` payloads, changing subscription semantics.

## The discriminator is the payload contradicting itself, not ordering

`update.State === 'running' && update.Exited === true`.

`State` is the only field taken from the transition; every other field is a fresh snapshot read at write time. When they disagree, believe the snapshot.

It cannot reject a genuine re-run (`wr retry`, a dependency re-run, a lost-job re-attempt), because `resetJobForReservation` clears `Exited` at Reserve, before a job can be `running` again. It always catches the stale duplicate, because `archiveCompletedJob` writes to the database **before** `q.Remove` fires the complete callback.

Alternatives rejected on evidence:

- **`Attempts`** — `resetCompletedJobForRerun` sets it to 0, so it is not monotonic and would reject the legitimate re-run.
- **`Started`** — heartbeat updates carry no `Started`/`Ended`, so the old run's timestamp would persist for ever.
- **Gating on the existing row being terminal** — written, then removed: no test justified it, and it makes a real case worse (a failed job released for retry shows `ready`, and its own stale `running` should still be dropped).

If the guard ever mis-fires, the cost is one dropped update, healed by the next heartbeat or terminal update. It cannot wedge a row.

## Testing

`jobqueue/static/js/wr/` has no JS test runner. The repo's precedent (the flicker fix) is a Go test loading the real handler into a node `vm` context, so this follows that and runs inside plain `make test`.

Red: `go test -tags netgo ./jobqueue -run TestStatusPageStaleRunningPushUpdate`

```
Error: a running push update whose own snapshot says the job exited must not revive the row
--- FAIL: TestStatusPageStaleRunningPushUpdate
```

Both clauses of the predicate were mutation-tested, since a two-clause guard can silently over- or under-fire:

| mutation | result |
|---|---|
| drop the `State` check | FAIL — the complete push update was not applied |
| drop the `Exited` check | FAIL — a genuine re-run must be able to leave a terminal state |

Gates: `make test` 360 passed / 9 skipped; `make race` 360 passed / 8 skipped; `make lint` 0 issues; `make browser-test` all 8 Playwright fixtures.

## Known limitation, recorded not guessed at

A job **deleted** mid-flight is in neither the queue nor the complete bucket, so the payload falls back to `statusFromJobUpdate`, which never sets `Exited` — the field is on `JStatus` and so is always sent, but at its zero value `false`, so the fallback cannot report an exited snapshot and the guard cannot fire on it. For that to matter, a stale `running` would have to arrive after a `deleted` update, needing the job deleted within the ~50ms window of being reserved. I could not show that is reachable, so it is documented rather than fixed with an unjustified clause.
