### PR TITLE
Fix pre-existing lost-job bugs: kill the run that was lost, not whatever is there later

### DIFF
--- a/.docs/bugfixes/260831-1.md
+++ b/.docs/bugfixes/260831-1.md
@@ -501,7 +501,7 @@ and then hung the job for ever.
     makes two submissions of one command one job, and changing it changes what a
     job IS.
 - [ ] Recorded by round 12, NOT fixed:
-  - **`lostJobRetryCheck` never fires for a reserved-not-started run, because
+  - [x] **`lostJobRetryCheck` never fires for a reserved-not-started run, because
     `Job.State` is the previous run's** (server.go:2337). `State` is set at
     `Started` and at each exit, never at Reserve, so through a whole reservation
     it still says `delayed` (measured: `TestKillingALostJobSparesTheRunThatReplacesIt`
@@ -517,6 +517,39 @@ and then hung the job for ever.
     `markJobComplete` deliberately leaves open, where the item is still in the
     run sub-queue with `Lost` set and `State` already `complete`. Not attempted
     under this brief.
+    - **Fixed here**, by the one-line repair the item names: the gate is now
+      `job.Exited || !job.Lost`, which is the same "is this run over?" question
+      `ttrCallback` asks in the lines that declare the job lost in the first
+      place. A reserved-not-started run passes it, because
+      `resetJobForReservation` clears `Exited`; the stretch `markJobComplete`
+      leaves open is still REFUSED, because `applySuccessfulEndStateLocked` sets
+      it - so an archived run parked in the run sub-queue with `Lost` set is
+      turned away exactly as the old gate turned it away. `Job.State` is now
+      read nowhere in this path, so nothing in it depends on a field that
+      describes the run before.
+    - Red command:
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -v -run TestLostJobRetryCheckFindsAReservedNotStartedRun`.
+      On the unfixed tree it failed at `lost_job_behaviours_test.go:822`
+      (`So(checked, ShouldBeTrue)`) with `Expected: true` / `Actual: false`, 37
+      total assertions. The assertion two lines above it PASSED on that same
+      run: `l.live.State` really did read `delayed` while the manager reported
+      the reservation `lost`, which is the staleness itself.
+    - Files touched: `jobqueue/server.go` (the gate, and why it asks `Exited`),
+      `jobqueue/lost_job_behaviours_test.go`
+      (`TestLostJobRetryCheckFindsAReservedNotStartedRun`).
+    - The test asserts BOTH halves, so the gate cannot simply be deleted: a
+      lost, reserved-not-started run IS picked up, and pinned as ITSELF -
+      `retry.pin.run` is the run at the queue, its `actualCwd` is blank (so the
+      cleanup it carries resolves to no workspace and deletes nothing) and its
+      pid is the reserving runner's, which is what makes a second
+      `confirmJobDead` worth making; and a lost run whose `Exited` is set is
+      refused. Guard mutations, both still compiling (`go vet` after each): the
+      old `job.State != JobStateRunning` gate restored - half (a) RED at line
+      822; the `Exited` term dropped, leaving `!job.Lost` alone - half (b) RED
+      at line 846.
+    - Gates on the fixed tree: `make test` `410 passed / 9 skipped`, `make race`
+      `410 passed / 9 skipped`, `make lint` `0 issues.` - one test more than the
+      409 this branch stood at.
   - **A run that FAILS before `Started` leaks its workspace too, and the runner
     could clean it up itself.** `Client.Execute`'s mount, env, docker and
     `cmd.Start` failure paths return through `buryWrapErr`/`Bury`/`Release`

--- a/.docs/bugfixes/260831-1.md
+++ b/.docs/bugfixes/260831-1.md
@@ -630,6 +630,16 @@ and then hung the job for ever.
       `Job.Unmount`'s own empty-dir tidy-up takes the empty working directory
       and the levels above it, and the proven cleanup takes the TMPDIR, between
       them leaving nothing. Both are asserted.
+    - **A pinned `run` behaviour no longer fires on the three RESERVED paths, and
+      that is deliberate.** On `createLSFSymlinks`, `addBsubEnv` and
+      `setupDockerMonitor`, an `on_failure`/`on_exit` `run` used to execute in the
+      leaked working directory once the manager confirmed the run dead; the runner
+      has now reclaimed it, so `proveActualCwd` refuses it under `absenceRefused`.
+      That makes all seven pre-start paths consistent rather than splitting them:
+      `Client.Execute` calls `TriggerBehaviours` only after `cmd.Start()` has
+      succeeded, so the four paths that bury or release never ran user behaviours
+      either, and these three only did by accident of the job going lost. A
+      `cleanup` behaviour is unaffected, since absence is tolerated for it.
     - Gates on the fixed tree: `make test` `412 passed / 9 skipped`, `make race`
       `412 passed / 9 skipped`, `make lint` `0 issues.` - two tests more than
       the 410 this branch stood at: `TestClientExecuteUnstartedRunWorkSpace` and

--- a/.docs/bugfixes/260831-1.md
+++ b/.docs/bugfixes/260831-1.md
@@ -550,7 +550,7 @@ and then hung the job for ever.
     - Gates on the fixed tree: `make test` `410 passed / 9 skipped`, `make race`
       `410 passed / 9 skipped`, `make lint` `0 issues.` - one test more than the
       409 this branch stood at.
-  - **A run that FAILS before `Started` leaks its workspace too, and the runner
+  - [x] **A run that FAILS before `Started` leaks its workspace too, and the runner
     could clean it up itself.** `Client.Execute`'s mount, env, docker and
     `cmd.Start` failure paths return through `buryWrapErr`/`Bury`/`Release`
     without ever calling `TriggerBehaviours`, and the `os.RemoveAll(tmpDir)`
@@ -560,6 +560,85 @@ and then hung the job for ever.
     knows the directory, so this one is free to fix - but running the OnFailure
     behaviours there would execute the user's `run` command on a mount failure,
     which is a semantic change and wants its own brief.
+    - **Fixed - and it was SEVEN paths, not three.** Every return between
+      `resolveWorkingDir` and a successful `cmd.Start()` abandons the workspace,
+      and the four this item named are not the whole set (line numbers at
+      `906694f`): the lsf emulation `MkdirTemp` (1626, buries),
+      `createLSFSymlinks` (1634, neither buries nor releases), `job.Mount`
+      (1675, buries without unmounting), `job.Env` (1704, buries), `addBsubEnv`
+      (1722, neither), `setupDockerMonitor` (1734, neither) and `cmd.Start`
+      (1753, releases). Three of the seven leave the job RESERVED, so not even a
+      bury records what happened.
+    - **The live-mount hazard dictated the shape: unmount FIRST, and on a failed
+      unmount delete NOTHING.** For a job whose `MountConfig.Mount` is
+      unspecified the mount point IS the working directory, and 1722 and 1734
+      return with the mounts still live and no unmount at all, so an
+      `os.RemoveAll` there would recurse into a live FUSE mount and delete the
+      user's REMOTE data. A leaked workspace is recoverable; that is not. The
+      deletion is therefore the PROVEN path and nothing else:
+      `jobWorkSpaceSnapshot`'s new `cleanupWorkSpace`, which `Behaviour.cleanup`
+      now also calls, so there is one answer to what a Job's workspace cleanup
+      does and it still refuses a `--cwd_matters` job and still proves the
+      directory is the one `mkHashedDir` built for this job's key.
+    - **One armed defer, not seven patches.** `Execute` arms a single `defer`
+      immediately after `resolveWorkingDir` succeeds, guarded by
+      `actualCwd == ""` so it does nothing for a `--cwd_matters` job, and
+      disarms it (`cmdStarted = true`) immediately after `cmd.Start()` returns
+      nil - from which instant the `c.Started` failure path and the normal exit
+      path own the workspace through `TriggerBehaviours`. The `cmd.Start()`
+      FAILURE path is still covered, since it only releases. Any path added
+      later is covered too.
+    - **The job's behaviours are NOT run.** `OnFailure` would execute the user's
+      `run` command on a mount failure, which is the semantic change this item
+      ruled out. Only what wr created goes.
+    - **A defer cannot report here**, so it does not pretend to: `myerr` is a
+      plain local returned at the end of `Execute`, and a deferred assignment to
+      it after an early return is dropped. Both failures - the refused unmount
+      and a refused deletion - go to `clog.Warn` naming the directory and the
+      cause, which is the established idiom in this file.
+    - Red command:
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -run TestClientExecuteUnstartedRunWorkSpace -v`
+      Failing before the change with `A run whose command cannot start leaves no
+      working directory behind` red at `behaviours_test.go:1700` -
+      `soPathsGone`'s `os.IsNotExist`, `Expected: true`, `Actual: false`. The
+      working directory was still there, confirmed in the same run by an
+      `os.Stat` of it returning nil.
+    - Files touched: `jobqueue/client.go` (the armed defer and
+      `cleanupUnstartedWorkSpace`), `jobqueue/workspace.go`
+      (`cleanupWorkSpace`), `jobqueue/behaviours.go` (`Behaviour.cleanup` now
+      calls it), `jobqueue/client_payload_test.go` (the tests).
+    - Guard mutations - 4 of 4 RED, every one still compiling (`go vet` after
+      each): the armed defer removed; the disarm made unconditional
+      (`cmdStarted := true`); the refuse-on-failed-unmount guard made to
+      proceed anyway; and the unmount moved AFTER the deletion. The last two
+      are caught by `TestUnstartedRunWorkSpaceCleanupOrder`, which reads how
+      many of the Job's mounted filesystems are left at `cleanupProvenHook`
+      (`unmountAll` clears them) to pin which of the two happened first, and
+      forces a failed unmount with a mount point that is not a real dir.
+    - **The `actualCwd == ""` guard has no test, deliberately.** Removing it
+      leaves the whole suite green, because `cleanupWorkSpace` is already a
+      no-op for a `--cwd_matters` job; all it stops is an `Unmount` such a job's
+      pre-start paths do not do today, and reaching the two paths that would
+      show that (1722, 1734) needs a live mount or a broken docker client. It is
+      kept as the honest statement of what `resolveWorkingDir` returned, rather
+      than re-deriving `CwdMatters` a second time.
+    - **What this item's analysis got wrong, measured:** `Job.Mount` does NOT
+      leave earlier configs mounted any more - every failure in `mountConfig`
+      goes through `job.unmountOnError`, which unmounts everything mounted so
+      far - so 1675 leaves nothing live and the hazard is real at 1722 and 1734
+      instead. And 1675 now reclaims the WHOLE workspace, not just the TMPDIR:
+      `Job.Unmount`'s own empty-dir tidy-up takes the empty working directory
+      and the levels above it, and the proven cleanup takes the TMPDIR, between
+      them leaving nothing. Both are asserted.
+    - Gates on the fixed tree: `make test` `412 passed / 9 skipped`, `make race`
+      `412 passed / 9 skipped`, `make lint` `0 issues.` - two tests more than
+      the 410 this branch stood at: `TestClientExecuteUnstartedRunWorkSpace` and
+      `TestUnstartedRunWorkSpaceCleanupOrder`.
+    - Still not fixed, and still recorded above: the dropped `myerr` assignments
+      in the `prependPath` and `tmpDir` defers (client.go:1629, 1711) write to a
+      local that has already been returned, so those cleanup errors are lost as
+      well. That is the same latent bug as the unproven `RemoveAll` at 1711 and
+      wants its own brief.
   - **`ActualCwd` is still a reported field**, and everything that acts on it
     still proves it is the path `mkHashedDir` built for this job's key. What
     changed is that a run now starts out claiming nothing.

--- a/.docs/bugfixes/260831-1.md
+++ b/.docs/bugfixes/260831-1.md
@@ -1,0 +1,599 @@
+# Bugfixes 260831-1
+
+PR TBD (branch `fix-lost-job-run-identity`): a manager's lost-job decision
+carried out on a different RUN of the same job.
+
+## Where this came from
+
+These entries were found and fixed during rounds 9 to 12 of the cwd_matters
+cleanup PR #558 (branch `fix-cwd-matters-cleanup-deletes-parent`, checklist
+`.docs/bugfixes/260828-3.md`), because the two families surface in the same
+place: the manager's `killLostJobAndTriggerBehaviours` is one of the callers that
+deletes a job's working directory. They are a different bug, pre-existing and
+about neither `cwd_matters` nor cleanup's proofs, so at the repo owner's request
+they are here instead, and #558 keeps only the cwd_matters work. The split note
+at the top of `260828-3.md` says the same thing from the other side.
+
+This branch is STACKED on #558 and must merge after it. The pin these fixes
+carry is a `jobWorkSpaceSnapshot`, and both that type and the property that
+behaviours act on one rather than on a live `*Job` are #558's - see "Why this is
+stacked" at the end.
+
+The entries below are reproduced verbatim from `260828-3.md`, under their
+original round headings and with their original LAYER numbers, so that the
+argument each fix rests on is not paraphrased. Two consequences of keeping the
+numbering: it starts at 51, and #558 also has a LAYER 56 - the two families were
+numbered in one sequence, and round 10's LAYER 56 is the other PR's. Each round's
+guard-mutation tallies and gate numbers were measured on the combined tree,
+before the split; the sub-bullets naming the guards of these fixes are quoted
+under each round, and this branch's own post-split gates are at the end.
+
+## Round 9 - a lost job's behaviours acted on its own live retry
+
+- [x] LAYER 51 (**data loss and a leak at once, no adversary, one job, one
+  manager**): `killLostJobAndTriggerBehaviours` called `killJob` FIRST, and
+  `killJob` RELEASES a lost job back to ready before returning. It then re-fetched
+  the same `*Job` from the queue and triggered its behaviours on it. In that
+  window a runner reserves the RETRY, and the retry's first `Touch` carries its
+  new working directory into that same `*Job`
+  (`emitLiveTouchSnapshot` -> `applyLiveSnapshot` -> `setActualCwd`).
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestLostJobBehavioursActOnTheLostRun' -count=1`
+    (exit 1 with the pin moved back after the kill).
+  - Red evidence: the `run` behaviour's `pwd` printed the RETRY's working
+    directory; the retry's `partial.txt`, its working directory and its live
+    `TMPDIR` were deleted while it ran; the workspace that was actually abandoned
+    LEAKED; and `err` was **nil**. `stat .../cwd/partial.txt: no such file or
+    directory`. The identity proof cannot see any of it: the retry is the same
+    Job with the same `Key()`.
+  - Fix: **the behaviours are decided at one moment and must act on that moment.**
+    A Job's `Behaviours` and the state they act on are pinned together under one
+    read lock (`pinnedBehaviours`, `Job.pinBehaviours`), and the manager pins
+    BEFORE the kill. `Behaviour.trigger` and `Behaviours.trigger` take that pinned
+    `jobWorkSpaceSnapshot` instead of a `*Job`, so a behaviour cannot reach a live
+    Job at all; `Behaviour.cleanup`, `Behaviour.run` and `copyToManager` follow.
+    The exported `Trigger` methods keep their `*Job` signature and pin at the
+    call, which is the right moment for every caller that owns its own Job.
+  - The whole SET shares one pin rather than each behaviour reading the Job
+    again: `--on_failure cleanup --on_exit run` is one decision about one
+    directory, and re-reading between the two is how they came to act on
+    different ones.
+  - Every other caller of `TriggerBehaviours` was checked and none is exposed.
+    The three in `client.go` (Started failed, after the Cmd, after
+    `reportFinalState` failed) run in the RUNNER, on the runner's own `*Job`,
+    whose `ActualCwd` is written once by `resolveWorkingDir` and afterwards only
+    ever re-set to the same value by `Client.ended`. Nothing else in the manager
+    triggers behaviours.
+  - `Job.Unmount`'s tidy-up does NOT need the same treatment, for the same
+    reason: `Unmount` is called only from the runner (`client.go:1350` and
+    `:2100`), after the behaviours, in the same goroutine, on that same Job. It
+    was checked rather than assumed - the manager never unmounts a lost job.
+  - A `lostJobKilledHook` is added beside the three hooks `behaviours.go` already
+    has, for the same reason they exist: the moment between `killJob` returning
+    and the behaviours running is where the retry is reserved, and a test cannot
+    get into it reliably any other way. It is nil in production.
+
+- [ ] Round 9's guard mutations, the sub-bullet naming these guards (15 mutations
+      over the round's combined changed code, 13 RED; measured before the split):
+  - The pin: pinned after the kill instead of before it (M11); pinning the
+    behaviours but not the state they act on (M12); `pinBehaviours` taking no
+    lock (M13), under `-race`. The round's other two mutations of the same code,
+    M14 and M15, are #558's: they mutate `workSpaceSnapshot` and the exported
+    `Behaviour.Trigger`, which pin nothing beyond the call they are made from.
+  - Of round 9's four new tests, two are this branch's:
+    `TestLostJobBehavioursActOnTheLostRun` and `TestPinBehavioursIsLocked`.
+
+## Round 10 - the pin was right, the moment was not
+
+- [x] LAYER 54 (**data loss against a LIVE job, no adversary, one job, one
+  manager**): the whole path from `confirmOrReleaseLostJob` to
+  `pinLostJobBehaviours` runs `confirmJobDead` in the middle of it - an ssh round
+  trip bounded by `ServerLostJobCheckTimeout`, 15 seconds by default - and
+  nothing re-established that the job pinned afterwards was still the run that
+  had been lost. Three defects compounded:
+  - `pinLostJobBehaviours` checked NOTHING. It did `q.Get(key)` and pinned
+    whatever `*Job` was there, though the sibling retry path `lostJobRetryCheck`
+    has checked `job.Lost` all along.
+  - `killJob`'s bool was discarded, and it never meant "released" anyway:
+    `killJob` returns `(true, nil)` after setting `killCalled` and releasing
+    nothing when `job.Lost` is false. Acting on it fired the behaviours against a
+    job that had recovered and was still running.
+  - `job.Pid` is the CMD's pid, not the runner's (`c.Started(job,
+    cmd.Process.Pid)`), so `confirmJobDead` says "dead" the moment the Cmd exits,
+    while the runner is still alive, still touching, and still inside its own
+    behaviours and `Unmount` upload - the touch loop runs to `client.go:2165`,
+    past both. That is what makes the window easy to get into rather than rare.
+  - Two windows exploit it, neither needing an attacker. **A**: a transient blip
+    expires the TTR, the Cmd exits so the pid really is gone and the dead-check
+    confirms, the runner's next touch clears `Lost` (`recoverLostTouchedJob`),
+    and the manager then swept the LIVE working directory and `TMPDIR` and ran
+    the user's `run` command in it a second time, concurrently with the runner's
+    own. **B**: the job is released and re-reserved inside the window - a
+    retryable failure, or `wr kill` - and the pin captures the RETRY, which is
+    byte-for-byte the outcome `pinnedBehaviours`' own doc comment claims to have
+    fixed.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestLostJobBehaviours|TestLostJobRetryCheck' -count=1`
+    (exit 1 against every mutation of the guards below).
+  - Fix: **the pin belongs to the decision, and the decision has to be
+    re-established before it is carried out.** `markJobLost` pins in the same
+    breath as setting `Lost`, under the write lock it already holds
+    (`Job.pinBehavioursLocked`), and the pin travels as `lostJobDetails.pin`
+    through `confirmOrReleaseLostJob` and `confirmJobDeadAndKill` instead of
+    being re-fetched by key. `killLostRun` then refuses a job that is not still
+    lost and not still that run (`Job.isLostRunLocked`), and the behaviours run
+    only if it really released the pinned run.
+  - `(key, ActualCwd)` is the identity. The key is the same for every run of a
+    job by construction, so it cannot tell two runs apart - `q.Get` uses it to
+    find the job, not to identify the run. `ActualCwd` is what changes: it is one
+    run's working directory, written onto the shared `*Job` by that run's first
+    Touch. `Lost` covers the rest.
+  - The refusal does NOT mark the job either. `killCalled` turns a job's next
+    touch into a self-kill, so mistaking a recovered job for the lost one would
+    kill the run that had just come back - a second data loss on the same
+    mistake, and one no behaviour is involved in. `killRunningJob` therefore
+    leaves a job that fails the check entirely untouched.
+  - `killJob` keeps its signature and its meaning for its four other callers
+    (`serverCLI` handleKill, `serverREST`, `serverWebI`, `killJobsOnServers`),
+    which want "mark this job to kill itself". Its doc now says the bool is not
+    a release, and points at `killLostRun` for the caller that needs one.
+  - `confirmJobDeadAndKillAfterRetryTime` had the same defect and is fixed the
+    same way: `lostJobRetryCheck` pins under the same read lock as its `Lost`
+    check, and returns a `lostJobDetails` rather than a near-duplicate struct of
+    its own. Its answer is still about that moment only - the `confirmJobDead`
+    that follows reopens the window - which is exactly why the check that
+    matters is the one at the kill.
+  - `job.Pid` being the Cmd's pid rather than the runner's (`c.Started(job,
+    cmd.Process.Pid)`) is NOT changed, and does not need to be. It means
+    `confirmJobDead` proves less than it sounds like it proves: the Cmd is gone,
+    while the runner may still be alive, touching, and inside its own behaviours
+    and `Unmount` upload. Every way that weaker proof can hurt now goes through
+    the same door: if the runner is alive enough to touch, `Lost` is false at the
+    kill and nothing happens; if it is not, the job is lost by wr's own
+    definition and always was. Changing what `Started` reports is a change to the
+    meaning of "dead" across recovery, `killJobsOnServers` and the scheduler, and
+    it is not needed to close this window.
+  - A run that is refused leaks its workspace. That is the right way round and is
+    said so in the code: the job has moved on, and whatever it is doing now, it
+    is doing it there.
+
+- [ ] Round 10's guard mutations, the sub-bullets naming these guards (15
+      mutations over the round's combined changed code, 15 of 15 RED; measured
+      before the split):
+  - The identity check: `isLostRunLocked` ignoring `Lost` (M1), ignoring
+    `ActualCwd` (M2), or accepting anything (M3); `killLostRun` not naming the
+    run it is killing, ie. `killJob`'s old behaviour (M9).
+  - The moment: the pin taken after the dead-check as round 9 took it (M4);
+    `lostJobRetryCheck` pinning the key but not the run (M5); `markJobLost`
+    pinning the state but not the `Behaviours` (M14) or losing `ActualCwd` from
+    the state (M8).
+  - Acting on the answer: `killRunningJob` marking `killCalled` before the guard
+    rather than after it (M6); the behaviours triggered regardless of what the
+    kill decided (M7).
+  - **M7 was GREEN because the negative tests asserted at the wrong moment.**
+    They signalled on the kill decision and asserted while the manager raced on,
+    so a mutant that triggered the behaviours regardless swept the directory a
+    moment after the assertions had passed. Parking the manager at its decision
+    until the test lets it go proves nothing happened BEFORE the test looked; the
+    two behaviour hooks that already exist (`runResolvedHook`,
+    `cleanupProvenHook`) prove nothing happens after. Both halves are needed, and
+    only having the first is what made the test lie.
+  - **M8's first form was GREEN because the guard it mutated was wrong.**
+    `killRunningJob` reported `released` only when `releaseJob` returned no
+    error, which nothing can redden without a seam invented for it - and which is
+    the wrong way round: a failed release leaves the job lost and in the run
+    queue, `ttrCallback` does not re-mark an already-lost job, so no second
+    confirmation is coming and withholding the behaviours leaks the dead run's
+    workspace for ever. The bool now says the run WAS the one to release; the
+    release error is logged. M8 became a mutation of the pin instead.
+  - `make race` then found two data races in the fixture itself, and both were
+    real: the hooks were assigned AFTER `Serve` had started the goroutines that
+    read them, so nothing ordered the two, and the window hooks wrote the test's
+    own variables from the manager's goroutine. The hooks are installed before
+    `Serve` now and left in place afterwards - taking them down again is the same
+    unordered write in reverse, and a stopped fixture's hooks do nothing - and
+    every piece of work the window is about is done by the test on its own
+    goroutine, with the `*Job`'s lock the only thing shared. Parking a second
+    lost cycle is a bonus the same design buys: a long test's own TTR cannot fire
+    again and sweep the workspace behind an assertion.
+  - Round 10's four new tests are all this branch's:
+    `TestLostJobBehavioursSpareARecoveredJob`,
+    `TestLostJobBehavioursSpareARetryStartedInTheWindow`,
+    `TestLostJobBehavioursSpareASecondLostRun` and
+    `TestLostJobRetryCheckPinsTheLostRun`.
+- [ ] Recorded from round 10, NOT fixed (the bullets that are about this work):
+  - **`job.Pid` is the Cmd's pid, and is left that way.** The touch loop runs
+    until `client.go:2165`, well past `TriggerBehaviours` and `job.Unmount`, so a
+    runner really is alive and touching after the pid `confirmJobDead` asks about
+    has gone - which is exactly attack A. Closing the window did not require
+    changing it, because a runner alive enough to touch clears `Lost` and the
+    kill then refuses. Changing what `Started` reports would change the meaning
+    of "dead" for recovery, `killJobsOnServers` and the scheduler at once.
+  - **`TriggerBehaviours`' unlocked `j.Behaviours` read is left alone.** It reads
+    the field, then `Behaviours.Trigger` takes the workspace snapshot under the
+    lock, so the triple is not atomic. It is runner-only - `client.go` has the
+    only three callers - and the runner's `*Job` is its own deserialised copy,
+    not the manager's, with no second goroutine writing `Behaviours` while
+    `Execute` runs. Locking it would be a guard no test could redden. The
+    manager's lost-job path does not go through it at all any more.
+  - **A refused run leaks its workspace, deliberately.** When the job has moved
+    on, wr no longer knows that the old directory is nobody's, and the run that
+    replaced it is using a directory of its own. Leaking is the recoverable half
+    of the trade.
+
+## Round 11 - the identity was a field the runner reports, not a run
+
+An eleventh round found that round 10's run identity, `Lost && ActualCwd ==
+pinned`, degenerates to plain `Lost` in three ORDINARY configurations, so the
+window round 10 believed it had closed was open in all of them; and that the
+leak round 10 accepted as the right half of the trade is neither occasional nor
+caused by the refusal it was blamed on.
+
+- [x] LAYER 56 (**data loss against a LIVE job, no adversary, three ordinary
+  configurations**): `Job.isLostRunLocked` identified a run by `ActualCwd`,
+  which is REPORTED by the runner rather than minted by the manager, and is
+  blank or stale for the whole of a run in each of:
+  - a **cwd_matters** job, whose Cmd runs in the user's own Cwd, so
+    `setActualCwd` returns early for it and its `ActualCwd` is blank for ever;
+  - a manager with **no web port**, where `emitLiveTouchSnapshot` is gated on
+    `liveJTouchEnabled`, so no touch ever carries a directory at all;
+  - the **first touch interval of every run** (`ClientTouchInterval`, 15s), and
+    a run's whole life if it never touches - which is what makes a run lost.
+  - `ActualCwd` is also never cleared between runs, so where it is not blank it
+    is the PREVIOUS run's.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestLostCwdMattersJobSparesItsSecondRun|TestLostJobOnWeblessManagerSparesItsSecondRun|TestLostJobSparesASecondRunThatNeverTouched' -count=1`
+    (exit 1 without the fix, each with `waitForKillDecision` returning true: the
+    manager released and `killCalled`-marked the LIVE run on a death
+    confirmation about a different one).
+  - Red evidence, cwd_matters: the retry's `retry_output.tmp` was deleted by the
+    lost run's own `--on_failure run` command, executed in the shared Cwd, and
+    `ran_in.txt` was written there. `"" == ""` is what let it through.
+  - Fix: **the manager mints the identity.** `runToken` is handed out by
+    `Server.mintRunToken` in `applyJobStart` - the one place a run of a job
+    begins, and the one event every run has whatever it goes on to report. It is
+    pinned with the rest of the lost run's state (`pinnedBehaviours.run`) and
+    `Job.isLostRunLocked` compares it.
+  - `ActualCwd` is not compared at all any more. A corroborator that is blank in
+    the cases that matter corroborates nothing, and keeping it would only add
+    refusals of runs that had not changed.
+  - The token is unexported and never leaves the manager, because it is only
+    ever compared with one the same manager minted. A running job recovered from
+    the database after a crash carries the zero token, which is the run this
+    manager found already in progress; `mintRunToken` counts from 1, so no
+    minted token can be mistaken for it.
+  - `Job.Attempts` is minted in the same place and was the obvious candidate. It
+    is a COUNT rather than an identity: `resetJobStatusFields` sets it back to 0
+    so a web-UI rerun starts counting again, which makes it non-monotonic, and
+    it is exported, goes over the wire, and is separately incremented by the
+    runner's own copy in `client.go`. An identity another feature is free to
+    reset is not one.
+- [x] LAYER 57 (**a permanent leak of every workspace of a whole class of
+  runs**): a lost run the manager never learned a working directory for leaks
+  its ENTIRE workspace - `cwd`, `tmp`, the output and the `<AppName>_cwd/k/k/k`
+  chain above them - and has its `run` behaviour refused for the same reason,
+  since `paths()` resolves nothing from a blank `ActualCwd`. Nothing retries:
+  `killLostJobAndTriggerBehaviours` returns without rescheduling and
+  `ttrCallback` will not re-mark an already-lost job, so one loss is for ever.
+  That is 100% of lost runs on a manager with no web port, and on any manager
+  every run that dies inside its first touch interval.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestLostJobOnWeblessManagerCleansItsWorkSpace' -count=1`
+    (exit 1 without the fix: the workspace is still there, and `run behaviour
+    refused: ... reported no working directory to run in`).
+  - **The round 11 brief attributes this leak to LAYER 56's refusal, and that is
+    wrong.** In exactly these cases the refusal PASSES - blank equals blank - so
+    the kill is not refused at all: the red run above gets past
+    `waitForKillDecision` returning true and still leaks. The leak has a
+    different cause, and fixing the identity does not touch it.
+  - Fix: **the runner tells the manager where it is working when it starts.**
+    `Client.Execute` calls `resolveWorkingDir` before `Started`, so the
+    directory already exists by then; `Client.Started` now carries it and
+    `applyJobStart` records it against the run it is starting. No new trust is
+    placed in the runner: the reported directory still has to be proven to be
+    the one `mkHashedDir` built for this job's key before anything acts on it.
+  - `applyJobStart` clears `ActualCwd` before recording, so a run that reports
+    none does not inherit the previous run's. That is what a runner older than
+    this change does, and it is also how a `CwdMatters` job persisted by wr
+    v0.37.0|1 sheds the `ActualCwd` it was stored with.
+  - **Residual leak, measured.** A run that dies between `mkHashedDir` and
+    `Started` - mounting and `cmd.Start` - is still one the manager has no
+    directory for, and leaks. That window is the job's own setup rather than its
+    runtime, against the 15 second touch interval it replaces. A run REFUSED by
+    LAYER 56's check also still leaks, and that is unchanged and deliberate: the
+    job has moved on, and whatever it is doing now, it is doing it there.
+
+- [x] Three of round 11's four recorded items are this branch's, judged (the
+      fourth, a cache location above the workspace, stayed with #558):
+
+  - **`confirmOrReleaseLostJob`'s `killCalled` branch is gated** (was
+    server.go:3905). It waited `ttrReleaseWait` and called `releaseJob` on the
+    captured `*Job` with no identity check at all - and that `*Job` is shared by
+    every run of the job. 50ms is long enough for a killed job to be buried by
+    its runner and for the run at the queue to be one this confirmation was
+    never about. It now releases through `killRunningJob`, which proves the run
+    first, and the path stops carrying a `*Job` at all.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestKilledLostJobSparesItsSecondRun' -count=1`
+    (exit 1 with the un-gated release: the item is in `delay` rather than
+    `run`).
+  - **The "killed a job after confirming it was dead" log tells the truth** (was
+    server.go:3899). It was written before the goroutine that may REFUSE the
+    kill had run. It is now written by that goroutine, from the same `released`
+    value the tests already pin, with a counterpart for the refusal;
+    `confirmJobDeadAndKill` no longer reports a bool that meant "confirmed" and
+    read as "killed".
+  - **`markJobLost`'s `wasLost` parameter is gone** (was server.go:3827). Its
+    one caller always passed false, because `ttrCallback` has already returned
+    for an already-lost job.
+- [ ] Round 11's guard mutations, the sub-bullets naming these guards (18
+      mutations over the round's combined changed code, 18 of 18 RED; measured
+      before the split):
+  - The identity: `isLostRunLocked` dropping the token (M1) or the `Lost` check
+    (M2); `applyJobStart` minting nothing (M3); the pin carrying no token (M4);
+    `mintRunToken` counting from 0 (M5); `killLostRun` naming no run (M17).
+  - The working directory: `Started` not reporting it (M6); `applyJobStart` not
+    recording it (M7) or not clearing the previous run's (M8).
+  - Acting on the answer: the `killCalled` branch releasing un-gated (M9); the
+    behaviours triggered regardless of what the kill decided (M10);
+    `killRunningJob` marking `killCalled` before the guard (M11).
+  - Round 11's seven new tests are all this branch's:
+    `TestLostCwdMattersJobSparesItsSecondRun`,
+    `TestLostJobOnWeblessManagerSparesItsSecondRun`,
+    `TestLostJobSparesASecondRunThatNeverTouched`,
+    `TestLostJobOnWeblessManagerCleansItsWorkSpace`,
+    `TestKilledLostJobSparesItsSecondRun`,
+    `TestStartedRunDoesNotInheritThePreviousRunsWorkingDir` and
+    `TestMintedRunTokenIsNeverTheRecoveredOne`.
+- [ ] Recorded from round 11, NOT fixed:
+  - **A refused run still leaks its workspace**, and a run that dies before its
+    `Started` still leaks it too. Both are quantified under LAYER 57.
+
+## Round 12 - a run begins at Reserve, and its identity was minted at Started
+
+A twelfth round found that round 11's run identity is minted at the wrong
+moment. A run in wr begins when a runner RESERVES the job: the working
+directory, the mounts and `cmd.Start()` all happen after that and before the
+run's `Started` ever reaches the manager. Minting at `Started` left that whole
+window carrying the PREVIOUS run's token and `Lost` flag, so a confirmation made
+about a run that was over was carried out on a Cmd that was already executing -
+and then hung the job for ever.
+
+- [x] LAYER 59 (**a pinned kill carried out on a live retry, then the job hangs
+  for ever**): `resetJobForReservation` reset `ReservedBy`, `Exited`,
+  `StartTime`, `EndTime`, `PeakRAM`, `PeakDisk`, `Exitcode` and `killCalled`,
+  but not `runID` and not `Lost`. Between Reserve and `Started`, therefore, both
+  halves of `isLostRunLocked` answered yes for a run that had only just begun -
+  directly contradicting that function's own doc comment, which promises that "a
+  job that ... was released and re-reserved, is not the lost run whatever its
+  token says".
+  - The un-gated release that opens the window is `killJob ->
+    killRunningJob(..., nil)`, reached by **`wr kill`** - the documented way to
+    deal with a lost job, and the one whose own doc says it releases - and
+    automatically by `killJobOnServer` when the cloud scheduler destroys a bad
+    server.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestKillingALostJobSparesTheRunThatReplacesIt|TestKilledLostJobsReservationIsARunOfItsOwn' -count=1`
+    (exit 1 with the round 11 shape: `waitForKillDecision` returns true, so the
+    manager marked `killCalled` on the fresh reservation and released it, and
+    the second case reports the retry's state as `lost` rather than `reserved`).
+  - Both harms are in that one sequence. `killCalled` turns the retry's next
+    touch into a self-kill, and its Cmd is running. And `Lost` being carried into
+    the retry parks the job: `ttrCallback` returns early for an already-lost job,
+    so no confirmation is ever started for the run that is really happening, and
+    it is neither retried nor buried. The second case ends by killing the
+    reservation's runner before its `Started`, so the only way the job can ever
+    end is the manager declaring THAT run lost on its own account.
+  - Fix: **the run's identity is established where the run begins.**
+    `resetJobForReservation` is now a `*Server` method and mints the `runToken`
+    there, clears `Lost` there, and clears `ActualCwd` and `HostID` there.
+    `applyJobStart` no longer mints and no longer clears `ActualCwd`: the
+    reservation has already done both, before the window that needed it.
+  - **Reserve is the right moment because it is the only one the manager and the
+    run share before the run can do damage.** The runner's whole setup -
+    `resolveWorkingDir`, the BsubMode symlinks, `job.Mount()` with its
+    three-second fusermount retry, the env, the docker client and `cmd.Start()`
+    itself - happens between the reservation and the report, and the touch
+    ticker's first tick is a whole `ClientTouchInterval` away. Reserve is also
+    the event that puts the item back into the run sub-queue, which is where
+    every lost-run decision looks for it: minting anywhere later leaves a job
+    findable by a decision about a run that is over.
+  - **One run, one token.** `applyJobStart` deliberately does NOT re-mint. A
+    reservation is exactly one execution attempt, so a second mint would give
+    one run two identities and orphan a pin taken in the reserved-not-started
+    window. What that pin still needs is `applyJobStart`'s `Lost = false`, which
+    is now load-bearing on its own: a run declared lost before its `Started`
+    arrives is pinned under the very token its `Started` keeps, so taking the job
+    off lost is the only thing standing between that confirmation and a running
+    Cmd (`TestASlowStartedRunIsNotStillLost`).
+- [x] LAYER 60 (**the pin named an OLDER workspace of the same job**): round 11
+  moved the working-directory report to `Started`, which is late: a run that dies
+  between `mkHashedDir` and `Started` is covered by nothing, and `markJobLost`
+  then pinned `{actualCwd: the previous run's}`. For a job whose runs share a
+  Cwd that is another workspace of the SAME job, so the pinned `run` behaviour
+  would have executed in it and the pinned cleanup would have swept it - both
+  the destruction 3484bdb and LAYER 56 were written to stop, arrived at from the
+  other end.
+  - Red command: `CGO_ENABLED=0 go test ./jobqueue/ -run 'TestReservedRunDoesNotInheritThePreviousRunsWorkingDir' -count=1`
+    (exit 1 without the fix: the reserved run still claims
+    `.../jobqueue_cwd/a/0/5/08733774...653/cwd`, the workspace of the run
+    before it).
+  - Fix: `ActualCwd` is cleared at Reserve, so the pin carries blank, the
+    `run` behaviour is refused rather than executed somewhere it has never been,
+    and the cleanup correctly deletes nothing. The abandoned workspace is left
+    where it is, which is the right way round: a leak of directories is not a
+    deletion of a live job's outputs.
+- [x] Every field that describes "the previous run", checked at Reserve:
+  - **Fixed here**: `runID` (the identity), `Lost` (every lost-run decision),
+    `ActualCwd` (what cleanup deletes and what `run` executes in), `HostID` (the
+    scheduler's name for the machine a run is on, which
+    `killJobsOnBadServers` matches a job against before killing it through the
+    same un-gated release).
+  - **Already reset**: `ReservedBy`, `Exited`, `Exitcode`, `StartTime`,
+    `EndTime`, `PeakRAM`, `PeakDisk`, `killCalled`.
+  - **Deliberately set rather than cleared**: `Host` and `Pid`, which
+    `respondWithReservedJob` fills with the reserving runner's own so that a
+    reserved-not-started job's liveness can be confirmed (spec C1/C2).
+  - **Correctly left**: `UntilBuried` and `Retries` are per-JOB, not per-run.
+    `incrementedLimitGroups` is a note that a decrement is owed, and clearing it
+    would unbalance the limiter. `Attempts` is a count and is incremented at
+    `Started`. `FailReason`, `CPUtime`, `StdOutC` and `StdErrC` are the previous
+    run's, and are read only by display and by the requirements-learning path
+    (`failureMayUpdateJobRequirements`), which is asking about the run that just
+    failed and so wants exactly that.
+  - **`State` is stale and it matters, but not here** - see the recorded items
+    below.
+- [x] **The manager-restart hole is closed, and verified.** A job recovered from
+  the database carries the zero token, because this manager minted nothing for
+  it. `mintRunToken` counting from 1 only stops a MINTED token being mistaken for
+  it; what stops a `pin{0}` matching the same job at a later moment is the
+  reservation each later run begins with.
+  `TestMintedRunTokenIsNeverTheRecoveredOne` now pins both halves: the pin
+  matches the recovered run, and after `resetJobForReservation` it does not -
+  asserted with `Lost` set true again, so the token is the whole of what refuses
+  it.
+- [ ] **The pre-`Started` leak is NOT fixed. What leaks, and why each fix is
+  worse than the leak.** A run that dies between `mkHashedDir` and `Started`
+  leaks exactly three directories: the `os.MkdirTemp` leaf and the `cwd` and
+  `tmp` that `mkCwdAndTmp` makes in it. They are EMPTY in every case but one -
+  the Cmd has not started at all until the last step of that window, and in that
+  last step it has had the length of one RPC round trip to write anything. The
+  three hashed levels above them are shared with every other run of the job, so
+  they are not themselves leaked; the abandoned leaf does stop
+  `rmEmptyDirsIn` from taking them when a later run of the job cleans up, since
+  a leaf holding `cwd` and `tmp` is not empty. Nothing ever reclaims them.
+  - **Reporting the directory earlier costs one RPC per job.** There is no free
+    carrier. The touch loop starts right after `resolveWorkingDir`, but its first
+    tick is a whole `ClientTouchInterval` away and its snapshot is ignored
+    entirely by a manager with no web port (`liveJTouchEnabled`), so it would
+    have to become both immediate and unconditional. That is one extra round trip
+    on every job wr ever runs, at LSF scale, to recover three empty directories
+    from a window that is normally microseconds long.
+  - **Letting the manager dictate the leaf name at Reserve costs the uniqueness
+    guarantee and breaks older runners.** `os.MkdirTemp`'s atomic exclusive
+    create is what stops two live runs of one key sharing a working directory,
+    and a runner older than the change would ignore the dictated name, leaving
+    the manager recording a directory that does not exist - so the pinned `run`
+    behaviour of a lost run would be refused where it works today.
+  - **Sweeping the siblings is the same-key residual, and it destroys live
+    work.** The manager knows the hashed parent exactly; only the MkdirTemp
+    digits are unknown. Deleting every sibling that is not this run's is the
+    known residual this file already records: two LIVE instances of one Job in
+    different managers work below the same hashed parent, and their digits are
+    not pinned.
+- [x] The four items round 12 recorded, judged:
+  - **`killRunningJob` dropping the job lock between `isLostRunLocked` and
+    `releaseJob` is correct as it stands** (server.go:4916-4934). It cannot hold
+    the lock across `releaseJob`, which takes the queue mutex, and DEVELOPERS.md
+    section 2 forbids exactly that. What closes the gap is that `killCalled` is
+    set under the SAME lock as the proof: `handleTouch` reads `killCalled` before
+    it touches, so a touch that lands after the mark cannot recover the job at
+    all, and one that read it before recovers a job whose runner will be told to
+    self-kill on its next touch. The manager decided to kill that run, having
+    proven it was the pinned one; the release is what that decision means.
+  - **`markJobComplete` leaving `Lost` set is correct, and now safely so**
+    (serverCLI.go:1071). `Lost` is only ever consulted while the item is in the
+    run sub-queue, and every path back into the run sub-queue goes through
+    Reserve, which now clears it. Before this round that was a claim about
+    ordering; it is now an invariant with one enforcement point.
+  - **`resetJobExecutionFields` leaving `runID` is harmless, and no longer
+    "purely by ordering"** (serverWebI.go:795). A rerun job goes back to ready
+    and is reserved again, and that reservation mints. Clearing it there would be
+    a second place claiming to establish identity, which is the mistake this
+    round is fixing.
+  - **`Key()` excluding `Cwd` for non-cwd_matters jobs does not belong here**
+    (job.go:1178). It is the same fact as `Job.Cwd` cannot be normalised at
+    source, which this file's hard constraints already carry: the key is what
+    makes two submissions of one command one job, and changing it changes what a
+    job IS.
+- [ ] Recorded by round 12, NOT fixed:
+  - **`lostJobRetryCheck` never fires for a reserved-not-started run, because
+    `Job.State` is the previous run's** (server.go:2337). `State` is set at
+    `Started` and at each exit, never at Reserve, so through a whole reservation
+    it still says `delayed` (measured: `TestKillingALostJobSparesTheRunThatReplacesIt`
+    read `delayed` from `l.live.State` while the item was in the run sub-queue,
+    which is why that test reads the manager's own answer via `itemToJob`
+    instead). `lostJobRetryCheck` gates on `job.State != JobStateRunning`, so the
+    thirty-minute re-confirmation is a no-op for a reserved-not-started lost run:
+    if the FIRST `confirmJobDead` could not reach the host - which is the only
+    reason the retry exists - that run is parked lost for ever. It is a separate
+    bug in a separate path, and the obvious one-line repair (gate on
+    `job.Exited` instead, which is what `ttrCallback` uses for the same "this
+    run is over" question) has to be reasoned about against the window
+    `markJobComplete` deliberately leaves open, where the item is still in the
+    run sub-queue with `Lost` set and `State` already `complete`. Not attempted
+    under this brief.
+  - **A run that FAILS before `Started` leaks its workspace too, and the runner
+    could clean it up itself.** `Client.Execute`'s mount, env, docker and
+    `cmd.Start` failure paths return through `buryWrapErr`/`Bury`/`Release`
+    without ever calling `TriggerBehaviours`, and the `os.RemoveAll(tmpDir)`
+    defer is only registered after `job.Mount()` returns. So a mount failure
+    leaks the working directory AND the TMPDIR, and the job is buried, so nothing
+    will ever run its cleanup. Unlike the death case the runner is alive and
+    knows the directory, so this one is free to fix - but running the OnFailure
+    behaviours there would execute the user's `run` command on a mount failure,
+    which is a semantic change and wants its own brief.
+  - **`ActualCwd` is still a reported field**, and everything that acts on it
+    still proves it is the path `mkHashedDir` built for this job's key. What
+    changed is that a run now starts out claiming nothing.
+  - The known items the round 11 and 12 briefs listed are still open and
+    untouched: `client.go:1711`'s unproven `RemoveAll`; `CacheBase: "."`;
+    `cmd/add.go` storing `--cwd` unnormalised; `calculateHashedDir`'s
+    unreachable short-key panic; a `.hold` file blocking `removeEmptyParents`;
+    the `_cwd` suffix-only base check; and the same-key residual, re-measured as
+    unchanged - a `runToken` is about two runs of one Job in one manager and says
+    nothing about two LIVE instances of one Job.
+- [ ] Guard mutations - 16 of 16 RED, every one still compiling (`go vet` after
+  each), and one guard DELETED as redundant:
+  - This round's moment: `resetJobForReservation` minting nothing (N1), not
+    clearing `Lost` (N2), not clearing `ActualCwd` (N3), not clearing `HostID`
+    (N6); `applyJobStart` not clearing `Lost` (N5); and the whole round 11 shape
+    restored - mint and `ActualCwd` clear at `Started`, nothing at Reserve (N4).
+  - Round 11's identity and kill guards, re-verified against the new tests:
+    `isLostRunLocked` dropping the token (M1) or the `Lost` check (M2); the pin
+    carrying no token (M4); `mintRunToken` counting from 0 (M5); `Started` not
+    reporting the working directory (M6); `applyJobStart` not recording it (M7);
+    the `killCalled` branch releasing un-gated (M9); the behaviours triggered
+    regardless of what the kill decided (M10); `killRunningJob` marking
+    `killCalled` before the guard (M11); `killLostRun` naming no run (M17).
+  - **M8 is gone, correctly.** `applyJobStart`'s own `ActualCwd = ""` was round
+    11's guard against a run inheriting the previous run's directory. Reserve now
+    clears it strictly earlier, so the later clear guarded nothing that N3 does
+    not, and a second place claiming to clear the same field is the ambiguity
+    this round exists to remove. Its test moved with it:
+    `TestStartedRunDoesNotInheritThePreviousRunsWorkingDir` became
+    `TestReservedRunDoesNotInheritThePreviousRunsWorkingDir`, which asserts the
+    directory is disclaimed at Reserve and that a `Started` reporting none does
+    not put it back.
+  - Round 11's workspace and keep-set guards (M12-M16) were not re-run.
+    `workspace.go` and `behaviours.go`'s resolution are untouched by this round,
+    they were verified RED in round 11 against tests this round did not change,
+    and re-running them costs ten minutes for no new information.
+  - Gates, on the committed tree: `make test` `405 passed / 9 skipped`,
+    `make race` `404 passed / 10 skipped`, `make lint` `0 issues.`. The five
+    extra over round 11's 400 are
+    `TestKillingALostJobSparesTheRunThatReplacesIt`,
+    `TestKilledLostJobsReplacementIsStillWatched`,
+    `TestKilledLostJobsReservationIsARunOfItsOwn`,
+    `TestReservedRunDoesNotClaimThePreviousRunsHost` and
+    `TestASlowStartedRunIsNotStillLost`;
+    `TestStartedRunDoesNotInheritThePreviousRunsWorkingDir` was renamed
+    `TestReservedRunDoesNotInheritThePreviousRunsWorkingDir` rather than added.
+
+## Why this is stacked on #558
+
+`pinnedBehaviours` carries a `jobWorkSpaceSnapshot`, and `jobqueue/workspace.go`
+does not exist on develop, so this work cannot compile on a branch based on
+develop. Expressing the pin without that type was considered and rejected:
+
+- The token gate alone does not fix LAYER 51. `killLostRun` releases the job
+  before the behaviours run, so between the proof and the trigger a runner can
+  reserve the retry and its first Touch can write the retry's working directory
+  onto the same `*Job`. The state has to be pinned as well as the run identified,
+  which is why LAYER 51 and LAYER 54 are two findings rather than one.
+- Pinning the state on a develop-shaped `behaviours.go` means a second carrier
+  type, and changing the signatures of `Behaviour.cleanup`, `Behaviour.run` and
+  `Behaviours.trigger` to take it - the same functions #558 changes, differently.
+  Two PRs refactoring one function two ways is worse to review and worse to merge
+  than a stack.
+- `jobqueue/lost_job_behaviours_test.go` also needs `cleanupProvenHook` and
+  `runResolvedHook`, which are #558's seams, and `soPathsExist`/`soPathsGone`,
+  which live in #558's `behaviours_test.go`. Stacking means none of the three is
+  duplicated.
+
+Nothing was duplicated between the two branches, and no regression test was
+weakened or dropped to make the split possible: every test moved whole.

--- a/.docs/bugfixes/260901-2.md
+++ b/.docs/bugfixes/260901-2.md
@@ -1,0 +1,169 @@
+# Bugfixes 260901-2
+
+PR #562 (branch `fix-lost-job-run-identity`): unbounded concurrent lost-job
+cleanups could exhaust the manager's file descriptors.
+
+## Where this came from
+
+A reviewer on PR #558 asked whether multiple cleanups can run at once and
+whether that can exhaust file descriptors. They can, and it can. This is a
+review question answered with the smallest fix that bounds the resource - no
+config option, no timing knob, no new package, no restructuring of the lost-job
+paths.
+
+## The descriptor arithmetic
+
+Measured, not assumed (a throwaway test counted `/proc/self/fd` around the real
+walk for a Job whose workspace `mkHashedDir` really created):
+
+- The workspace is `createdCwdDepth - 1` = 5 path components below the Job's
+  `Cwd` (`createdCwdDepth` = `mkHashedLevels + 2` = 6 is the working directory
+  inside it; `workSpacePaths.workSpace` is `filepath.Dir(actualCwd)`).
+- `jobWorkSpace.cleanup` holds the whole descent OPEN for as long as the
+  emptying and the upward walk take: `prove` -> `openBaseRoot(cwd)` is 1
+  `*os.Root`, `provenDirs.openChain` opens 4 more (`names[:len-1]`, the base
+  handle being `roots[0]`), and `dirChain.openLeaf` opens the workspace itself.
+  Counted: `base=7 afterResolve=8 (+1) afterChain=12 (+5) afterLeaf=13 (+6)`,
+  ie. **6 descriptors** for a Job with no mounts.
+- A Job whose working directory must be opened separately to spare a cache
+  (`removeActualCwd` -> `openVerifiedDir`) holds a **7th** while it sweeps.
+
+Against that:
+
+- Lost-job handling was unbounded: `go s.confirmOrReleaseLostJob(...)` in
+  `markJobLost` and then `go s.killLostJobAndTriggerBehaviours(...)` in
+  `confirmJobDeadAndKill` are one goroutine per lost job, with no semaphore,
+  errgroup or worker pool anywhere on that path. The pinned behaviours those
+  goroutines trigger are what run the cleanup, in the MANAGER process.
+- wr never raises its own `RLIMIT_NOFILE`: there is no `Setrlimit` in the tree
+  (`grep -rn 'Setrlimit\|RLIMIT_NOFILE' --include='*.go'` finds nothing), so the
+  manager lives with whatever it inherited, commonly 1024. A few hundred
+  simultaneous cleanups exhaust that table, and a farm-wide loss of contact
+  makes many jobs lost in the same breath - the submission that prompted this
+  work had 19,632 jobs.
+- develop held essentially nothing here: `Behaviour.cleanup` there called
+  `removeAllManaged`/`removeActualCwd` and `rmEmptyDirs` on path STRINGS, and
+  `jobqueue/workspace.go` does not exist on develop. The held descriptors are
+  cost these branches added, which is why bounding them belongs here.
+
+The repo has no existing idiom that fits. `limiter` is for job limit groups (a
+named group with a capacity, driven by the queue's own accounting), not for
+bounding goroutines; there is no `errgroup` or `golang.org/x/sync/semaphore`
+use in the tree. So: a plain buffered channel.
+
+## The fix
+
+- [x] Bound how many lost jobs may have their pinned behaviours running at once,
+  with a buffered channel on the `Server` (`lostCleanupTokens`, made in `Serve`
+  beside `stopClientHandling`).
+  - Only the BEHAVIOURS are bounded, not the kill: `killLostJobAndTriggerBehaviours`
+    still calls `killLostRun` and makes its release decision immediately, and the
+    new `Server.triggerLostRunBehaviours` acquires a token only around
+    `d.pin.trigger(false)`. A job whose runner is confirmed dead is killed
+    promptly however long the queue of cleanups is, and the test pins that
+    (every kill decision is awaited while 32 cleanups are held).
+  - Blocking, not dropping: a queued cleanup still happens. A goroutine parked
+    on the channel costs a couple of KB; a descriptor is the scarce resource.
+  - The acquire is a `select` against `s.stopClientHandling`, the established
+    shutdown idiom on this path (`confirmJobDeadAndKillAfterRetryTime` and
+    `serveClientsReader` both select on it), so a shutting-down manager never
+    waits on a full channel. A shutdown that skips a cleanup leaks a workspace,
+    which the next manager's cleanup of the same lost run deletes; a shutdown
+    blocked behind a full channel is not recoverable.
+  - No lock is held across the wait (DEVELOPERS.md section 2): the acquire is
+    the first thing in `triggerLostRunBehaviours`, whose caller holds nothing -
+    `markJobLost` released `job` and the queue mutex long before, and
+    `killLostRun` returned before the kill was logged.
+  - Limit: `maxConcurrentLostCleanups = 32`. 32 x 7 descriptors is ~224, about a
+    fifth of a conservative inherited 1024, leaving the rest for client sockets,
+    the database and the web server. Not configurable, and deliberately a
+    constant rather than a knob: it is a property of the descriptor table, not of
+    a workload.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    go test ./jobqueue/ -run TestLostJobCleanupsAreBounded -v -count 1
+
+The test drives `lostCleanupDrivers` = 64 real lost runs of one real manager
+through `killLostJobAndTriggerBehaviours`, holding every cleanup at
+`cleanupProvenHook` until the test sends it on its way, and counts how many are
+held at once. Because the hook blocks, the count is decided by the test and by
+the bound rather than by how fast the box is: a held cleanup is still holding its
+descriptors.
+
+Red evidence, with the acquire removed (the pre-fix shape):
+
+```
+  Given more lost jobs confirmed dead than the manager may clean up at once ✔✔✔✔✔
+    no more than maxConcurrentLostCleanups of their cleanups run at once ✔✘
+
+Failures:
+
+  * /home/ubuntu/wr_clone2/jobqueue/lost_job_behaviours_test.go
+  Line 1615:
+  Expected '64' to be less than or equal to '32' (but it wasn't)!
+
+--- FAIL: TestLostJobCleanupsAreBounded (0.32s)
+```
+
+All 64 got in - the count equals the number of jobs driven, as the reviewer's
+arithmetic predicts. The failing assertion is made at a moment with no releases
+sent yet, so `inside` == `entered` there and the number is exact rather than
+sampled. An earlier red run of the same shape also logged four
+`readdirent ... no such file or directory` warnings, which is 64 concurrent
+upward walks racing each other over the empty parent directories they share
+below one `Cwd` - another symptom of the same unboundedness, absent from the
+green run.
+
+Green: `13 total assertions`, `--- PASS: TestLostJobCleanupsAreBounded (0.32s)`,
+and stable over `-race -count 5` (3.9s).
+
+## Mutation check
+
+`go vet ./jobqueue/` was run after each edit, so no verdict below is a build
+failure masquerading as a dead guard.
+
+- [x] M1: remove the `select` acquire and the `defer` release from
+  `triggerLostRunBehaviours` (the pre-fix shape). Vet OK. **RED**:
+  `Expected '64' to be less than or equal to '32' (but it wasn't)!`
+- [x] M2: `maxConcurrentLostCleanups = 100000`, ie. effectively unlimited. Vet
+  OK. **RED**: the bound is never reached, so `reachedLimit()` is false
+  (`lost_job_behaviours_test.go:1619`, `Expected: true Actual: false`), and the
+  test says so rather than passing on a bound nothing tests against. This is why
+  `lostCleanupDrivers` is a literal 64 rather than a multiple of the constant:
+  scaling with the constant would have hidden this mutation.
+- [x] Both reverted, `jobqueue/server.go` byte-identical to the fixed tree, and
+  green again.
+
+## Files touched
+
+- `jobqueue/server.go`: the `maxConcurrentLostCleanups` constant, the
+  `Server.lostCleanupTokens` field, its `make` in `Serve`, and
+  `Server.triggerLostRunBehaviours` extracted from the tail of
+  `killLostJobAndTriggerBehaviours` (which now ends in a call to it). Nothing
+  else on the lost-job path moved.
+- `jobqueue/lost_job_behaviours_test.go`: `TestLostJobCleanupsAreBounded` and the
+  `boundedCleanups` gate, plus the `newLostRuns` / `loseEveryRun` /
+  `startAndLoseRun` / `countGone` fixture helpers.
+
+## Gates
+
+On the committed tree, from the repo root with all `OS_*` unset:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `414 passed - 9 skipped - 29 packages - 3m50s`.
+- `make race`: `414 passed - 9 skipped - 29 packages - 4m40s`.
+- `make lint`: `0 issues.`
+
+The baseline was 413 passed / 9 skipped; the one extra is
+`TestLostJobCleanupsAreBounded`.
+
+## What this fix does NOT claim
+
+It bounds the descriptors held by lost-job cleanups. It does not bound the
+goroutines: one per lost job is still spawned, and the ones beyond the bound wait
+in the channel, which is the trade the fix is making. It also does not touch the
+other callers of `TriggerBehaviours` (a runner's own end-of-job behaviours run
+one per runner PROCESS, so there is nothing to bound in the manager), and it does
+not raise `RLIMIT_NOFILE`, which remains inherited.

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -70,16 +70,12 @@ var (
 )
 
 // lostJobDeadCheckedHook and lostJobKilledHook, when set, are called in the two
-// moments a lost job's behaviours have to survive, and are nil in production. A
-// test cannot get into either reliably any other way.
+// moments a lost job's behaviours have to survive; both are nil in production.
 //
-// lostJobDeadCheckedHook is called where the dead-check returns and before the
-// kill, which is the far end of the window between the manager pinning the lost
-// run and acting on it: a 15 second ssh round trip in which the job can recover,
-// be released, and be reserved and started again as a different run.
-// lostJobKilledHook is called with what the kill decided, in the moment before
-// the pinned behaviours run, which is when a runner can reserve the retry and
-// touch its new working directory onto the same Job.
+// lostJobDeadCheckedHook is called once the dead-check has returned and before
+// the kill, the far end of the window in which the job can recover, or be
+// released and reserved again as a different run. lostJobKilledHook is called
+// with what the kill decided, before the pinned behaviours run.
 //
 //nolint:gochecknoglobals // test hooks into two moments that cannot be reached otherwise
 var (
@@ -182,8 +178,8 @@ func (b *Behaviour) Trigger(status BehaviourTrigger, j *Job) error {
 	return b.trigger(status, j.workSpaceSnapshot())
 }
 
-// trigger is Trigger against a Job state that was pinned when the behaviours
-// were decided on, which is not always the same moment; see pinnedBehaviours.
+// trigger is Trigger against a pinned copy of the Job's state; see
+// pinnedBehaviours.
 func (b *Behaviour) trigger(status BehaviourTrigger, ws jobWorkSpaceSnapshot) error {
 	if b.When&status == 0 {
 		return nil
@@ -381,8 +377,8 @@ func (bs Behaviours) Trigger(success bool, j *Job) error {
 	return bs.trigger(success, j.workSpaceSnapshot())
 }
 
-// trigger is Trigger against a Job state that was pinned when the behaviours
-// were decided on, which is not always the same moment; see pinnedBehaviours.
+// trigger is Trigger against a pinned copy of the Job's state; see
+// pinnedBehaviours.
 func (bs Behaviours) trigger(success bool, ws jobWorkSpaceSnapshot) error {
 	var status BehaviourTrigger
 	if success {
@@ -411,43 +407,24 @@ func (bs Behaviours) trigger(success bool, ws jobWorkSpaceSnapshot) error {
 	return merr.ErrorOrNil()
 }
 
-// pinnedBehaviours is a Job's Behaviours together with the state they must act
-// on, both taken at ONE moment under the Job's lock and carried to them as a
-// value.
+// pinnedBehaviours is a Job's Behaviours together with the state they act on -
+// the key and ActualCwd naming the working directory they delete and run the
+// user's command in - copied at ONE moment under the Job's lock.
 //
-// Behaviours delete the Job's working directory and run the user's own command
-// inside it, and which directory that is comes from the (key, ActualCwd) pair
-// the Job carries. Deciding to trigger them and triggering them are not always
-// the same moment: the manager decides when it declares a job lost, then the
-// kill RELEASES that Job back to ready before the behaviours run, so a runner can
-// reserve the RETRY and its first Touch writes the retry's working directory
-// into that same Job (emitLiveTouchSnapshot -> applyLiveSnapshot). Reading the
-// Job afterwards read the retry's directory: measured, the `run` behaviour's pwd
-// was the retry's, the retry's partial output, working directory and live TMPDIR
-// were deleted while it ran, the workspace that was actually abandoned leaked,
-// and the error was nil - the retry is the same Job with the same key, so no
-// proof about the path can tell the two apart.
+// The manager pins when it declares a job lost, not when it triggers, because
+// the kill releases that Job back to ready first: a runner can then reserve the
+// RETRY, and its first Touch writes the retry's working directory onto the same
+// Job (emitLiveTouchSnapshot -> applyLiveSnapshot). Triggering off the Job at
+// that point deletes the live directory of the retry, and since the retry is the
+// same Job under the same key, no check on the path can tell the two apart.
 //
-// Pinning is what fixes that, and it is the only thing that can: it is not the
-// resolution that is wrong, it is being asked a question about a moment that has
-// passed. Every other caller triggers the behaviours of a Job it holds alone, so
-// for them the pin is taken at the call itself (Behaviours.Trigger).
-//
-// WHEN the pin is taken is as load-bearing as the pin. The manager's decision is
-// made in markJobLost, and everything after it - a 15 second ssh round trip in
-// confirmJobDead, or half an hour of retry timer - happens while the job is free
-// to move on. A pin taken after that trip is a pin of whatever run the job is on
-// by then, which is how the retry came to be pinned in the first place. The pin
-// is therefore taken with the decision and carried (lostJobDetails.pin), and
-// what the pin describes is checked to still be the run at the queue before
-// anything acts on it (isLostRunLocked).
+// Behaviours.Trigger pins at the call, for the callers that hold the Job alone.
 type pinnedBehaviours struct {
 	behaviours Behaviours
 	workSpace  jobWorkSpaceSnapshot
 
-	// run is the token the manager minted for the run this pin belongs to, and
-	// is what says the pin is still about the run at the queue when the time
-	// comes to act on it. See runToken and Job.isLostRunLocked.
+	// run says which run was pinned, so isLostRunLocked can check the queue is
+	// still on that run before anything acts on the pin. See runToken.
 	run runToken
 }
 
@@ -461,15 +438,12 @@ func (j *Job) pinBehaviours() pinnedBehaviours {
 }
 
 // pinBehavioursLocked is pinBehaviours for a caller that already holds at least
-// the Job's read lock, so that the pin can be taken in the same breath as the
-// decision it belongs to - which for the manager is the moment it declares the
-// job lost, not the moment 15 seconds later when it gets round to the kill.
+// the Job's read lock, so the pin can be taken with the decision it belongs to.
 func (j *Job) pinBehavioursLocked() pinnedBehaviours {
 	return pinnedBehaviours{behaviours: j.Behaviours, workSpace: j.workSpaceSnapshotLocked(), run: j.runID}
 }
 
-// trigger runs the pinned Behaviours against the pinned state, as
-// Behaviours.Trigger does against a Job's current state.
+// trigger runs the pinned Behaviours against the pinned state.
 func (p pinnedBehaviours) trigger(success bool) error {
 	return p.behaviours.trigger(success, p.workSpace)
 }

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -298,13 +298,7 @@ func (b *Behaviour) String() string {
 // kept, is decided entirely by resolveWorkSpace. A nil workspace means wr created
 // nothing here that it may delete.
 func (b *Behaviour) cleanup(snap jobWorkSpaceSnapshot, _ bool) error {
-	ws, err := snap.resolveWorkSpace()
-	if err != nil || ws == nil {
-		return err
-	}
-	defer ws.Close()
-
-	return ws.cleanup()
+	return snap.cleanupWorkSpace()
 }
 
 // run runs the given command in the directory the Job's Cmd ran in.

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -71,11 +71,9 @@ var (
 
 // lostJobDeadCheckedHook and lostJobKilledHook, when set, are called in the two
 // moments a lost job's behaviours have to survive; both are nil in production.
-//
-// lostJobDeadCheckedHook is called once the dead-check has returned and before
-// the kill, the far end of the window in which the job can recover, or be
-// released and reserved again as a different run. lostJobKilledHook is called
-// with what the kill decided, before the pinned behaviours run.
+// lostJobDeadCheckedHook is called after the dead-check and before the kill, the
+// window in which the job can recover or be reserved again as a different run;
+// lostJobKilledHook with what the kill decided, before the behaviours run.
 //
 //nolint:gochecknoglobals // test hooks into two moments that cannot be reached otherwise
 var (
@@ -178,8 +176,7 @@ func (b *Behaviour) Trigger(status BehaviourTrigger, j *Job) error {
 	return b.trigger(status, j.workSpaceSnapshot())
 }
 
-// trigger is Trigger against a pinned copy of the Job's state; see
-// pinnedBehaviours.
+// trigger is Trigger against a pinned copy of the Job's state; see pinnedBehaviours.
 func (b *Behaviour) trigger(status BehaviourTrigger, ws jobWorkSpaceSnapshot) error {
 	if b.When&status == 0 {
 		return nil
@@ -377,8 +374,7 @@ func (bs Behaviours) Trigger(success bool, j *Job) error {
 	return bs.trigger(success, j.workSpaceSnapshot())
 }
 
-// trigger is Trigger against a pinned copy of the Job's state; see
-// pinnedBehaviours.
+// trigger is Trigger against a pinned copy of the Job's state; see pinnedBehaviours.
 func (bs Behaviours) trigger(success bool, ws jobWorkSpaceSnapshot) error {
 	var status BehaviourTrigger
 	if success {
@@ -411,14 +407,12 @@ func (bs Behaviours) trigger(success bool, ws jobWorkSpaceSnapshot) error {
 // the key and ActualCwd naming the working directory they delete and run the
 // user's command in - copied at ONE moment under the Job's lock.
 //
-// The manager pins when it declares a job lost, not when it triggers, because
-// the kill releases that Job back to ready first: a runner can then reserve the
-// RETRY, and its first Touch writes the retry's working directory onto the same
-// Job (emitLiveTouchSnapshot -> applyLiveSnapshot). Triggering off the Job at
-// that point deletes the live directory of the retry, and since the retry is the
-// same Job under the same key, no check on the path can tell the two apart.
-//
-// Behaviours.Trigger pins at the call, for the callers that hold the Job alone.
+// The manager pins when it declares a job lost, not when it triggers, because the
+// kill releases that Job back to ready first: a runner can then reserve the RETRY,
+// whose first Touch writes its working directory onto the same Job. Triggering off
+// the Job then deletes the retry's live directory, and as the retry is the same Job
+// under the same key, no check on the path tells the two apart. Behaviours.Trigger
+// pins at the call, for the callers that hold the Job alone.
 type pinnedBehaviours struct {
 	behaviours Behaviours
 	workSpace  jobWorkSpaceSnapshot
@@ -428,8 +422,7 @@ type pinnedBehaviours struct {
 	run runToken
 }
 
-// pinBehaviours pins this Job's Behaviours and the state they must act on, as
-// they are now, for triggering later.
+// pinBehaviours pins this Job's Behaviours and the state they act on, as they are now.
 func (j *Job) pinBehaviours() pinnedBehaviours {
 	j.RLock()
 	defer j.RUnlock()

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -69,6 +69,24 @@ var (
 	runProvenHook   func()
 )
 
+// lostJobDeadCheckedHook and lostJobKilledHook, when set, are called in the two
+// moments a lost job's behaviours have to survive, and are nil in production. A
+// test cannot get into either reliably any other way.
+//
+// lostJobDeadCheckedHook is called where the dead-check returns and before the
+// kill, which is the far end of the window between the manager pinning the lost
+// run and acting on it: a 15 second ssh round trip in which the job can recover,
+// be released, and be reserved and started again as a different run.
+// lostJobKilledHook is called with what the kill decided, in the moment before
+// the pinned behaviours run, which is when a runner can reserve the retry and
+// touch its new working directory onto the same Job.
+//
+//nolint:gochecknoglobals // test hooks into two moments that cannot be reached otherwise
+var (
+	lostJobDeadCheckedHook func()
+	lostJobKilledHook      func(released bool)
+)
+
 // BehaviourTrigger is supplied to a Behaviour to define under what circumstance
 // that Behaviour will trigger.
 type BehaviourTrigger uint8
@@ -164,9 +182,8 @@ func (b *Behaviour) Trigger(status BehaviourTrigger, j *Job) error {
 	return b.trigger(status, j.workSpaceSnapshot())
 }
 
-// trigger is Trigger against a snapshot of the Job's state taken once, rather
-// than against the Job itself; see Behaviours.trigger for why the snapshot is
-// shared by a whole set.
+// trigger is Trigger against a Job state that was pinned when the behaviours
+// were decided on, which is not always the same moment; see pinnedBehaviours.
 func (b *Behaviour) trigger(status BehaviourTrigger, ws jobWorkSpaceSnapshot) error {
 	if b.When&status == 0 {
 		return nil
@@ -367,8 +384,12 @@ func (bs Behaviours) Trigger(success bool, j *Job) error {
 		return nil
 	}
 
-	ws := j.workSpaceSnapshot()
+	return bs.trigger(success, j.workSpaceSnapshot())
+}
 
+// trigger is Trigger against a Job state that was pinned when the behaviours
+// were decided on, which is not always the same moment; see pinnedBehaviours.
+func (bs Behaviours) trigger(success bool, ws jobWorkSpaceSnapshot) error {
 	var status BehaviourTrigger
 	if success {
 		status = OnSuccess
@@ -394,6 +415,69 @@ func (bs Behaviours) Trigger(success bool, j *Job) error {
 	}
 
 	return merr.ErrorOrNil()
+}
+
+// pinnedBehaviours is a Job's Behaviours together with the state they must act
+// on, both taken at ONE moment under the Job's lock and carried to them as a
+// value.
+//
+// Behaviours delete the Job's working directory and run the user's own command
+// inside it, and which directory that is comes from the (key, ActualCwd) pair
+// the Job carries. Deciding to trigger them and triggering them are not always
+// the same moment: the manager decides when it declares a job lost, then the
+// kill RELEASES that Job back to ready before the behaviours run, so a runner can
+// reserve the RETRY and its first Touch writes the retry's working directory
+// into that same Job (emitLiveTouchSnapshot -> applyLiveSnapshot). Reading the
+// Job afterwards read the retry's directory: measured, the `run` behaviour's pwd
+// was the retry's, the retry's partial output, working directory and live TMPDIR
+// were deleted while it ran, the workspace that was actually abandoned leaked,
+// and the error was nil - the retry is the same Job with the same key, so no
+// proof about the path can tell the two apart.
+//
+// Pinning is what fixes that, and it is the only thing that can: it is not the
+// resolution that is wrong, it is being asked a question about a moment that has
+// passed. Every other caller triggers the behaviours of a Job it holds alone, so
+// for them the pin is taken at the call itself (Behaviours.Trigger).
+//
+// WHEN the pin is taken is as load-bearing as the pin. The manager's decision is
+// made in markJobLost, and everything after it - a 15 second ssh round trip in
+// confirmJobDead, or half an hour of retry timer - happens while the job is free
+// to move on. A pin taken after that trip is a pin of whatever run the job is on
+// by then, which is how the retry came to be pinned in the first place. The pin
+// is therefore taken with the decision and carried (lostJobDetails.pin), and
+// what the pin describes is checked to still be the run at the queue before
+// anything acts on it (isLostRunLocked).
+type pinnedBehaviours struct {
+	behaviours Behaviours
+	workSpace  jobWorkSpaceSnapshot
+
+	// run is the token the manager minted for the run this pin belongs to, and
+	// is what says the pin is still about the run at the queue when the time
+	// comes to act on it. See runToken and Job.isLostRunLocked.
+	run runToken
+}
+
+// pinBehaviours pins this Job's Behaviours and the state they must act on, as
+// they are now, for triggering later.
+func (j *Job) pinBehaviours() pinnedBehaviours {
+	j.RLock()
+	defer j.RUnlock()
+
+	return j.pinBehavioursLocked()
+}
+
+// pinBehavioursLocked is pinBehaviours for a caller that already holds at least
+// the Job's read lock, so that the pin can be taken in the same breath as the
+// decision it belongs to - which for the manager is the moment it declares the
+// job lost, not the moment 15 seconds later when it gets round to the kill.
+func (j *Job) pinBehavioursLocked() pinnedBehaviours {
+	return pinnedBehaviours{behaviours: j.Behaviours, workSpace: j.workSpaceSnapshotLocked(), run: j.runID}
+}
+
+// trigger runs the pinned Behaviours against the pinned state, as
+// Behaviours.Trigger does against a Job's current state.
+func (p pinnedBehaviours) trigger(success bool) error {
+	return p.behaviours.trigger(success, p.workSpace)
 }
 
 // RemovalRequested tells you if one of the behaviours is Remove.

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -2649,6 +2649,12 @@ func (c *Client) Started(job *Job, pid int) error {
 	requestJob.Host = job.Host
 	requestJob.HostIP = job.HostIP
 	requestJob.Pid = job.Pid
+
+	// the working directory this run is going to use, which resolveWorkingDir
+	// has already created. Reporting it HERE is what lets the manager clean up
+	// after a run that dies without ever touching, and after every run at all on
+	// a manager with no web port, which never asks for a live snapshot.
+	requestJob.ActualCwd = job.ActualCwd
 	job.Unlock()
 
 	_, err = c.request(&clientRequest{Method: requestMethodStart, Job: requestJob})

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1455,19 +1455,17 @@ func (c *Client) ensureCwdExists(job *Job) error {
 
 // cleanupUnstartedWorkSpace removes the working directory Execute made for a run
 // whose command never started. Every failure between resolveWorkingDir and a
-// successful cmd.Start() returns without the job's behaviours running - the job
-// is buried, released, or left reserved - so nothing else would remove that
-// directory, and the abandoned leaf also stops rmEmptyDirsIn reclaiming the
-// hashed levels above it. The behaviours are deliberately not run: OnFailure
-// would execute the user's `run` command on, say, a mount failure. Only what
-// resolveWorkSpace can show wr built for this Job's key goes.
+// successful cmd.Start() returns without the job's behaviours running, so nothing
+// else would remove that directory, and the abandoned leaf also stops
+// rmEmptyDirsIn reclaiming the hashed levels above it. The behaviours are
+// deliberately not run: OnFailure would execute the user's `run` command on, say,
+// a mount failure.
 //
 // Unmounting comes FIRST, and a failed unmount deletes nothing at all: the
 // pre-start failure paths do not all unmount, a Job with no ActualCwd-relative
-// Mount has the working directory itself as a mount point, and deleting through
-// a live mount would delete the user's remote data. A leaked workspace is
-// recoverable; that is not. Job.Unmount is safe to call whether or not something
-// already did, since unmountAll clears the Job's mounted filesystems.
+// Mount has the working directory itself as a mount point, and deleting through a
+// live mount would delete the user's remote data. A leaked workspace is
+// recoverable; that is not. Job.Unmount is safe to call twice.
 //
 // Failures are logged rather than returned because Execute's myerr is a plain
 // local returned at the end of the function, so a deferred assignment to it
@@ -2701,9 +2699,9 @@ func (c *Client) Started(job *Job, pid int) error {
 	requestJob.HostIP = job.HostIP
 	requestJob.Pid = job.Pid
 
-	// the working directory resolveWorkingDir already created for this run.
-	// Reporting it HERE is what lets the manager clean up after a run that dies
-	// without ever touching, and after every run on a manager with no web port.
+	// the working directory resolveWorkingDir already created. Reporting it HERE
+	// lets the manager clean up after a run that dies without ever touching, and
+	// after every run on a manager with no web port.
 	requestJob.ActualCwd = job.ActualCwd
 	job.Unlock()
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -481,46 +481,6 @@ func reserveHostAndPid() (string, int) {
 	return host, os.Getpid()
 }
 
-// cleanupUnstartedWorkSpace removes the working directory Execute made for a run
-// whose command never started. Every failure between resolveWorkingDir and a
-// successful cmd.Start() returns without the job's behaviours ever running - it
-// is buried, released, or left reserved - so nothing else will ever remove that
-// directory, and the abandoned leaf also stops rmEmptyDirsIn reclaiming the
-// hashed levels wr made above it.
-//
-// The job's own behaviours are deliberately NOT run: OnFailure would execute the
-// user's `run` command on, say, a mount failure. Only what wr created goes.
-//
-// Unmounting comes FIRST, and a failed unmount deletes nothing at all: the
-// pre-start failure paths do not all unmount, a mount point of a Job with no
-// ActualCwd-relative Mount is the working directory itself, and deleting through
-// a live mount would delete the user's remote data. Leaving a workspace behind is
-// recoverable; that is not. Job.Unmount is safe to call whether or not something
-// already did, since unmountAll clears the Job's mounted filesystems.
-//
-// Nothing is deleted that the workspace resolution cannot prove wr built for this
-// Job's key, which is also what keeps a live mount's directory: cleanupWorkSpace
-// is the same proven path Behaviour.cleanup takes.
-//
-// Failures are reported rather than returned: Execute's myerr is a plain local
-// returned at the end of the function, so a deferred assignment to it after an
-// early return would be dropped, and a silent leak is one nobody can diagnose.
-func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
-	snap := job.workSpaceSnapshot()
-
-	if _, err := job.Unmount(true); err != nil {
-		clog.Warn(ctx, "not removing the working directory of a run that never started, "+
-			"since unmounting it first failed", "dir", snap.actualCwd, "err", err)
-
-		return
-	}
-
-	if err := snap.cleanupWorkSpace(); err != nil {
-		clog.Warn(ctx, "could not remove the working directory of a run that never started",
-			"dir", snap.actualCwd, "err", err)
-	}
-}
-
 func currentProcessTreeCPUtime(pid int) time.Duration {
 	pid32, ok := processPID(pid)
 	if !ok {
@@ -1491,6 +1451,46 @@ func (c *Client) ensureCwdExists(job *Job) error {
 	}
 
 	return nil
+}
+
+// cleanupUnstartedWorkSpace removes the working directory Execute made for a run
+// whose command never started. Every failure between resolveWorkingDir and a
+// successful cmd.Start() returns without the job's behaviours ever running - it
+// is buried, released, or left reserved - so nothing else will ever remove that
+// directory, and the abandoned leaf also stops rmEmptyDirsIn reclaiming the
+// hashed levels wr made above it.
+//
+// The job's own behaviours are deliberately NOT run: OnFailure would execute the
+// user's `run` command on, say, a mount failure. Only what wr created goes.
+//
+// Unmounting comes FIRST, and a failed unmount deletes nothing at all: the
+// pre-start failure paths do not all unmount, a mount point of a Job with no
+// ActualCwd-relative Mount is the working directory itself, and deleting through
+// a live mount would delete the user's remote data. Leaving a workspace behind is
+// recoverable; that is not. Job.Unmount is safe to call whether or not something
+// already did, since unmountAll clears the Job's mounted filesystems.
+//
+// Nothing is deleted that the workspace resolution cannot prove wr built for this
+// Job's key, which is also what keeps a live mount's directory: cleanupWorkSpace
+// is the same proven path Behaviour.cleanup takes.
+//
+// Failures are reported rather than returned: Execute's myerr is a plain local
+// returned at the end of the function, so a deferred assignment to it after an
+// early return would be dropped, and a silent leak is one nobody can diagnose.
+func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
+	snap := job.workSpaceSnapshot()
+
+	if _, err := job.Unmount(true); err != nil {
+		clog.Warn(ctx, "not removing the working directory of a run that never started, "+
+			"since unmounting it first failed", "dir", snap.actualCwd, "err", err)
+
+		return
+	}
+
+	if err := snap.cleanupWorkSpace(); err != nil {
+		clog.Warn(ctx, "could not remove the working directory of a run that never started",
+			"dir", snap.actualCwd, "err", err)
+	}
 }
 
 // Execute runs the given Job's Cmd and blocks until it exits. Then any Job

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -481,6 +481,46 @@ func reserveHostAndPid() (string, int) {
 	return host, os.Getpid()
 }
 
+// cleanupUnstartedWorkSpace removes the working directory Execute made for a run
+// whose command never started. Every failure between resolveWorkingDir and a
+// successful cmd.Start() returns without the job's behaviours ever running - it
+// is buried, released, or left reserved - so nothing else will ever remove that
+// directory, and the abandoned leaf also stops rmEmptyDirsIn reclaiming the
+// hashed levels wr made above it.
+//
+// The job's own behaviours are deliberately NOT run: OnFailure would execute the
+// user's `run` command on, say, a mount failure. Only what wr created goes.
+//
+// Unmounting comes FIRST, and a failed unmount deletes nothing at all: the
+// pre-start failure paths do not all unmount, a mount point of a Job with no
+// ActualCwd-relative Mount is the working directory itself, and deleting through
+// a live mount would delete the user's remote data. Leaving a workspace behind is
+// recoverable; that is not. Job.Unmount is safe to call whether or not something
+// already did, since unmountAll clears the Job's mounted filesystems.
+//
+// Nothing is deleted that the workspace resolution cannot prove wr built for this
+// Job's key, which is also what keeps a live mount's directory: cleanupWorkSpace
+// is the same proven path Behaviour.cleanup takes.
+//
+// Failures are reported rather than returned: Execute's myerr is a plain local
+// returned at the end of the function, so a deferred assignment to it after an
+// early return would be dropped, and a silent leak is one nobody can diagnose.
+func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
+	snap := job.workSpaceSnapshot()
+
+	if _, err := job.Unmount(true); err != nil {
+		clog.Warn(ctx, "not removing the working directory of a run that never started, "+
+			"since unmounting it first failed", "dir", snap.actualCwd, "err", err)
+
+		return
+	}
+
+	if err := snap.cleanupWorkSpace(); err != nil {
+		clog.Warn(ctx, "could not remove the working directory of a run that never started",
+			"dir", snap.actualCwd, "err", err)
+	}
+}
+
 func currentProcessTreeCPUtime(pid int) time.Duration {
 	pid32, ok := processPID(pid)
 	if !ok {
@@ -1551,6 +1591,20 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return err
 	}
 
+	// one seam covers every way this run can fail before its command starts: see
+	// cleanupUnstartedWorkSpace for why each of them would otherwise leak the
+	// directory we just made, and cmdStarted below for where the run takes it
+	// over.
+	cmdStarted := false
+
+	defer func() {
+		if cmdStarted || actualCwd == "" {
+			return
+		}
+
+		cleanupUnstartedWorkSpace(ctx, job)
+	}()
+
 	if tmpDir != "" {
 		dirsToCheckDiskSpace = append(dirsToCheckDiskSpace, tmpDir)
 	}
@@ -1755,6 +1809,10 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 		return fmt.Errorf("could not start command [%s]: %w%s", jc, err, extra)
 	}
+
+	// the run owns its workspace from here on: the c.Started failure path below
+	// and the normal exit path both trigger the job's behaviours.
+	cmdStarted = true
 
 	clog.Info(ctx, "started executing", "cmd", job.Cmd, "pid", cmd.Process.Pid)
 

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1455,28 +1455,23 @@ func (c *Client) ensureCwdExists(job *Job) error {
 
 // cleanupUnstartedWorkSpace removes the working directory Execute made for a run
 // whose command never started. Every failure between resolveWorkingDir and a
-// successful cmd.Start() returns without the job's behaviours ever running - it
-// is buried, released, or left reserved - so nothing else will ever remove that
+// successful cmd.Start() returns without the job's behaviours running - the job
+// is buried, released, or left reserved - so nothing else would remove that
 // directory, and the abandoned leaf also stops rmEmptyDirsIn reclaiming the
-// hashed levels wr made above it.
-//
-// The job's own behaviours are deliberately NOT run: OnFailure would execute the
-// user's `run` command on, say, a mount failure. Only what wr created goes.
+// hashed levels above it. The behaviours are deliberately not run: OnFailure
+// would execute the user's `run` command on, say, a mount failure. Only what
+// resolveWorkSpace can show wr built for this Job's key goes.
 //
 // Unmounting comes FIRST, and a failed unmount deletes nothing at all: the
-// pre-start failure paths do not all unmount, a mount point of a Job with no
-// ActualCwd-relative Mount is the working directory itself, and deleting through
-// a live mount would delete the user's remote data. Leaving a workspace behind is
+// pre-start failure paths do not all unmount, a Job with no ActualCwd-relative
+// Mount has the working directory itself as a mount point, and deleting through
+// a live mount would delete the user's remote data. A leaked workspace is
 // recoverable; that is not. Job.Unmount is safe to call whether or not something
 // already did, since unmountAll clears the Job's mounted filesystems.
 //
-// Nothing is deleted that the workspace resolution cannot prove wr built for this
-// Job's key, which is also what keeps a live mount's directory: cleanupWorkSpace
-// is the same proven path Behaviour.cleanup takes.
-//
-// Failures are reported rather than returned: Execute's myerr is a plain local
-// returned at the end of the function, so a deferred assignment to it after an
-// early return would be dropped, and a silent leak is one nobody can diagnose.
+// Failures are logged rather than returned because Execute's myerr is a plain
+// local returned at the end of the function, so a deferred assignment to it
+// after an early return would be dropped.
 func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
 	snap := job.workSpaceSnapshot()
 
@@ -1591,10 +1586,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return err
 	}
 
-	// one seam covers every way this run can fail before its command starts: see
-	// cleanupUnstartedWorkSpace for why each of them would otherwise leak the
-	// directory we just made, and cmdStarted below for where the run takes it
-	// over.
+	// one seam covers every way this run can fail before its command starts; see
+	// cleanupUnstartedWorkSpace.
 	cmdStarted := false
 
 	defer func() {
@@ -2708,10 +2701,9 @@ func (c *Client) Started(job *Job, pid int) error {
 	requestJob.HostIP = job.HostIP
 	requestJob.Pid = job.Pid
 
-	// the working directory this run is going to use, which resolveWorkingDir
-	// has already created. Reporting it HERE is what lets the manager clean up
-	// after a run that dies without ever touching, and after every run at all on
-	// a manager with no web port, which never asks for a live snapshot.
+	// the working directory resolveWorkingDir already created for this run.
+	// Reporting it HERE is what lets the manager clean up after a run that dies
+	// without ever touching, and after every run on a manager with no web port.
 	requestJob.ActualCwd = job.ActualCwd
 	job.Unlock()
 

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -39,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/muxfys/v5"
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
@@ -110,6 +111,60 @@ func TestExecuteLiveStateSnapshots(t *testing.T) {
 		So(snapshot.PeakRAM, ShouldEqual, 124)
 		So(snapshot.PeakDisk, ShouldEqual, int64(457))
 		So(snapshot.CPUtime, ShouldEqual, 8*time.Second)
+	})
+}
+
+// TestUnstartedRunWorkSpaceCleanupOrder pins the order the unstarted-run cleanup
+// does its two jobs in, which is the one thing about it that cannot be got wrong
+// safely: a mount point of a job with no relative Mount IS its working directory,
+// so deleting before unmounting would delete the user's remote data.
+func TestUnstartedRunWorkSpaceCleanupOrder(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a directory a job's workspace can be made in", t, func() {
+		cwd := t.TempDir()
+
+		// the Job's mounted filesystems are what unmountAll clears, so how many
+		// are left when the deletion proves what it may delete says which of the
+		// two happened first. -1 means the deletion never got that far.
+		mountedWhenProven := -1
+
+		Reset(func() { cleanupProvenHook = nil })
+
+		Convey("The cleanup unmounts before it deletes anything", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			fs, err := muxfys.New(&muxfys.Config{Mount: filepath.Join(t.TempDir(), testWSMount)})
+			So(err, ShouldBeNil)
+
+			job.mountedFS = append(job.mountedFS, fs)
+			cleanupProvenHook = func() { mountedWhenProven = len(job.mountedFS) }
+
+			cleanupUnstartedWorkSpace(context.Background(), job)
+
+			So(mountedWhenProven, ShouldEqual, 0)
+			soPathsGone(actualCwd, tmpDir, workSpace, filepath.Join(cwd, AppName+createdCwdBaseSuffix))
+			soPathsExist(cwd)
+		})
+
+		Convey("The cleanup deletes nothing at all when the unmount fails", func() {
+			// a mount point that is not a real dir makes Unmount's own empty-dir
+			// tidy-up refuse, which is the cheapest failed unmount to force; what
+			// matters is that ANY of them stops the deletion.
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{Mount: testWSMount}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+			cleanupProvenHook = func() { mountedWhenProven = len(job.mountedFS) }
+
+			So(os.WriteFile(filepath.Join(actualCwd, testWSMount), []byte("x"), liveExecuteFileMode), ShouldBeNil)
+
+			cleanupUnstartedWorkSpace(context.Background(), job)
+
+			So(mountedWhenProven, ShouldEqual, -1)
+			soPathsExist(actualCwd, tmpDir, workSpace, cwd)
+		})
 	})
 }
 
@@ -1263,4 +1318,53 @@ func expectedPrefixSuffixOutput(data []byte) string {
 	So(err, ShouldBeNil)
 
 	return string(bytes.TrimSpace(saver.Bytes()))
+}
+
+// TestClientExecuteUnstartedRunWorkSpace covers the runs that fail between
+// resolveWorkingDir making a working directory and cmd.Start() succeeding. None
+// of them runs the job's behaviours - they bury or release, or return with the
+// job still reserved - so if Execute does not remove the directory it made,
+// nothing ever will, and the abandoned leaf also stops rmEmptyDirsIn ever
+// reclaiming the hashed levels above it.
+func TestClientExecuteUnstartedRunWorkSpace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a job that gets a wr-created working directory", t, func() {
+		capture := &liveTouchCapture{}
+		client := newLiveExecuteCaptureClient(capture)
+		cwd := liveExecuteCwd(t)
+		precious := writeFileIn(cwd, "05_RunCisEQTL.R")
+		hashedBase := filepath.Join(cwd, AppName+createdCwdBaseSuffix)
+
+		Convey("A run whose command cannot start leaves no working directory behind", func() {
+			job := liveExecuteHashedCwdJob(client, cwd, "true")
+			noShell := filepath.Join(t.TempDir(), "no-such-shell")
+
+			err := client.Execute(context.Background(), job, noShell)
+
+			So(job.ActualCwd, ShouldNotBeBlank)
+			soPathsGone(job.ActualCwd, filepath.Dir(job.ActualCwd), hashedBase)
+			soPathsExist(precious, cwd)
+
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("A run whose mounts fail leaves no working directory behind either", func() {
+			// this is the path that buries the job without ever unmounting, and
+			// nothing here is left mounted: Job.Mount unmounts what it managed
+			// before the config that failed, and the cleanup unmounts again.
+			job := liveExecuteHashedCwdJob(client, cwd, "true")
+			job.MountConfigs = MountConfigs{{Mount: testWSMount}}
+
+			err := client.Execute(context.Background(), job, "/bin/sh")
+
+			So(job.ActualCwd, ShouldNotBeBlank)
+			soPathsGone(job.ActualCwd, filepath.Dir(job.ActualCwd), hashedBase)
+			soPathsExist(precious, cwd)
+
+			So(err, ShouldNotBeNil)
+		})
+	})
 }

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1455,38 +1455,29 @@ func (j *Job) statusStreams() (jobStatusStreams, error) {
 }
 
 // runToken identifies ONE run of a Job. The manager mints it at every
-// reservation (resetJobForReservation), and it never leaves the manager: it is
-// only ever compared for equality with a token this manager minted.
+// reservation (resetJobForReservation) and never lets it out: it is only ever
+// compared for equality with a token this manager minted. Counting from 1 keeps
+// the zero token for a run recovered from the database, which it never reserved.
 //
 // The manager mints it rather than reading a field the runner reports, because
-// nothing reported tells two runs of a job apart. Key() and every path below Cwd
-// are the same for every run by construction. ActualCwd is blank throughout a
-// cwd_matters run (setActualCwd), blank on a manager with no web port
-// (liveJTouchEnabled), and blank until a run's first Touch, which never comes for
-// a run that dies inside ClientTouchInterval - and dying is what makes a run
-// lost. Attempts is a count that resetJobStatusFields puts back to 0 for a
-// web-UI rerun.
+// nothing reported tells two runs of a job apart: Key() and every path below Cwd
+// are the same for every run by construction, ActualCwd is blank until a run's
+// first Touch (and always, for a cwd_matters run or a manager with no web port),
+// and Attempts is a count that resetJobStatusFields puts back to 0.
 //
-// A run BEGINS AT RESERVE, so that is where the token is minted. Making the
+// A run BEGINS AT RESERVE, so that is where the token is minted: making the
 // working directory, mounting remote filesystems and starting the Cmd all happen
-// after the reservation and before the runner's Started reaches the manager.
-// Minting at Started left that window carrying the previous run's token, so a
-// confirmation of an earlier loss matched the retry and killed a Cmd that was
-// already executing.
-//
-// Counting from 1 leaves the zero token for a run recovered from the database
-// after a crash, which this manager never reserved.
+// after the reservation and before the runner's Started reaches the manager, so
+// minting at Started left that window carrying the previous run's token, and a
+// confirmation of an earlier loss killed a Cmd that was already executing.
 type runToken uint64
 
 // isLostRunLocked says whether this Job is still lost, and still the RUN the
 // given token was minted for. The caller must hold at least the Job's read lock.
 //
 // Both halves are needed: a job that recovered on a touch is not lost, and a job
-// that was released and reserved again is neither lost nor that run, since
-// resetJobForReservation clears Lost and mints a token in the same breath. A
-// decision pinned to the earlier run is therefore refused from the moment the
-// retry exists, before its runner has made a directory, mounted anything or
-// started a Cmd.
+// that was released and reserved again is neither lost nor that run, so a decision
+// pinned to the earlier run is refused from the moment the retry exists.
 func (j *Job) isLostRunLocked(run runToken) bool {
 	return j.Lost && j.runID == run
 }

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -503,6 +503,10 @@ type Job struct {
 	// killCalled is set for running jobs if Kill() is called on them.
 	killCalled bool
 
+	// runID identifies the RUN this Job is currently on, and is minted by the
+	// manager at every reservation. It is server side only: see runToken.
+	runID runToken
+
 	// incrementedLimitGroups notes that we have incremented limit groups for
 	// this job, so they should be decremented when the job finishes running.
 	incrementedLimitGroups []string
@@ -1448,6 +1452,69 @@ func (j *Job) statusStreams() (jobStatusStreams, error) {
 	streams.envOverrides, err = j.envCurrentOverrides()
 
 	return streams, err
+}
+
+// runToken identifies ONE run of a Job, in the manager that minted it.
+//
+// Nothing else can. A Job's Key() is the same for every run of it by
+// construction - that is what makes it a key - and every path proof is a proof
+// about a directory, so two runs of one job cannot be told apart by anything the
+// filesystem knows either. The state a run leaves on the shared *Job is no
+// better: it is REPORTED by the runner, when the runner gets round to it and if
+// it has anything to report, and a decision about one run that is carried out on
+// another kills a job that is alive.
+//
+// ActualCwd was tried as that identity and is not one. It is blank for the whole
+// of every run of a cwd_matters job (setActualCwd), blank for every run on a
+// manager with no web port (liveJTouchEnabled gates the touch snapshots that
+// carry it), and blank until a run's first Touch - which for a run that dies
+// inside ClientTouchInterval is for ever, and dying is what makes a run lost.
+// In each of those, comparing it compares nothing: "" == "" for two different
+// runs, and a stale value from the previous run for a third.
+//
+// So the token is minted by the MANAGER, in resetJobForReservation, and it is
+// the one thing every run has whatever it reports. It is unexported and never
+// leaves the manager: it is only ever compared for equality with a token this
+// manager minted, so a Job recovered from the database after a crash carries the
+// zero token, which is the run this manager found in progress and is distinct
+// from every run it goes on to mint (mintRunToken counts from 1).
+//
+// A run BEGINS AT RESERVE, which is why that is where it is minted. Everything
+// the runner does that another run's decision could destroy - making the working
+// directory, mounting remote filesystems, starting the Cmd - it does after the
+// reservation and before its Started ever reaches the manager, and the manager's
+// own reservation reset is what puts the job back in the run sub-queue where
+// every lost-run decision looks for it. Minting at Started left that whole
+// window carrying the PREVIOUS run's token: `wr kill` on a lost job releases it,
+// a runner reserves the retry, and the confirmation that comes back seconds
+// later matched the retry and killed a Cmd that was already executing.
+//
+// A run recovered from the database is the one case with no reservation of this
+// manager's behind it, and that is exactly the zero token: a pin taken of it
+// names run 0, and every run this manager reserves afterwards names something
+// else.
+//
+// Job.Attempts was the obvious candidate, but it is a COUNT rather than an
+// identity: resetJobStatusFields sets it back to 0 so that a web-UI rerun
+// starts counting again, which makes it non-monotonic, and
+// it is an exported field that goes over the wire and that a runner keeps its
+// own copy of (client.go's Started). An identity that another feature is free to
+// reset is not an identity.
+type runToken uint64
+
+// isLostRunLocked says whether this Job is still lost, and still the RUN the
+// given token was minted for. The caller must hold at least the Job's read lock.
+//
+// It is the only thing standing between a decision made about one run and its
+// being carried out on another, and both halves are needed. A job that recovered
+// on a touch is not lost, whatever its token says. A job that was released and
+// re-reserved is neither: its reservation minted it a token of its own and took
+// it off lost in the same breath (resetJobForReservation), so both halves answer
+// no for it from the moment the retry exists - before its runner has made a
+// directory, mounted anything or started a Cmd, all of which happen before the
+// manager hears a word from it.
+func (j *Job) isLostRunLocked(run runToken) bool {
+	return j.Lost && j.runID == run
 }
 
 // setActualCwd records cwd as the unique working directory that wr created below

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1454,65 +1454,39 @@ func (j *Job) statusStreams() (jobStatusStreams, error) {
 	return streams, err
 }
 
-// runToken identifies ONE run of a Job, in the manager that minted it.
+// runToken identifies ONE run of a Job. The manager mints it at every
+// reservation (resetJobForReservation), and it never leaves the manager: it is
+// only ever compared for equality with a token this manager minted.
 //
-// Nothing else can. A Job's Key() is the same for every run of it by
-// construction - that is what makes it a key - and every path proof is a proof
-// about a directory, so two runs of one job cannot be told apart by anything the
-// filesystem knows either. The state a run leaves on the shared *Job is no
-// better: it is REPORTED by the runner, when the runner gets round to it and if
-// it has anything to report, and a decision about one run that is carried out on
-// another kills a job that is alive.
+// The manager mints it rather than reading a field the runner reports, because
+// nothing reported tells two runs of a job apart. Key() and every path below Cwd
+// are the same for every run by construction. ActualCwd is blank throughout a
+// cwd_matters run (setActualCwd), blank on a manager with no web port
+// (liveJTouchEnabled), and blank until a run's first Touch, which never comes for
+// a run that dies inside ClientTouchInterval - and dying is what makes a run
+// lost. Attempts is a count that resetJobStatusFields puts back to 0 for a
+// web-UI rerun.
 //
-// ActualCwd was tried as that identity and is not one. It is blank for the whole
-// of every run of a cwd_matters job (setActualCwd), blank for every run on a
-// manager with no web port (liveJTouchEnabled gates the touch snapshots that
-// carry it), and blank until a run's first Touch - which for a run that dies
-// inside ClientTouchInterval is for ever, and dying is what makes a run lost.
-// In each of those, comparing it compares nothing: "" == "" for two different
-// runs, and a stale value from the previous run for a third.
+// A run BEGINS AT RESERVE, so that is where the token is minted. Making the
+// working directory, mounting remote filesystems and starting the Cmd all happen
+// after the reservation and before the runner's Started reaches the manager.
+// Minting at Started left that window carrying the previous run's token, so a
+// confirmation of an earlier loss matched the retry and killed a Cmd that was
+// already executing.
 //
-// So the token is minted by the MANAGER, in resetJobForReservation, and it is
-// the one thing every run has whatever it reports. It is unexported and never
-// leaves the manager: it is only ever compared for equality with a token this
-// manager minted, so a Job recovered from the database after a crash carries the
-// zero token, which is the run this manager found in progress and is distinct
-// from every run it goes on to mint (mintRunToken counts from 1).
-//
-// A run BEGINS AT RESERVE, which is why that is where it is minted. Everything
-// the runner does that another run's decision could destroy - making the working
-// directory, mounting remote filesystems, starting the Cmd - it does after the
-// reservation and before its Started ever reaches the manager, and the manager's
-// own reservation reset is what puts the job back in the run sub-queue where
-// every lost-run decision looks for it. Minting at Started left that whole
-// window carrying the PREVIOUS run's token: `wr kill` on a lost job releases it,
-// a runner reserves the retry, and the confirmation that comes back seconds
-// later matched the retry and killed a Cmd that was already executing.
-//
-// A run recovered from the database is the one case with no reservation of this
-// manager's behind it, and that is exactly the zero token: a pin taken of it
-// names run 0, and every run this manager reserves afterwards names something
-// else.
-//
-// Job.Attempts was the obvious candidate, but it is a COUNT rather than an
-// identity: resetJobStatusFields sets it back to 0 so that a web-UI rerun
-// starts counting again, which makes it non-monotonic, and
-// it is an exported field that goes over the wire and that a runner keeps its
-// own copy of (client.go's Started). An identity that another feature is free to
-// reset is not an identity.
+// Counting from 1 leaves the zero token for a run recovered from the database
+// after a crash, which this manager never reserved.
 type runToken uint64
 
 // isLostRunLocked says whether this Job is still lost, and still the RUN the
 // given token was minted for. The caller must hold at least the Job's read lock.
 //
-// It is the only thing standing between a decision made about one run and its
-// being carried out on another, and both halves are needed. A job that recovered
-// on a touch is not lost, whatever its token says. A job that was released and
-// re-reserved is neither: its reservation minted it a token of its own and took
-// it off lost in the same breath (resetJobForReservation), so both halves answer
-// no for it from the moment the retry exists - before its runner has made a
-// directory, mounted anything or started a Cmd, all of which happen before the
-// manager hears a word from it.
+// Both halves are needed: a job that recovered on a touch is not lost, and a job
+// that was released and reserved again is neither lost nor that run, since
+// resetJobForReservation clears Lost and mints a token in the same breath. A
+// decision pinned to the earlier run is therefore refused from the moment the
+// retry exists, before its runner has made a directory, mounted anything or
+// started a Cmd.
 func (j *Job) isLostRunLocked(run runToken) bool {
 	return j.Lost && j.runID == run
 }

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -779,6 +779,77 @@ func TestLostJobRetryCheckPinsTheLostRun(t *testing.T) {
 	})
 }
 
+func TestLostJobRetryCheckFindsAReservedNotStartedRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job the manager could not confirm dead the first time", t, func() {
+		l := newLostRun(ctx, t, "lost_job_retry_check_reserved")
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+
+		Convey("its retry check picks up a reservation lost before its Started", func() {
+			// `wr kill` releases the lost run and a runner takes the job on
+			// again, and that reservation goes silent before its Started ever
+			// reaches the manager. It is the run with a confirmation owing: its
+			// host and pid are the reserving runner's, so the death the first
+			// confirmation could not reach the host to establish is exactly what
+			// the thirty-minute re-check is for.
+			l.killAndReserveTheJob(ctx)
+			l.markRetryLost()
+
+			retry, checked := l.server.lostJobRetryCheck(l.key)
+			l.proceedManager()
+
+			// the run the parked confirmation is about is over, so its kill is
+			// refused; the run at the queue is the reservation, and the manager
+			// reports it lost.
+			So(l.waitForKillDecision(), ShouldBeFalse)
+			So(l.reportedState(ctx), ShouldEqual, JobStateLost)
+
+			// and Job.State is written at Started and at each exit, never at
+			// Reserve, so for the whole of this reservation it still reads what
+			// the release of the run before left there. A check that asks it
+			// whether the run is over is asking about a run that is finished.
+			state, _ := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateDelayed)
+
+			So(checked, ShouldBeTrue)
+			So(retry.key, ShouldEqual, l.key)
+			So(retry.pid, ShouldEqual, os.Getpid())
+
+			// pinned as the run it found lost, which is the reservation: it has
+			// made no working directory the manager knows of, so the behaviours
+			// it carries resolve to no workspace at all.
+			So(retry.pin.run, ShouldEqual, l.live.pinBehaviours().run)
+			So(retry.pin.workSpace.actualCwd, ShouldBeBlank)
+		})
+
+		Convey("but a lost run that has exited is refused", func() {
+			// markJobComplete deliberately leaves Lost set and the item in the
+			// run sub-queue, so that the removal counts lost->complete: a
+			// completed run is still a lost job in the run sub-queue for that
+			// stretch. Its run is over, and re-confirming a run that has
+			// reported its own exit could only kill the job it archived.
+			//
+			// The manager is left parked at its dead-check throughout, so
+			// nothing but the archive moves the job (l.stop releases it).
+			_, _, _, srerr := markJobComplete(l.live, &JobEndState{Exited: true, EndTime: time.Now()}, nil)
+
+			exited, checked := l.server.lostJobRetryCheck(l.key)
+
+			So(checked, ShouldBeFalse)
+			So(exited, ShouldResemble, lostJobDetails{})
+			So(srerr, ShouldBeBlank)
+		})
+	})
+}
+
 func TestPinBehavioursIsLocked(t *testing.T) {
 	if runnermode || servermode {
 		return

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -1,0 +1,1382 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+// This file guards the moment a lost job's behaviours run in the MANAGER.
+//
+// Two things have to be true of that moment, and each was got wrong on its own.
+//
+// The behaviours must act on the run that was LOST. killJob releases a lost job
+// back to ready before it returns, so a runner can reserve the RETRY while the
+// behaviours of the lost run are still to come, and the retry's first Touch
+// writes its new working directory onto the very same *Job. Same job, same key,
+// so nothing the workspace resolution proves about a path can tell the two runs
+// apart. Only pinning the state when the job is declared lost can.
+//
+// And they must act only on a run that really was killed. The manager's
+// dead-check is an ssh round trip bounded by ServerLostJobCheckTimeout - fifteen
+// seconds by default - and in it the job can recover on a touch, or be released
+// and started again. Deciding on one run and acting on another swept the working
+// directory of a job that was still RUNNING.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	"github.com/VertebrateResequencing/wr/queue"
+	"github.com/gofrs/uuid/v5"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// lostRunTTR is the ItemTTR the fixture's manager runs with: short enough not
+	// to dominate the test's run time, long enough that a slow box still reaches
+	// the first expiry the way a fast one does.
+	lostRunTTR = 1 * time.Second
+
+	// lostRunSettleTime is how long a test waits for something it expects the
+	// manager to do.
+	lostRunSettleTime = 20 * time.Second
+
+	// noBehaviourWindow is how long a test watches a resumed manager it expects
+	// to run no behaviour at all.
+	noBehaviourWindow = 2 * time.Second
+
+	// retryOutputName is what a cwd_matters retry calls the file it is part way
+	// through writing. It ends in .tmp because the lost run's `run` behaviour
+	// deletes *.tmp in the directory it is given, which is the ordinary shape of
+	// an --on_failure cleanup command and what makes the wrong directory fatal.
+	retryOutputName = "retry_output.tmp"
+)
+
+// lostRunOpts says which ordinary manager and job the fixture is to be. Each
+// combination is a case in which the reported ActualCwd is blank or stale for
+// the whole of a run, so that pinning it identifies no run at all.
+type lostRunOpts struct {
+	// cwdMatters makes the job a --cwd_matters one, which runs directly in the
+	// user's own Cwd and so never has a working directory of wr's - its
+	// ActualCwd is permanently blank (Job.setActualCwd).
+	cwdMatters bool
+
+	// webless makes the fixture behave as a manager with no web port does: it
+	// never enables the live touch snapshots (liveJTouchEnabled), so it learns
+	// nothing about a run after its Started.
+	webless bool
+}
+
+// lostRun is a real manager with one real job in it, reserved, started with a
+// pid that is really dead, and given the workspace a real mkHashedDir made for
+// it - so that letting its TTR expire drives the whole lost-job sequence:
+// ttrCallback -> markJobLost (which pins) -> confirmJobDead (which confirms,
+// because the pid is gone) -> killLostJobAndTriggerBehaviours.
+//
+// The manager runs that sequence on its own goroutine, and the test does every
+// piece of work itself, on its own. Nothing is shared between the two but the
+// channels below and the *Job's own locked fields: a hook that wrote the test's
+// variables was a data race, and so was assigning the hooks after Serve had
+// already started the goroutines that read them - which is why they are assigned
+// BEFORE it, when starting those goroutines is still what orders the two.
+type lostRun struct {
+	server *Server
+	client *Client
+	opts   lostRunOpts
+
+	// key and live are the job's key and the manager's own *Job for it, which is
+	// what every run of the job shares and what a retry writes itself onto.
+	key  string
+	live *Job
+
+	// cwd is the job's Cwd, and ranIn is the file the `run` behaviour reports its
+	// pwd to. It is outside the workspace so that the cleanup behaviour cannot
+	// take the evidence away with it, and OnFailure runs before OnExit, so it is
+	// written before the sweep.
+	cwd   string
+	ranIn string
+
+	// lostCwd, lostTmp and lostOut are the working directory, TMPDIR and output
+	// of the run that gets lost.
+	lostCwd string
+	lostTmp string
+	lostOut string
+
+	// deadChecked and proceed hand the test the window the dead-check occupies:
+	// after the job was declared lost and its behaviours pinned, and before the
+	// kill. That is where a job recovers, or is released and started again.
+	//
+	// killed and resume hand it the moment after the kill decision, which is
+	// where a runner reserves the retry.
+	//
+	// All four are unbuffered, so the manager is PARKED at each moment for as
+	// long as the test wants it to be. A test that asserts nothing was deleted
+	// has to make that assertion at a moment when nothing could yet have deleted
+	// it, and "signal and carry on" is not such a moment: it passes against a
+	// manager that goes on to sweep the directory a millisecond later.
+	deadChecked chan struct{}
+	proceed     chan struct{}
+	killed      chan bool
+	resume      chan struct{}
+
+	// behavioursRan carries the name of the first behaviour moment the manager
+	// reached, if it reached one. Parking the manager proves nothing happened
+	// BEFORE the test looked; this is what proves nothing happens after it is
+	// let go, which is a different claim and needs its own evidence.
+	behavioursRan chan string
+
+	// done releases a parked manager whatever the test did or did not do, so
+	// that a failed test, or a SECOND lost cycle the test never asked for, ends
+	// with the fixture rather than blocking on it.
+	done chan struct{}
+
+	proceedOnce sync.Once
+	resumeOnce  sync.Once
+	doneOnce    sync.Once
+}
+
+// newLostRun builds the fixture. The caller must defer stop().
+func newLostRun(ctx context.Context, t *testing.T, rg string, opts ...lostRunOpts) *lostRun {
+	t.Helper()
+
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(false)
+	serverConfig.Timings.ItemTTR = lostRunTTR
+
+	l := &lostRun{
+		opts:        firstLostRunOpts(opts),
+		cwd:         t.TempDir(),
+		deadChecked: make(chan struct{}), proceed: make(chan struct{}),
+		killed: make(chan bool), resume: make(chan struct{}),
+		behavioursRan: make(chan string, 2), done: make(chan struct{}),
+	}
+	l.ranIn = filepath.Join(l.cwd, "ran_in.txt")
+
+	l.installHooks()
+
+	server, _, token, err := serve(ctx, serverConfig)
+	So(err, ShouldBeNil)
+
+	jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+	So(err, ShouldBeNil)
+
+	l.server, l.client = server, jq
+	l.startLostRun(jq, rg, standardReqs)
+
+	return l
+}
+
+// firstLostRunOpts is the fixture's options, defaulting to the ordinary manager
+// running an ordinary job.
+func firstLostRunOpts(opts []lostRunOpts) lostRunOpts {
+	if len(opts) == 0 {
+		return lostRunOpts{}
+	}
+
+	return opts[0]
+}
+
+// installHooks points the manager's four test seams at this fixture. It runs
+// before Serve, because that is what orders it against the goroutines that read
+// them; the hooks are left in place afterwards, since taking them down again
+// would be the same unordered write in reverse. A stopped fixture's hooks do
+// nothing at all - see done.
+func (l *lostRun) installHooks() {
+	lostJobDeadCheckedHook = func() { l.handOver(l.deadChecked, l.proceed) }
+	lostJobKilledHook = l.killedHook
+	runResolvedHook = func() { l.behaviourRan("run") }
+	cleanupProvenHook = func() { l.behaviourRan("cleanup") }
+}
+
+// startLostRun adds the job, reserves it, makes the workspace of the run that is
+// about to be lost, and starts it with a dead pid.
+//
+// It does those last two in the order a runner does them: Client.Execute
+// resolves the working directory (resolveWorkingDir) before it calls Started, so
+// the run's own Started is the FIRST thing that can tell the manager where the
+// run is working, and on a manager with no web port it is the only thing.
+func (l *lostRun) startLostRun(jq *Client, rg string, reqs *scheduler.Requirements) {
+	job := &Job{
+		Cmd: restFormTrue, Cwd: l.cwd, CwdMatters: l.opts.cwdMatters, RepGroup: rg, ReqGroup: rg,
+		Requirements: reqs, Retries: 3,
+		Behaviours: Behaviours{
+			{When: OnFailure, Do: Run, Arg: "pwd > " + l.ranIn + "; rm -f *" + filepath.Ext(retryOutputName)},
+			{When: OnExit, Do: CleanupAll},
+		},
+	}
+
+	_, _, err := jq.Add([]*Job{job}, os.Environ(), true)
+	So(err, ShouldBeNil)
+
+	reserved, err := jq.Reserve(2 * time.Second)
+	So(err, ShouldBeNil)
+	So(reserved, ShouldNotBeNil)
+
+	l.key = reserved.Key()
+	l.live = l.liveJob()
+
+	l.makeLostWorkSpace(reserved)
+
+	// started with a pid that has already exited, so the manager's dead-check
+	// really does confirm this run dead, through the real scheduler.
+	So(jq.Started(reserved, exitedPid()), ShouldBeNil)
+
+	if !l.opts.cwdMatters && !l.opts.webless {
+		applyLiveSnapshot(l.live, &JobEndState{Cwd: l.lostCwd})
+	}
+}
+
+// makeLostWorkSpace makes the lost run's workspace with the real mkHashedDir,
+// puts output in it, and records it on the runner's own Job exactly as
+// Client.resolveWorkingDir does - which is what its Started then reports.
+//
+// A cwd_matters job gets none of that: its Cmd runs in the user's own Cwd, so wr
+// creates no working directory for it and its ActualCwd stays blank for the
+// whole of every run.
+func (l *lostRun) makeLostWorkSpace(reserved *Job) {
+	if l.opts.cwdMatters {
+		return
+	}
+
+	var err error
+
+	l.lostCwd, l.lostTmp, err = mkHashedDir(l.cwd, l.key)
+	So(err, ShouldBeNil)
+
+	l.lostOut = writeFileIn(l.lostCwd, "abandoned.txt")
+
+	reserved.Lock()
+	reserved.setActualCwd(l.lostCwd)
+	reserved.Unlock()
+}
+
+// handOver parks the manager, telling the test it has reached one of its two
+// moments, until the test gives it back. A stopped fixture does neither.
+func (l *lostRun) handOver(reached, given chan struct{}) {
+	select {
+	case reached <- struct{}{}:
+	case <-l.done:
+		return
+	}
+
+	select {
+	case <-given:
+	case <-l.done:
+	}
+}
+
+// killedHook is handOver for the moment that carries the kill decision with it.
+func (l *lostRun) killedHook(released bool) {
+	select {
+	case l.killed <- released:
+	case <-l.done:
+		return
+	}
+
+	select {
+	case <-l.resume:
+	case <-l.done:
+	}
+}
+
+// behaviourRan records that the manager reached one of the two moments a
+// behaviour cannot get past without acting.
+func (l *lostRun) behaviourRan(which string) {
+	select {
+	case l.behavioursRan <- which:
+	default:
+	}
+}
+
+func (l *lostRun) stop(ctx context.Context) {
+	l.doneOnce.Do(func() { close(l.done) })
+
+	disconnect(l.client)
+	l.server.Stop(ctx, true)
+}
+
+// liveJob is the manager's own *Job for the fixture's job.
+func (l *lostRun) liveJob() *Job {
+	item, err := l.server.q.Get(l.key)
+	So(err, ShouldBeNil)
+
+	job, ok := item.Data().(*Job)
+	So(ok, ShouldBeTrue)
+
+	return job
+}
+
+// waitForDeadCheckWindow blocks until the manager has declared the job lost,
+// pinned its behaviours and confirmed the run dead, and is about to kill it.
+// Whatever the test does next happens in the window that confirmation opened.
+func (l *lostRun) waitForDeadCheckWindow() {
+	select {
+	case <-l.deadChecked:
+	case <-time.After(lostRunSettleTime):
+		So("the job was never declared lost and confirmed dead", ShouldBeBlank)
+	}
+}
+
+// proceedManager lets the manager out of the dead-check window.
+func (l *lostRun) proceedManager() {
+	l.proceedOnce.Do(func() { close(l.proceed) })
+}
+
+// waitForKillDecision returns what the manager's kill decided. The manager stays
+// parked at that decision until resumeManager.
+func (l *lostRun) waitForKillDecision() bool {
+	select {
+	case released := <-l.killed:
+		return released
+	case <-time.After(lostRunSettleTime):
+		So("the manager never reached its kill decision", ShouldBeBlank)
+
+		return false
+	}
+}
+
+// resumeManager lets the manager past its kill decision.
+func (l *lostRun) resumeManager() {
+	l.resumeOnce.Do(func() { close(l.resume) })
+}
+
+// soNoBehaviourRuns lets the manager past its kill decision and asserts that it
+// runs no behaviour at all afterwards.
+//
+// The wait is bounded rather than signalled because what is being asserted is a
+// negative: a manager that was going to act does so as soon as it is let go, so
+// a window several orders of magnitude wider than that is evidence, while no
+// completion signal could tell "did not act" from "has not acted yet".
+func (l *lostRun) soNoBehaviourRuns() {
+	l.resumeManager()
+
+	select {
+	case which := <-l.behavioursRan:
+		So(which, ShouldBeBlank)
+	case <-time.After(noBehaviourWindow):
+	}
+}
+
+// killCalledOnLiveJob says whether the manager has marked the job to kill itself
+// on its next touch.
+func (l *lostRun) killCalledOnLiveJob() bool {
+	l.live.RLock()
+	defer l.live.RUnlock()
+
+	return l.live.killCalled
+}
+
+// jobStateAndKillCalled reports the live job's state and whether the manager has
+// marked it to kill itself on its next touch.
+func (l *lostRun) jobStateAndKillCalled() (JobState, bool) {
+	l.live.RLock()
+	defer l.live.RUnlock()
+
+	return l.live.State, l.live.killCalled
+}
+
+// makeRetryWorkspace makes a second workspace for the same key, with partial
+// output in it, and reports it onto the live *Job the way the retry's first
+// Touch does. It is a second workspace of the SAME key, since it is the same
+// job: that is what nothing about a path can tell apart.
+func (l *lostRun) makeRetryWorkspace() (actualCwd, tmpDir, output string) {
+	l.reserveRetry()
+
+	actualCwd, tmpDir, err := mkHashedDir(l.cwd, l.key)
+	So(err, ShouldBeNil)
+	So(actualCwd, ShouldNotEqual, l.lostCwd)
+
+	output = writeFileIn(actualCwd, "partial.txt")
+
+	applyLiveSnapshot(l.live, &JobEndState{Cwd: actualCwd})
+
+	return actualCwd, tmpDir, output
+}
+
+// startRetryInWindow starts the job again as a second run, the way a runner
+// does: it reserves the job (which is where the manager mints the run and clears
+// the last one off the shared *Job), makes whatever that run works in, then its
+// Started tells the manager, and only a manager with a web port goes on to learn
+// the directory again from the run's touches.
+//
+// A cwd_matters retry works in the shared Cwd, so what it has part way through
+// is a file beside the user's other ones rather than a directory of wr's.
+//
+// touched says whether the retry got as far as its first live Touch. A run's
+// touches are ClientTouchInterval apart - 15 seconds by default - so a run that
+// dies inside that interval, which is the commonest way a node kills a job, is
+// one no touch was ever received for.
+func (l *lostRun) startRetryInWindow(touched bool) (actualCwd, tmpDir, output string) {
+	l.reserveRetry()
+
+	if l.opts.cwdMatters {
+		l.startRetry("", touched)
+
+		return "", "", writeFileIn(l.cwd, retryOutputName)
+	}
+
+	actualCwd, tmpDir, err := mkHashedDir(l.cwd, l.key)
+	So(err, ShouldBeNil)
+	So(actualCwd, ShouldNotEqual, l.lostCwd)
+
+	output = writeFileIn(actualCwd, retryOutputName)
+
+	l.startRetry(actualCwd, touched)
+
+	return actualCwd, tmpDir, output
+}
+
+// reserveRetry is the manager's own reserve-time reset of the shared *Job: what
+// respondWithReservedJob does to it the moment a runner takes the job on again.
+//
+// A retry cannot exist without one, and it is where the run BEGINS: everything
+// the retry's runner does that another run's decision could destroy - making its
+// working directory, mounting, starting the Cmd - it does after this and before
+// its Started reaches the manager.
+func (l *lostRun) reserveRetry() {
+	l.server.resetJobForReservation(l.live, newTestClientID())
+}
+
+// startRetry is the retry's own Started, carrying the working directory it has
+// already made, plus the touch snapshot a manager with a web port gets from a
+// run that lived long enough to touch.
+func (l *lostRun) startRetry(actualCwd string, touched bool) {
+	So(l.server.applyJobStart(l.live, &Job{Pid: os.Getpid(), Host: localhost, ActualCwd: actualCwd}),
+		ShouldBeTrue)
+
+	if actualCwd != "" && touched && !l.opts.webless {
+		applyLiveSnapshot(l.live, &JobEndState{Cwd: actualCwd})
+	}
+}
+
+// killAndReserveTheJob is `wr kill` on a lost job, followed by a runner taking
+// the job on again - both through the real manager, so the item really does go
+// out of the run sub-queue and really does come back into it.
+//
+// killJob is the documented way to deal with a job wr has lost contact with, and
+// its own doc says what it does: it RELEASES the lost job. That opens a window
+// that closes as soon as a runner reserves the retry, and it opens it while the
+// confirmation of the lost run is still to come back.
+func (l *lostRun) killAndReserveTheJob(ctx context.Context) *Job {
+	killed, err := l.server.killJob(ctx, l.key)
+	So(err, ShouldBeNil)
+	So(killed, ShouldBeTrue)
+
+	reserved, err := l.client.Reserve(lostRunSettleTime)
+	So(err, ShouldBeNil)
+	So(reserved, ShouldNotBeNil)
+	So(reserved.Key(), ShouldEqual, l.key)
+
+	return reserved
+}
+
+// getOnWithTheRun is everything a runner does with a reservation before its
+// Started reaches the manager: Client.Execute resolves the working directory,
+// sets up mounts and calls cmd.Start(), and only then reports. So a Cmd is
+// already executing, in a directory the manager has not been told about, for the
+// whole of the window this models.
+func (l *lostRun) getOnWithTheRun(reserved *Job) (actualCwd, tmpDir, output string) {
+	actualCwd, tmpDir, err := mkHashedDir(l.cwd, l.key)
+	So(err, ShouldBeNil)
+	So(actualCwd, ShouldNotEqual, l.lostCwd)
+
+	output = writeFileIn(actualCwd, retryOutputName)
+
+	reserved.Lock()
+	reserved.setActualCwd(actualCwd)
+	reserved.Unlock()
+
+	return actualCwd, tmpDir, output
+}
+
+// reportItStarted is the run's own Started, which is the first thing the manager
+// hears about it.
+func (l *lostRun) reportItStarted(reserved *Job, pid int) {
+	So(l.client.Started(reserved, pid), ShouldBeNil)
+}
+
+// runnerDied replaces the host and pid the manager recorded for the reservation
+// (respondWithReservedJob records the reserving runner's own) with a process
+// that has already exited. That is what a runner killed by its node leaves
+// behind: a reservation held by nothing, and no Started ever coming.
+func (l *lostRun) runnerDied() {
+	pid := exitedPid()
+
+	l.live.Lock()
+	l.live.Host = localhost
+	l.live.Pid = pid
+	l.live.Unlock()
+}
+
+// reportedState is the state the manager reports for the job, which is what `wr
+// status` shows: reserved while a runner holds it and has yet to report its
+// Started, running once it has, and lost only while the manager has lost contact
+// with the run that holds it.
+func (l *lostRun) reportedState(ctx context.Context) JobState {
+	item, err := l.server.q.Get(l.key)
+	So(err, ShouldBeNil)
+
+	return l.server.itemToJob(ctx, item, false, false).State
+}
+
+// soLeavesRunQueueWithin waits up to lostRunSettleTime for the job to stop
+// holding a reservation, which is what a job that was killed, buried or released
+// for another try has done and a job parked lost for ever has not.
+func (l *lostRun) soLeavesRunQueueWithin() {
+	deadline := time.Now().Add(lostRunSettleTime)
+
+	for time.Now().Before(deadline) {
+		item, err := l.server.q.Get(l.key)
+		So(err, ShouldBeNil)
+
+		if item.Stats().State != queue.ItemStateRun {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	item, err := l.server.q.Get(l.key)
+	So(err, ShouldBeNil)
+	So(item.Stats().State, ShouldNotEqual, queue.ItemStateRun)
+}
+
+// markRetryLost marks the live *Job lost, as a second TTR expiry does for a
+// retry that goes silent in its turn.
+func (l *lostRun) markRetryLost() {
+	l.live.Lock()
+	l.live.Lost = true
+	l.live.Unlock()
+}
+
+// exitedPid returns the pid of a process that has run and been reaped, so that
+// the scheduler's `ps` really finds nothing.
+func exitedPid() int {
+	cmd := exec.CommandContext(context.Background(), "/bin/true")
+	So(cmd.Run(), ShouldBeNil)
+
+	return cmd.Process.Pid
+}
+
+// soGoneWithin waits up to lostRunSettleTime for path to be deleted.
+func soGoneWithin(path string) {
+	deadline := time.Now().Add(lostRunSettleTime)
+
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	soPathsGone(path)
+}
+
+func TestLostJobBehavioursActOnTheLostRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job whose retry is reserved before its behaviours run", t, func() {
+		l := newLostRun(ctx, t, "lost_job_behaviours")
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+		l.proceedManager()
+
+		So(l.waitForKillDecision(), ShouldBeTrue)
+
+		// the retry, reported onto the same *Job in the window killLostRun opens
+		// by releasing the lost job back to ready.
+		retryCwd, retryTmp, retryOutput := l.makeRetryWorkspace()
+
+		Convey("the behaviours act on the run that was lost, not on the live retry", func() {
+			l.resumeManager()
+			soGoneWithin(l.lostCwd)
+
+			// the retry is running in these; the survival is asserted before
+			// anything else, since it is the data loss that matters.
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+
+			// and the workspace that was really abandoned is the one that goes,
+			// rather than being leaked while the live one is swept.
+			soPathsGone(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+
+			ran, err := os.ReadFile(l.ranIn)
+			So(err, ShouldBeNil)
+			So(strings.TrimSpace(string(ran)), ShouldEqual, l.lostCwd)
+		})
+	})
+}
+
+func TestLostJobBehavioursSpareARecoveredJob(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job that recovers on a touch inside the dead-check window", t, func() {
+		l := newLostRun(ctx, t, "lost_job_recovered")
+
+		defer l.stop(ctx)
+
+		// the blip that lost the job clears, and the runner's next Touch takes
+		// the job back off lost. Its Cmd is still running, in the very working
+		// directory the manager is about to sweep - and the touch loop really
+		// does run that late, past the behaviours and the Unmount upload.
+		l.waitForDeadCheckWindow()
+		l.server.recoverLostTouchedJob(l.live)
+		l.proceedManager()
+
+		Convey("the manager neither kills it nor runs its behaviours", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			// the job is still running, in a working directory that is all still
+			// there, and the manager has not marked it to kill itself either.
+			soPathsExist(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+			soPathsGone(l.ranIn)
+
+			state, killCalled := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateRunning)
+			So(killCalled, ShouldBeFalse)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(l.lostOut, l.lostCwd, l.lostTmp)
+		})
+	})
+}
+
+func TestLostJobBehavioursSpareARetryStartedInTheWindow(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job whose retry is started inside the dead-check window", t, func() {
+		l := newLostRun(ctx, t, "lost_job_retry_in_window")
+
+		defer l.stop(ctx)
+
+		// the job is released and reserved again while the manager is off asking
+		// whether the old run is dead - a retryable failure, or a `wr kill`.
+		l.waitForDeadCheckWindow()
+		retryCwd, retryTmp, retryOutput := l.startRetryInWindow(true)
+		l.proceedManager()
+
+		Convey("the manager acts on neither run", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			// the retry is running in these.
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+			soPathsGone(l.ranIn)
+
+			state, killCalled := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateRunning)
+			So(killCalled, ShouldBeFalse)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput, retryCwd, retryTmp)
+		})
+	})
+}
+
+func TestLostJobBehavioursSpareASecondLostRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job whose retry is itself lost inside the dead-check window", t, func() {
+		l := newLostRun(ctx, t, "lost_job_second_loss")
+
+		defer l.stop(ctx)
+
+		// the worst version of the window: the job is started again as a second
+		// run, reports its own working directory, and that run is then declared
+		// lost too. Lost is true and the key is the same, so only the pinned
+		// ActualCwd tells the manager that the death it confirmed was the FIRST
+		// run's and says nothing about this one - which has its own confirmation
+		// on the way.
+		l.waitForDeadCheckWindow()
+		retryCwd, retryTmp, retryOutput := l.startRetryInWindow(true)
+		l.markRetryLost()
+		l.proceedManager()
+
+		Convey("the manager sweeps neither run", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+			soPathsExist(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+			soPathsGone(l.ranIn)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput, retryCwd, l.lostOut, l.lostCwd)
+		})
+	})
+}
+
+func TestLostJobRetryCheckPinsTheLostRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job the manager could not confirm dead the first time", t, func() {
+		l := newLostRun(ctx, t, "lost_job_retry_check")
+
+		defer l.stop(ctx)
+
+		// the retry path re-asks whether the job is still lost after half an
+		// hour, and then reopens the very window the pin exists to survive by
+		// calling confirmJobDead again. Its answer is therefore only worth
+		// having if it pins the run it just checked.
+		l.waitForDeadCheckWindow()
+		retry, checked := l.server.lostJobRetryCheck(l.key)
+		l.proceedManager()
+
+		Convey("its retry check pins the run it found lost", func() {
+			So(l.waitForKillDecision(), ShouldBeTrue)
+			So(checked, ShouldBeTrue)
+			So(retry.key, ShouldEqual, l.key)
+			So(retry.pin.workSpace.key, ShouldEqual, l.key)
+			So(retry.pin.workSpace.actualCwd, ShouldEqual, l.lostCwd)
+			So(retry.pin.behaviours, ShouldHaveLength, 2)
+		})
+	})
+}
+
+func TestPinBehavioursIsLocked(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Pinning a lost job's behaviours reads its state under the Job's lock", t, func() {
+		// the pin is taken in the manager, on the queue's live *Job, while a
+		// runner's touches are writing ActualCwd onto it under that same lock
+		// (applyLiveSnapshot). An unlocked read here is a data race whose
+		// outcome decides which directory the behaviours delete and run in.
+		// -race is what makes this test bite.
+		const (
+			concurrentRounds          = 50
+			concurrentWriterAndPinner = 2
+		)
+
+		cwd := t.TempDir()
+		job := &Job{Cwd: cwd, Cmd: testWSCmd, Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}}}
+		actualCwd, _, _ := realWorkSpace(job)
+
+		var wg sync.WaitGroup
+
+		wg.Add(concurrentWriterAndPinner)
+
+		go func() {
+			defer wg.Done()
+
+			for range concurrentRounds {
+				applyLiveSnapshot(job, &JobEndState{Cwd: actualCwd})
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			for range concurrentRounds {
+				_ = job.pinBehaviours()
+			}
+		}()
+
+		wg.Wait()
+
+		soPathsExist(cwd)
+	})
+}
+
+func TestLostCwdMattersJobSparesItsSecondRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost cwd_matters job whose retry is itself lost in the dead-check window", t, func() {
+		l := newLostRun(ctx, t, "lost_job_cwd_matters", lostRunOpts{cwdMatters: true})
+
+		defer l.stop(ctx)
+
+		// a cwd_matters job's ActualCwd is blank for the whole of every run, so
+		// pinning it pins nothing: the run that was lost and the run that is
+		// live report the same blank directory, and only something the manager
+		// mints per run can tell them apart.
+		l.waitForDeadCheckWindow()
+		_, _, retryOutput := l.startRetryInWindow(true)
+		l.markRetryLost()
+		l.proceedManager()
+
+		Convey("the manager neither releases the live run nor runs the lost run's command", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			// the live retry is part way through writing this, in the Cwd the
+			// lost run's `run` command would have been executed in.
+			soPathsExist(retryOutput)
+			soPathsGone(l.ranIn)
+
+			state, killCalled := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateRunning)
+			So(killCalled, ShouldBeFalse)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput)
+		})
+	})
+}
+
+func TestLostJobOnWeblessManagerSparesItsSecondRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a webless manager's lost job whose retry is itself lost in the window", t, func() {
+		l := newLostRun(ctx, t, "lost_job_webless", lostRunOpts{webless: true})
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+		retryCwd, retryTmp, retryOutput := l.startRetryInWindow(true)
+		l.markRetryLost()
+		l.proceedManager()
+
+		Convey("the manager sweeps neither run", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+			soPathsExist(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+			soPathsGone(l.ranIn)
+
+			state, killCalled := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateRunning)
+			So(killCalled, ShouldBeFalse)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput, retryCwd, l.lostOut, l.lostCwd)
+		})
+	})
+}
+
+func TestLostJobSparesASecondRunThatNeverTouched(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job whose retry is lost before its first touch", t, func() {
+		l := newLostRun(ctx, t, "lost_job_untouched_retry")
+
+		defer l.stop(ctx)
+
+		// the ordinary manager, and the ordinary way a node kills a job: the
+		// retry dies inside its first touch interval, so no touch of its own
+		// ever reaches the manager.
+		l.waitForDeadCheckWindow()
+		retryCwd, retryTmp, retryOutput := l.startRetryInWindow(false)
+		l.markRetryLost()
+		l.proceedManager()
+
+		Convey("the manager sweeps neither run", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+			soPathsExist(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+			soPathsGone(l.ranIn)
+
+			state, killCalled := l.jobStateAndKillCalled()
+			So(state, ShouldEqual, JobStateRunning)
+			So(killCalled, ShouldBeFalse)
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput, retryCwd, l.lostOut, l.lostCwd)
+		})
+	})
+}
+
+func TestLostJobOnWeblessManagerCleansItsWorkSpace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a webless manager's lost job that no touch was ever received for", t, func() {
+		l := newLostRun(ctx, t, "lost_job_webless_cleanup", lostRunOpts{webless: true})
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+		l.proceedManager()
+
+		Convey("its workspace is still cleaned up and its command still runs in it", func() {
+			So(l.waitForKillDecision(), ShouldBeTrue)
+
+			l.resumeManager()
+			soGoneWithin(l.lostCwd)
+			soPathsGone(l.lostOut, l.lostCwd, l.lostTmp, filepath.Dir(l.lostCwd))
+
+			ran, err := os.ReadFile(l.ranIn)
+			So(err, ShouldBeNil)
+			So(strings.TrimSpace(string(ran)), ShouldEqual, l.lostCwd)
+		})
+	})
+}
+
+func TestKillingALostJobSparesTheRunThatReplacesIt(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job the user kills while its death is still being confirmed", t, func() {
+		l := newLostRun(ctx, t, "kill_lost_job_retry")
+
+		defer l.stop(ctx)
+
+		// this is the un-gated release: `wr kill` marks the job and releases it,
+		// and a runner has the retry reserved, its working directory made and its
+		// Cmd EXECUTING before the confirmation of the lost run comes back - and
+		// before the manager has heard a single word from it. Once its Started
+		// has been reported the job is off lost, so this window, and only this
+		// window, is where a decision about the run before it can land.
+		l.waitForDeadCheckWindow()
+
+		reserved := l.killAndReserveTheJob(ctx)
+		retryCwd, retryTmp, retryOutput := l.getOnWithTheRun(reserved)
+
+		l.proceedManager()
+
+		Convey("the confirmation is not carried out on the retry", func() {
+			So(l.waitForKillDecision(), ShouldBeFalse)
+
+			// killCalled is the half that ends a Cmd already running: it turns
+			// the retry's next touch into a self-kill.
+			So(l.reportedState(ctx), ShouldEqual, JobStateReserved)
+			So(l.killCalledOnLiveJob(), ShouldBeFalse)
+
+			soPathsExist(retryOutput, retryCwd, retryTmp, filepath.Dir(retryCwd))
+
+			l.soNoBehaviourRuns()
+			soPathsExist(retryOutput, retryCwd, retryTmp)
+			soPathsGone(l.ranIn)
+
+			// and the retry still holds the reservation, so it gets to report
+			// its Started - which a job released out from under it cannot.
+			l.reportItStarted(reserved, os.Getpid())
+			So(l.reportedState(ctx), ShouldEqual, JobStateRunning)
+		})
+	})
+}
+
+func TestKilledLostJobsReplacementIsStillWatched(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a killed lost job whose replacement run dies in its turn", t, func() {
+		l := newLostRun(ctx, t, "kill_lost_job_no_hang")
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+
+		// the retry is started with a pid that has already exited, so it goes
+		// silent the way a run killed by its node does.
+		reserved := l.killAndReserveTheJob(ctx)
+		retryCwd, _, _ := l.getOnWithTheRun(reserved)
+		l.reportItStarted(reserved, exitedPid())
+
+		l.proceedManager()
+		So(l.waitForKillDecision(), ShouldBeFalse)
+		l.resumeManager()
+
+		Convey("the manager declares that run lost on its own account", func() {
+			// carrying the killed run's Lost flag into the retry parks the job
+			// for ever: ttrCallback refuses to re-mark an already-lost job, so
+			// nothing is ever confirmed, nothing killed, and the job is neither
+			// retried nor buried. Reaching a second dead-check at all is the
+			// evidence that the retry was watched as a run of its own.
+			l.waitForDeadCheckWindow()
+			So(l.waitForKillDecision(), ShouldBeTrue)
+
+			// and the run that really was abandoned is the one swept.
+			soGoneWithin(retryCwd)
+			soPathsExist(l.lostCwd)
+		})
+	})
+}
+
+func TestKilledLostJobsReservationIsARunOfItsOwn(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job killed and then taken on by a runner that dies before Started", t, func() {
+		l := newLostRun(ctx, t, "kill_lost_job_reserved")
+
+		defer l.stop(ctx)
+
+		l.waitForDeadCheckWindow()
+
+		// the reservation IS the new run, and everything its runner does before
+		// its Started - the working directory, the mounts, the Cmd itself - it
+		// does inside this window. So the manager has to see a run of its own
+		// here, rather than the run it lost.
+		l.killAndReserveTheJob(ctx)
+		So(l.reportedState(ctx), ShouldEqual, JobStateReserved)
+
+		// and this runner is killed by its node before it ever calls Started, so
+		// silence is the only thing the manager will ever hear about the run.
+		l.runnerDied()
+
+		l.proceedManager()
+		So(l.waitForKillDecision(), ShouldBeFalse)
+		l.resumeManager()
+
+		Convey("the manager declares that run lost on its own account and ends it", func() {
+			// carrying the killed run's Lost flag into this one parks the job for
+			// ever: ttrCallback refuses to re-mark an already-lost job, so no
+			// confirmation is ever started for the run that is really happening,
+			// and it is neither retried nor buried.
+			l.waitForDeadCheckWindow()
+			So(l.waitForKillDecision(), ShouldBeTrue)
+
+			l.soLeavesRunQueueWithin()
+		})
+	})
+}
+
+// startedRun is a real manager with one real job in it, reserved and started
+// through the real client, with the default TTR so that nothing expires under a
+// test. It is the fixture for the checks about what a START does, rather than
+// about a loss.
+type startedRun struct {
+	server *Server
+	item   *queue.Item
+	live   *Job
+
+	// key is the job's key and actualCwd the working directory its first run
+	// made and reported, the way Client.Execute does: resolveWorkingDir before
+	// Started.
+	key       string
+	actualCwd string
+}
+
+// newStartedRun builds the fixture. The manager and client are torn down with
+// the test.
+func newStartedRun(ctx context.Context, t *testing.T, rg, cwd string, bs Behaviours) *startedRun {
+	t.Helper()
+
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(false)
+
+	server, _, token, err := serve(ctx, serverConfig)
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() { server.Stop(ctx, true) })
+
+	jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() { disconnect(jq) })
+
+	job := &Job{
+		Cmd: restFormTrue, Cwd: cwd, RepGroup: rg, ReqGroup: rg,
+		Requirements: standardReqs, Retries: 3, Behaviours: bs,
+	}
+
+	_, _, err = jq.Add([]*Job{job}, os.Environ(), true)
+	So(err, ShouldBeNil)
+
+	reserved, err := jq.Reserve(2 * time.Second)
+	So(err, ShouldBeNil)
+	So(reserved, ShouldNotBeNil)
+
+	r := &startedRun{server: server, key: reserved.Key()}
+
+	r.actualCwd, _, err = mkHashedDir(cwd, r.key)
+	So(err, ShouldBeNil)
+
+	reserved.Lock()
+	reserved.setActualCwd(r.actualCwd)
+	reserved.Unlock()
+
+	So(jq.Started(reserved, os.Getpid()), ShouldBeNil)
+
+	r.item, err = server.q.Get(r.key)
+	So(err, ShouldBeNil)
+
+	live, ok := r.item.Data().(*Job)
+	So(ok, ShouldBeTrue)
+
+	r.live = live
+
+	return r
+}
+
+// liveActualCwd is the working directory the manager currently believes the job
+// is running in.
+func (r *startedRun) liveActualCwd() string {
+	r.live.RLock()
+	defer r.live.RUnlock()
+
+	return r.live.ActualCwd
+}
+
+// liveHostID is the scheduler's name for the machine the manager currently
+// believes the job is running on.
+func (r *startedRun) liveHostID() string {
+	r.live.RLock()
+	defer r.live.RUnlock()
+
+	return r.live.HostID
+}
+
+// ranOnCloudServer gives the job the HostID a run on a cloud server gets at its
+// Started. The local scheduler names no host, so this is the only way to have
+// one to be stale about.
+func (r *startedRun) ranOnCloudServer(id string) {
+	r.live.Lock()
+	r.live.HostID = id
+	r.live.Unlock()
+}
+
+// markLost marks the manager's own *Job lost, as a TTR expiry does.
+func (r *startedRun) markLost() {
+	r.live.Lock()
+	r.live.Lost = true
+	r.live.Unlock()
+}
+
+// reserveAgain is the manager's own reserve-time reset of the shared *Job, which
+// is what a runner taking the job on again does to it - and where the run it is
+// taking on begins.
+func (r *startedRun) reserveAgain() {
+	r.server.resetJobForReservation(r.live, newTestClientID())
+}
+
+// newTestClientID is the id of a runner other than the one that had the job
+// before.
+func newTestClientID() uuid.UUID {
+	clientID, err := uuid.NewV4()
+	So(err, ShouldBeNil)
+
+	return clientID
+}
+
+func TestKilledLostJobSparesItsSecondRun(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a lost job the user had already killed, whose retry is lost in its turn", t, func() {
+		r := newStartedRun(ctx, t, "killed_lost_run", t.TempDir(), nil)
+
+		// a `wr kill`ed run goes silent, is declared lost, and has its details
+		// pinned. This is the one lost-job path with no dead-check in it at all:
+		// it simply waits ttrReleaseWait and releases.
+		r.live.Lock()
+		r.live.killCalled = true
+		r.live.Lost = true
+		r.live.Unlock()
+
+		pin := r.live.pinBehaviours()
+
+		// but that wait is long enough for the job to be released, reserved and
+		// started again, and lost again. Same key, same *Job, and Lost is true
+		// once more, so what tells the two runs apart is what the manager minted
+		// for the second reservation.
+		r.reserveAgain()
+		So(r.server.applyJobStart(r.live, &Job{Pid: os.Getpid(), Host: localhost}), ShouldBeTrue)
+		r.markLost()
+
+		Convey("the release lands on neither run", func() {
+			r.server.confirmOrReleaseLostJob(ctx, lostJobDetails{key: r.key, killCalled: true, pin: pin})
+
+			So(r.item.Stats().State, ShouldEqual, queue.ItemStateRun)
+		})
+	})
+}
+
+func TestReservedRunDoesNotClaimThePreviousRunsHost(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a job whose first run was on a cloud server", t, func() {
+		r := newStartedRun(ctx, t, "reserve_clears_host", t.TempDir(), nil)
+
+		r.ranOnCloudServer("the-server-of-the-run-that-is-over")
+
+		Convey("a fresh reservation stops it naming that server", func() {
+			r.reserveAgain()
+
+			// killJobsOnBadServers kills every running or lost job whose HostID
+			// is a server the cloud scheduler has condemned, and it does so
+			// through the same un-gated release `wr kill` uses. A run that has
+			// yet to report where it is must not answer for where the run before
+			// it was.
+			So(r.liveHostID(), ShouldBeBlank)
+		})
+	})
+}
+
+func TestASlowStartedRunIsNotStillLost(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a reservation declared lost before its Started arrived", t, func() {
+		r := newStartedRun(ctx, t, "slow_start_recovers", t.TempDir(), nil)
+
+		// a runner whose reserve-to-Started stretch outlasts the TTR - S3 mounts
+		// retry for seconds, and a saturated socket delays the report itself - is
+		// declared lost while its Cmd is starting, and pinned.
+		r.reserveAgain()
+		r.markLost()
+
+		pin := r.live.pinBehaviours()
+
+		Convey("its Started recovers it, so the confirmation of that loss is refused", func() {
+			So(r.server.applyJobStart(r.live, &Job{Pid: os.Getpid(), Host: localhost}), ShouldBeTrue)
+
+			// the run this pin names is the very run that has just reported in:
+			// its reservation minted the token and its Started did not change it.
+			// So taking the job off lost is the only thing left standing between
+			// a confirmation of that loss and a Cmd that is running.
+			released, err := r.server.killLostRun(ctx, pin)
+			So(err, ShouldBeNil)
+			So(released, ShouldBeFalse)
+			So(r.item.Stats().State, ShouldEqual, queue.ItemStateRun)
+		})
+	})
+}
+
+func TestReservedRunDoesNotInheritThePreviousRunsWorkingDir(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a job whose first run made and reported a working directory", t, func() {
+		cwd := t.TempDir()
+		ranIn := filepath.Join(cwd, "ran_in.txt")
+		r := newStartedRun(ctx, t, "reserve_clears_cwd", cwd, Behaviours{{When: OnFailure, Do: Run, Arg: "pwd > " + ranIn}})
+
+		So(r.liveActualCwd(), ShouldEqual, r.actualCwd)
+
+		Convey("a fresh reservation stops it claiming that directory, before the new run reports anything", func() {
+			r.reserveAgain()
+
+			So(r.liveActualCwd(), ShouldBeBlank)
+
+			// the retry's runner is now making its working directory, mounting
+			// remote filesystems and starting the Cmd, and its Started reaches
+			// the manager only after all of it. A TTR expiry anywhere in there
+			// pins THIS run, and ActualCwd is what the pinned cleanup deletes and
+			// what a pinned `run` executes in - so what it must not carry is an
+			// OLDER workspace of the same job.
+			r.markLost()
+
+			pin := r.live.pinBehaviours()
+			So(pin.workSpace.actualCwd, ShouldBeBlank)
+			So(pin.trigger(false), ShouldNotBeNil)
+			soPathsGone(ranIn)
+			soPathsExist(r.actualCwd)
+
+			// and a Started that reports no directory of its own - an older
+			// runner, or a cwd_matters job carrying the ActualCwd that wr
+			// v0.37.0|1 stored on one - does not put the old one back either.
+			So(r.server.applyJobStart(r.live, &Job{Pid: os.Getpid(), Host: localhost}), ShouldBeTrue)
+			So(r.liveActualCwd(), ShouldBeBlank)
+		})
+	})
+}
+
+func TestMintedRunTokenIsNeverTheRecoveredOne(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A run this manager never started is not the run any token it mints identifies", t, func() {
+		// a running job recovered from the database after a crash carries the
+		// zero token, because this manager minted nothing for it. Every token it
+		// does mint has to be distinct from that, or the first run it starts
+		// would answer to a pin taken of the recovered one.
+		server := &Server{}
+		recovered := &Job{Lost: true}
+
+		So(recovered.isLostRunLocked(server.mintRunToken()), ShouldBeFalse)
+		So(recovered.isLostRunLocked(0), ShouldBeTrue)
+
+		Convey("and neither is the run reserved after it", func() {
+			// counting from 1 keeps a MINTED token off the recovered run. What
+			// keeps a pin OF the recovered run off the job's later runs is the
+			// reservation each of them begins with: without one, the recovered
+			// job carries the zero token into every run that follows until its
+			// Started, and the pin matches them all.
+			pin := recovered.pinBehaviours()
+			So(recovered.isLostRunLocked(pin.run), ShouldBeTrue)
+
+			server.resetJobForReservation(recovered, newTestClientID())
+
+			// and when that run is itself lost, so that the Lost half answers
+			// yes again, the token is the whole of what refuses the pin.
+			recovered.Lost = true
+			So(recovered.isLostRunLocked(pin.run), ShouldBeFalse)
+		})
+	})
+}

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -43,7 +43,9 @@ package jobqueue
 // directory of a job that was still RUNNING.
 
 import (
+	"cmp"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1450,4 +1452,308 @@ func TestMintedRunTokenIsNeverTheRecoveredOne(t *testing.T) {
 			So(recovered.isLostRunLocked(pin.run), ShouldBeFalse)
 		})
 	})
+}
+
+// lostCleanupDrivers is how many lost jobs TestLostJobCleanupsAreBounded drives
+// at once. It is a literal rather than a multiple of maxConcurrentLostCleanups
+// on purpose: raising the bound without raising this too would leave the test
+// unable to reach the bound, and it then says so rather than passing.
+const lostCleanupDrivers = 64
+
+// boundedCleanups is the gate every lost job's cleanup is held at, and the count
+// of how many are held there at once.
+//
+// The gate is what makes the count an invariant rather than a race: a held
+// cleanup is still holding its descriptors, and it finishes only when the test
+// sends it on its way, so the number inside at any moment is decided by the test
+// and by the bound, not by how fast the box happens to be.
+type boundedCleanups struct {
+	mu      sync.Mutex
+	inside  int
+	entered int
+	peak    int
+
+	// atLimit is closed by the cleanup that brings the number held up to
+	// maxConcurrentLostCleanups. Nothing has been released by then, so reaching
+	// it says the whole of what the bound allows really is in use.
+	atLimit chan struct{}
+
+	// release is unbuffered: each value the test sends lets exactly one held
+	// cleanup finish, so a slot comes free only because the test said so.
+	release     chan struct{}
+	releaseOnce sync.Once
+
+	// killed and done carry a value per lost job: one when its kill decision has
+	// been made, one when its whole handling is over.
+	killed chan struct{}
+	done   chan struct{}
+}
+
+func newBoundedCleanups(n int) *boundedCleanups {
+	return &boundedCleanups{
+		atLimit: make(chan struct{}), release: make(chan struct{}),
+		killed: make(chan struct{}, n), done: make(chan struct{}, n),
+	}
+}
+
+// hold is the cleanupProvenHook: it counts this cleanup in, and keeps it - and
+// the descriptors its deletion walk holds open - there until the test releases
+// it.
+func (b *boundedCleanups) hold() {
+	b.mu.Lock()
+	b.inside++
+	b.entered++
+	b.peak = max(b.peak, b.inside)
+	atLimit := b.entered == maxConcurrentLostCleanups
+	b.mu.Unlock()
+
+	if atLimit {
+		close(b.atLimit)
+	}
+
+	<-b.release
+
+	b.mu.Lock()
+	b.inside--
+	b.mu.Unlock()
+}
+
+// counts is how many cleanups are held right now, how many have ever been held,
+// and the most that were ever held at once.
+func (b *boundedCleanups) counts() (inside, entered, peak int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.inside, b.entered, b.peak
+}
+
+// reachedLimit reports whether maxConcurrentLostCleanups cleanups were held at
+// once.
+func (b *boundedCleanups) reachedLimit() bool {
+	select {
+	case <-b.atLimit:
+		return true
+	case <-time.After(lostRunSettleTime):
+		return false
+	}
+}
+
+// releaseEach lets n held cleanups finish, one at a time, and reports whether
+// every one of them took its turn.
+func (b *boundedCleanups) releaseEach(n int) bool {
+	for range n {
+		select {
+		case b.release <- struct{}{}:
+		case <-time.After(lostRunSettleTime):
+			return false
+		}
+	}
+
+	return true
+}
+
+// freeAll unblocks any cleanup still held, so that a failed assertion ends with
+// the test rather than parking its goroutines for good.
+func (b *boundedCleanups) freeAll() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+// await takes n values from ch and reports whether they all arrived.
+func await(ch <-chan struct{}, n int) bool {
+	for range n {
+		select {
+		case <-ch:
+		case <-time.After(lostRunSettleTime):
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestLostJobCleanupsAreBounded(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given more lost jobs confirmed dead than the manager may clean up at once", t, func() {
+		b := newBoundedCleanups(lostCleanupDrivers)
+
+		// the hooks are assigned BEFORE Serve, because starting the goroutines
+		// that read them is what orders the assignment against them.
+		lostJobDeadCheckedHook = nil
+		lostJobKilledHook = func(bool) { b.killed <- struct{}{} }
+		cleanupProvenHook = b.hold
+
+		Reset(func() {
+			b.freeAll()
+
+			lostJobKilledHook = nil
+			cleanupProvenHook = nil
+		})
+
+		server, pins, actualCwds := newLostRuns(ctx, t, "bounded_cleanups", lostCleanupDrivers)
+
+		Convey("no more than maxConcurrentLostCleanups of their cleanups run at once", func() {
+			for _, pin := range pins {
+				go func() {
+					server.killLostJobAndTriggerBehaviours(ctx, lostJobDetails{key: pin.workSpace.key, pin: pin})
+
+					b.done <- struct{}{}
+				}()
+			}
+
+			// every kill decision is made whatever the cleanups are doing: the
+			// bound is on the behaviours, because they are what holds the
+			// descriptors, and a job whose runner is confirmed dead has to be
+			// killed promptly however long the queue of deletions is.
+			So(await(b.killed, lostCleanupDrivers), ShouldBeTrue)
+
+			inside, _, _ := b.counts()
+			So(inside, ShouldBeLessThanOrEqualTo, maxConcurrentLostCleanups)
+
+			// and the bound is really reached, so this is not passing by cleaning
+			// up nothing.
+			So(b.reachedLimit(), ShouldBeTrue)
+
+			// the rest are waiting for a slot rather than having been dropped, so
+			// letting the held ones go one at a time gets through all of them.
+			So(b.releaseEach(lostCleanupDrivers), ShouldBeTrue)
+			So(await(b.done, lostCleanupDrivers), ShouldBeTrue)
+
+			_, entered, peak := b.counts()
+			So(peak, ShouldEqual, maxConcurrentLostCleanups)
+			So(entered, ShouldEqual, lostCleanupDrivers)
+			So(countGone(actualCwds), ShouldEqual, lostCleanupDrivers)
+		})
+	})
+}
+
+// newLostRuns is a real manager with n real jobs in it, each reserved, started,
+// and declared lost with the behaviours of that run pinned - the state
+// killLostJobAndTriggerBehaviours is called in. It returns the pins, and the
+// working directory each lost run made, which its cleanup must delete.
+func newLostRuns(ctx context.Context, t *testing.T, rg string, n int) (*Server, []pinnedBehaviours, []string) {
+	t.Helper()
+
+	config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(false)
+
+	// long enough that no job in here expires while the test is holding its
+	// cleanups, whatever a previous test left ServerItemTTR set to.
+	serverConfig.Timings.ItemTTR = ServerItemTTR
+
+	server, _, token, err := serve(ctx, serverConfig)
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() { server.Stop(ctx, true) })
+
+	jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() { disconnect(jq) })
+
+	cwd := t.TempDir()
+	jobs := make([]*Job, n)
+
+	for i := range n {
+		jobs[i] = &Job{
+			Cmd: fmt.Sprintf("%s %d", restFormTrue, i), Cwd: cwd, RepGroup: rg, ReqGroup: rg,
+			Requirements: standardReqs, Retries: 3,
+			Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}},
+		}
+	}
+
+	_, _, err = jq.Add(jobs, os.Environ(), true)
+	So(err, ShouldBeNil)
+
+	pins, actualCwds, failures := loseEveryRun(server, jq, cwd, n)
+	So(failures, ShouldBeBlank)
+	So(len(pins), ShouldEqual, n)
+
+	return server, pins, actualCwds
+}
+
+// loseEveryRun reserves and starts n jobs and declares each of them lost,
+// returning a pin and a working directory per job, plus the first failure it met
+// (rather than an assertion per job, of which there would be hundreds).
+func loseEveryRun(server *Server, jq *Client, cwd string, n int) ([]pinnedBehaviours, []string, string) {
+	pins := make([]pinnedBehaviours, 0, n)
+	actualCwds := make([]string, 0, n)
+	failure := ""
+
+	for range n {
+		reserved, err := jq.Reserve(2 * time.Second)
+		if err != nil || reserved == nil {
+			failure = cmp.Or(failure, fmt.Sprintf("reserve failed: %v", err))
+
+			continue
+		}
+
+		pin, actualCwd, err := startAndLoseRun(server, jq, reserved, cwd)
+		if err != nil {
+			failure = cmp.Or(failure, err.Error())
+
+			continue
+		}
+
+		pins = append(pins, pin)
+		actualCwds = append(actualCwds, actualCwd)
+	}
+
+	return pins, actualCwds, failure
+}
+
+// startAndLoseRun gives the reserved job the working directory a real
+// mkHashedDir makes for it, starts it with a real pid, then declares the
+// manager's own Job lost and pins the behaviours of that run in the same lock,
+// as markJobLost does.
+func startAndLoseRun(server *Server, jq *Client, reserved *Job, cwd string) (pinnedBehaviours, string, error) {
+	actualCwd, _, err := mkHashedDir(cwd, reserved.Key())
+	if err != nil {
+		return pinnedBehaviours{}, "", err
+	}
+
+	if err = os.WriteFile(filepath.Join(actualCwd, "abandoned.txt"), []byte("abandoned\n"), 0o600); err != nil {
+		return pinnedBehaviours{}, "", err
+	}
+
+	reserved.Lock()
+	reserved.setActualCwd(actualCwd)
+	reserved.Unlock()
+
+	if err = jq.Started(reserved, os.Getpid()); err != nil {
+		return pinnedBehaviours{}, "", err
+	}
+
+	item, err := server.q.Get(reserved.Key())
+	if err != nil {
+		return pinnedBehaviours{}, "", err
+	}
+
+	live, ok := item.Data().(*Job)
+	if !ok {
+		return pinnedBehaviours{}, "", fmt.Errorf("%w: %s", errNotACreatedCwd, reserved.Key())
+	}
+
+	live.Lock()
+	live.Lost = true
+	pin := live.pinBehavioursLocked()
+	live.Unlock()
+
+	return pin, actualCwd, nil
+}
+
+// countGone is how many of the given paths are not there.
+func countGone(paths []string) int {
+	gone := 0
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			gone++
+		}
+	}
+
+	return gone
 }

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -160,6 +160,24 @@ const (
 	// drainPollInterval is how often Drain() polls the queue to see whether all
 	// runners have finished.
 	drainPollInterval = 1 * time.Second
+
+	// maxConcurrentLostCleanups is how many lost jobs may have their pinned
+	// behaviours running in the manager at once.
+	//
+	// The cleanup among those behaviours holds the whole path it deletes through
+	// OPEN, one descriptor per component below the Job's Cwd (createdCwdDepth of
+	// them) plus one on the workspace it empties: 6 for a Job with no mounts, 7
+	// for one whose working directory has to be opened separately to spare a
+	// cache. A farm-wide loss of contact declares many jobs lost in the same
+	// breath (the submission that prompted this bound had 19,632 jobs), and each
+	// one gets a goroutine of its own, so the descriptors are what runs out
+	// first: wr never raises its own RLIMIT_NOFILE, so the manager lives with
+	// whatever it inherited, commonly 1024. 32 cleanups is ~224 descriptors,
+	// about a fifth of that table, leaving the rest for client sockets, the
+	// database and the web server. The jobs beyond the bound wait rather than
+	// being skipped: a goroutine parked on the channel costs a couple of KB,
+	// which is the cheaper of the two resources.
+	maxConcurrentLostCleanups = 32
 )
 
 // ServerVersion gets set during build:
@@ -911,6 +929,9 @@ type Server struct {
 	done               chan error
 	stopSigHandling    chan bool
 	stopClientHandling chan bool
+	// lostCleanupTokens bounds how many lost jobs may have their pinned
+	// behaviours running at once; see maxConcurrentLostCleanups.
+	lostCleanupTokens  chan struct{}
 	clientHandlingDone chan struct{}
 	wg                 *waitgroup.WaitGroup
 	// bgWG tracks only the background startup goroutines (prior-state recovery
@@ -2877,6 +2898,7 @@ func Serve(ctx context.Context, config ServerConfig) (s *Server, msg string, tok
 		pprofServer:               pprofServer,
 		stopSigHandling:           stopSigHandling,
 		stopClientHandling:        stopClientHandling,
+		lostCleanupTokens:         make(chan struct{}, maxConcurrentLostCleanups),
 		clientHandlingDone:        clientHandlingDone,
 		done:                      done,
 		wg:                        wg,
@@ -4680,6 +4702,30 @@ func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobD
 	}
 
 	clog.Info(ctx, "killed a job after confirming it was dead", "key", d.key)
+
+	s.triggerLostRunBehaviours(ctx, d)
+}
+
+// triggerLostRunBehaviours runs the pinned behaviours of a lost run that really
+// was killed, no more than maxConcurrentLostCleanups of them at a time.
+//
+// Only the behaviours are bounded, not the kill above: the cleanup among them is
+// what holds a descriptor per level of the tree it deletes, while a job whose
+// runner is confirmed dead has to be killed promptly however long the queue of
+// cleanups is.
+//
+// A shutting-down manager takes the wait back rather than joining it, so
+// stopClientHandling closing leaves the workspace behind, which is recoverable
+// (the next manager's cleanup of the same lost run deletes it), where a shutdown
+// blocked behind a full channel is not.
+func (s *Server) triggerLostRunBehaviours(ctx context.Context, d lostJobDetails) {
+	select {
+	case s.lostCleanupTokens <- struct{}{}:
+	case <-s.stopClientHandling:
+		return
+	}
+
+	defer func() { <-s.lostCleanupTokens }()
 
 	//nolint:contextcheck // behaviours run detached from the cancellable job context
 	if errt := d.pin.trigger(false); errt != nil {

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -2334,7 +2334,16 @@ func (s *Server) lostJobRetryCheck(jobKey string) (lostJobDetails, bool) {
 	job.RLock()
 	defer job.RUnlock()
 
-	if job.State != JobStateRunning || !job.Lost {
+	// job.Exited is the same "is this run over?" question ttrCallback asks, and
+	// the only one that answers for a run the manager has heard nothing from:
+	// Job.State is written at Started and at each exit, never at Reserve, so
+	// through a whole reservation it still reads the PREVIOUS run's value. Gating
+	// on State therefore never fired for a reserved-not-started run - the one
+	// case whose host and pid are the reserving runner's, so that a first
+	// confirmation that could not reach the host is worth retrying at all. It
+	// still refuses the stretch markJobComplete leaves open, where an archived
+	// run is in the run sub-queue with Lost set: that run reported its own exit.
+	if job.Exited || !job.Lost {
 		return lostJobDetails{}, false
 	}
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -3907,23 +3907,16 @@ func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) 
 	case !d.killCalled && !recovered:
 		s.confirmJobDeadAndKill(ctx, d)
 	case d.killCalled:
-		s.releaseKilledLostRun(ctx, d)
-	}
-}
+		defer internal.LogPanic(ctx, "jobqueue ttr callback releaseJob", true)
 
-// releaseKilledLostRun releases a lost run the user had already called kill on,
-// so that the kill takes effect on a job wr has lost contact with. It triggers no
-// behaviours: the user asked for the job to stop, not for its work to be swept.
-// The wait below is long enough for a different run to be under this key, so the
-// release is gated on the pinned one.
-func (s *Server) releaseKilledLostRun(ctx context.Context, d lostJobDetails) {
-	defer internal.LogPanic(ctx, "jobqueue ttr callback releaseJob", true)
+		// wait for the item to go back to run queue
+		<-time.After(ttrReleaseWait)
 
-	// wait for the item to go back to run queue
-	<-time.After(ttrReleaseWait)
-
-	if _, _, err := s.killRunningJob(ctx, d.key, &d.pin.run); err != nil {
-		clog.Warn(ctx, "failed to release job after TTR", "err", err)
+		// no behaviours: the user asked for the job to stop, not for its work to be
+		// swept. The wait is long enough for a different run to be under this key.
+		if _, _, err := s.killRunningJob(ctx, d.key, &d.pin.run); err != nil {
+			clog.Warn(ctx, "failed to release job after TTR", "err", err)
+		}
 	}
 }
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -887,13 +887,6 @@ func (cm *casterMember) drainQueue() bool {
 	}
 }
 
-type lostJobRetryCheck struct {
-	jobKey       string
-	jobHost      string
-	jobPID       int
-	checkTimeout time.Duration
-}
-
 type repGroupStatusOptions struct {
 	RepGroup             string
 	Match                RepGroupMatch
@@ -978,6 +971,10 @@ type Server struct {
 	waitingReserves      []chan struct{}
 	recoveredRunningJobs map[string]bool
 	nextSubscriptionID   uint64
+
+	// lastRunToken is the last runToken this manager minted. It is only ever
+	// touched atomically, by mintRunToken.
+	lastRunToken atomic.Uint64
 
 	// timings holds this server's resolved timing parameters. The fixed ones
 	// are set once in Serve() and then only read; the three below
@@ -2323,31 +2320,34 @@ func jobUpdateFromLockedJob(job *Job, state JobState) *JobUpdate {
 	}
 }
 
-func (s *Server) lostJobRetryCheck(jobKey string) (lostJobRetryCheck, bool) {
+func (s *Server) lostJobRetryCheck(jobKey string) (lostJobDetails, bool) {
 	item, err := s.q.Get(jobKey)
 	if err != nil || item.Stats().State != queue.ItemStateRun {
-		return lostJobRetryCheck{}, false
+		return lostJobDetails{}, false
 	}
 
 	job, ok := item.Data().(*Job)
 	if !ok {
-		return lostJobRetryCheck{}, false
+		return lostJobDetails{}, false
 	}
 
 	job.RLock()
 	defer job.RUnlock()
 
 	if job.State != JobStateRunning || !job.Lost {
-		return lostJobRetryCheck{}, false
+		return lostJobDetails{}, false
 	}
 
 	timeout, _ := s.lostJobCheckDurations()
 
-	return lostJobRetryCheck{
-		jobKey:       job.Key(),
-		jobHost:      job.Host,
-		jobPID:       job.Pid,
+	pin := job.pinBehavioursLocked()
+
+	return lostJobDetails{
+		key:          pin.workSpace.key,
+		host:         job.Host,
+		pid:          job.Pid,
 		checkTimeout: timeout,
+		pin:          pin,
 	}, true
 }
 
@@ -3819,7 +3819,7 @@ func (s *Server) ttrCallback(ctx context.Context, job *Job) queue.SubQueue {
 	// we don't test recovered jobs are dead because they might have exited
 	// while the server wasn't running, and we want the existing client to tell
 	// us if it should be archived or buried
-	defer s.markJobLost(ctx, job, false, lostUpdate)
+	defer s.markJobLost(ctx, job, lostUpdate)
 
 	return queue.SubQueueRun
 }
@@ -3827,34 +3827,38 @@ func (s *Server) ttrCallback(ctx context.Context, job *Job) queue.SubQueue {
 // markJobLost records a running->lost transition for job (which must be locked;
 // it is unlocked here) and asynchronously confirms whether the job is dead,
 // killing or releasing it as appropriate. It runs as a deferred call from
-// ttrCallback while the queue mutex is still held.
-func (s *Server) markJobLost(ctx context.Context, job *Job, wasLost bool, lostUpdate *JobUpdate) {
+// ttrCallback while the queue mutex is still held, which has already
+// established that the job was not already lost.
+func (s *Server) markJobLost(ctx context.Context, job *Job, lostUpdate *JobUpdate) {
 	killCalled := job.killCalled
-	jobKey := job.Key()
 	jobHost := job.Host
 	jobPID := job.Pid
 	repGroup := job.RepGroup
+
+	// the behaviours of the run being declared lost are pinned HERE, in the same
+	// breath as the decision that it is lost, and carried all the way to the
+	// kill. See lostJobDetails.pin. Its snapshot already holds the job's key, so
+	// this runs Key()'s hash once rather than twice - and it runs while
+	// queue.mutex is still held, since ttrCallback defers this call.
+	pin := job.pinBehavioursLocked()
+	jobKey := pin.workSpace.key
+
 	serverLostJobCheckTimeout, serverLostJobCheckRetryTime := s.lostJobCheckDurations()
 	job.Unlock()
 
 	// since our changed callback won't be called, record this running -> lost
 	// transition through the single chokepoint: the web-UI status-count delta
-	// always (statusCaster derives the "+all+" aggregate from the contribution),
-	// and the pre-built lost subscription update only if the job wasn't already
-	// lost. Both run after job.Unlock while queue.mutex is still held; neither
-	// statusCaster.Send nor the subscription locks are ever taken before the
-	// queue lock.
+	// (statusCaster derives the "+all+" aggregate from the contribution) and the
+	// pre-built lost subscription update. Both run after job.Unlock while
+	// queue.mutex is still held; neither statusCaster.Send nor the subscription
+	// locks are ever taken before the queue lock.
 	s.emitJobTransition(
 		[]countContribution{{from: JobStateRunning, to: JobStateLost, repGroup: repGroup, n: 1}},
-		func() {
-			if !wasLost {
-				s.enqueueSubscriptionUpdate(lostUpdate, false)
-			}
-		},
+		func() { s.enqueueSubscriptionUpdate(lostUpdate, false) },
 	)
 
-	go s.confirmOrReleaseLostJob(ctx, job, lostJobDetails{
-		key: jobKey, host: jobHost, pid: jobPID, killCalled: killCalled,
+	go s.confirmOrReleaseLostJob(ctx, lostJobDetails{
+		key: jobKey, host: jobHost, pid: jobPID, killCalled: killCalled, pin: pin,
 		checkTimeout: serverLostJobCheckTimeout, checkRetryTime: serverLostJobCheckRetryTime,
 	})
 }
@@ -3868,34 +3872,63 @@ type lostJobDetails struct {
 	killCalled     bool
 	checkTimeout   time.Duration
 	checkRetryTime time.Duration
+
+	// pin is the lost RUN: its Behaviours and the state they must act on, taken
+	// at the moment the job was declared lost.
+	//
+	// It is carried rather than re-fetched because everything between here and
+	// the kill takes time the job does not stand still for. confirmJobDead is an
+	// ssh round trip bounded by ServerLostJobCheckTimeout - 15 seconds by
+	// default - and in it the job can recover (a touch clears Lost), or be
+	// released and re-reserved, so that the *Job under this key is a DIFFERENT
+	// run by the time the kill happens. Fetching the job afterwards fetched that
+	// other run and swept its live working directory. See pinnedBehaviours, and
+	// isLostRunLocked for the check that the pin is still the run at the queue.
+	pin pinnedBehaviours
 }
 
 // confirmOrReleaseLostJob confirms whether a lost job is really dead and kills
 // it, or (if the user already called kill) releases it back to the run queue.
-func (s *Server) confirmOrReleaseLostJob(ctx context.Context, job *Job, d lostJobDetails) {
+//
+// It is given the lost RUN rather than the queue's *Job, because the *Job is
+// shared by every run of the job and everything below happens after a wait: what
+// either branch must act on is the run that was declared lost, and both ask the
+// queue for it by key and prove it is still that run.
+func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) {
 	s.rrjMu.RLock()
 	recovered := s.recoveredRunningJobs[d.key]
 	s.rrjMu.RUnlock()
 
-	confirmedDead := !d.killCalled && !recovered
-	if confirmedDead {
-		confirmedDead = s.confirmJobDeadAndKill(ctx, d.key, d.host, d.pid, d.checkTimeout, d.checkRetryTime)
-	}
-
 	switch {
-	case confirmedDead:
-		clog.Info(ctx, "killed a job after confirming it was dead", "key", d.key)
+	case !d.killCalled && !recovered:
+		// what the kill decided is logged where it is decided. Saying "killed a
+		// job after confirming it was dead" here said it before the goroutine
+		// that may REFUSE the kill had run, and said it whether or not the kill
+		// happened.
+		s.confirmJobDeadAndKill(ctx, d)
 	case d.killCalled:
-		defer internal.LogPanic(ctx, "jobqueue ttr callback releaseJob", true)
+		s.releaseKilledLostRun(ctx, d)
+	}
+}
 
-		// wait for the item to go back to run queue
-		<-time.After(ttrReleaseWait)
+// releaseKilledLostRun releases a lost run the user had already called kill on,
+// so that the kill takes effect on a job wr has lost contact with. It triggers
+// no behaviours: the user asked for the job to stop, not for its work to be
+// swept.
+//
+// The release is the same release killLostRun makes and needs the same proof, so
+// it is made through the same guarded path. The wait below is long enough for
+// the job to be buried by a runner that got the kill, and for the *Job under
+// this key to be a run this confirmation was never about; releasing that one
+// would end a job that is running normally.
+func (s *Server) releaseKilledLostRun(ctx context.Context, d lostJobDetails) {
+	defer internal.LogPanic(ctx, "jobqueue ttr callback releaseJob", true)
 
-		// now release it
-		err := s.releaseJob(ctx, job, &JobEndState{Exitcode: -1, Exited: true}, FailReasonLost, false, false)
-		if err != nil {
-			clog.Warn(ctx, "failed to release job after TTR", "err", err)
-		}
+	// wait for the item to go back to run queue
+	<-time.After(ttrReleaseWait)
+
+	if _, _, err := s.killRunningJob(ctx, d.key, &d.pin.run); err != nil {
+		clog.Warn(ctx, "failed to release job after TTR", "err", err)
 	}
 }
 
@@ -4579,55 +4612,73 @@ func (s *Server) applyDependencyUpdates(ctx context.Context, updates []jobDepend
 	return nil
 }
 
-// confirmJobDeadAndKill calls and returns the value of confirmJobDead(). If
-// true, kills the job and triggers behaviours in a goroutine. If false,
-// arranges to re-call this after the configured retry time. This is so that if
-// we can't currently confirm the job is dead due to an ssh issue, but later on
-// the job really does die because the server it was running on gets rebooted,
-// we eventually auto-kill the job.
-func (s *Server) confirmJobDeadAndKill(ctx context.Context, jobKey, jobHost string,
-	jobPID int, serverLostJobCheckTimeout, serverLostJobCheckRetryTime time.Duration) bool {
-	if !s.confirmJobDead(ctx, jobPID, jobHost, serverLostJobCheckTimeout) {
-		go s.confirmJobDeadAndKillAfterRetryTime(ctx, jobKey, serverLostJobCheckRetryTime)
-
-		return false
-	}
-
-	go s.killLostJobAndTriggerBehaviours(ctx, jobKey)
-
-	return true
+// mintRunToken hands out the identity of one run of one job. Counting from 1
+// leaves the zero token to mean "the run this manager found already in progress
+// when it recovered", which is a run it never minted a token for and which no
+// minted token can be mistaken for.
+func (s *Server) mintRunToken() runToken {
+	return runToken(s.lastRunToken.Add(1))
 }
 
-// killLostJobAndTriggerBehaviours kills the lost job and, on success, runs its
-// behaviours, logging any problems.
-func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, jobKey string) {
-	if _, errk := s.killJob(ctx, jobKey); errk != nil {
+// confirmJobDeadAndKill calls confirmJobDead(). If it confirms, kills the job
+// and triggers behaviours in a goroutine. If not, arranges to re-call this after
+// the configured retry time. This is so that if we can't currently confirm the
+// job is dead due to an ssh issue, but later on the job really does die because
+// the server it was running on gets rebooted, we eventually auto-kill the job.
+//
+// It reports nothing, because a confirmation is not a kill: the goroutine below
+// still has to establish that the run it confirmed dead is the run at the queue,
+// and it is the only thing that knows whether the kill happened.
+func (s *Server) confirmJobDeadAndKill(ctx context.Context, d lostJobDetails) {
+	if !s.confirmJobDead(ctx, d.pid, d.host, d.checkTimeout) {
+		go s.confirmJobDeadAndKillAfterRetryTime(ctx, d.key, d.checkRetryTime)
+
+		return
+	}
+
+	go s.killLostJobAndTriggerBehaviours(ctx, d)
+}
+
+// killLostJobAndTriggerBehaviours releases the lost RUN whose behaviours d
+// carries and, only if it really released that run, triggers them, logging any
+// problems.
+//
+// Both halves are about one run, and neither re-asks the queue what that run is.
+// The behaviours were pinned when the job was declared lost, so they act on the
+// state of the run that was lost even though a retry may since have written its
+// own working directory onto the same *Job. And killLostRun refuses a job that
+// is no longer that run, so the behaviours never fire against a job that was not
+// released and may still be RUNNING: killJob reports success without releasing
+// anything when the job is not lost, and acting on that swept the working
+// directory of a live job while its runner was still writing to it.
+//
+// A run that is refused leaks its workspace, which is the right way round: the
+// job has moved on and whatever it is doing now is doing it there.
+func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobDetails) {
+	if lostJobDeadCheckedHook != nil {
+		lostJobDeadCheckedHook()
+	}
+
+	released, errk := s.killLostRun(ctx, d.pin)
+	if errk != nil {
 		clog.Warn(ctx, "failed to kill a job after TTR", "err", errk)
+	}
+
+	if lostJobKilledHook != nil {
+		lostJobKilledHook(released)
+	}
+
+	if !released {
+		clog.Info(ctx, "did not kill a job confirmed dead, because the job has moved on to another run",
+			"key", d.key)
 
 		return
 	}
 
-	q := s.queueIfPresent()
-	if q == nil {
-		clog.Warn(ctx, "failed to get a killed lost job", "err", queueClosedError("Get", jobKey))
-
-		return
-	}
-
-	item, errg := q.Get(jobKey)
-	if errg != nil {
-		clog.Warn(ctx, "failed to get a killed lost job", "err", errg)
-
-		return
-	}
-
-	job, ok := item.Data().(*Job)
-	if !ok {
-		return
-	}
+	clog.Info(ctx, "killed a job after confirming it was dead", "key", d.key)
 
 	//nolint:contextcheck // behaviours run detached from the cancellable job context
-	if errt := job.TriggerBehaviours(false); errt != nil {
+	if errt := d.pin.trigger(false); errt != nil {
 		clog.Warn(ctx, "failed to run behaviours for a killed lost job", "err", errt)
 	}
 }
@@ -4652,13 +4703,18 @@ func (s *Server) confirmJobDeadAndKillAfterRetryTime(ctx context.Context, jobKey
 
 	select {
 	case <-timer.C:
-		retry, ok := s.lostJobRetryCheck(jobKey)
+		// the retry check re-establishes that the job is still lost AND pins the
+		// run it is lost in, in one lock. Its answer is about that moment only:
+		// the confirmJobDead call below reopens the same window the pin exists
+		// to survive, and it is killLostRun that has to be satisfied afterwards.
+		d, ok := s.lostJobRetryCheck(jobKey)
 		if !ok {
 			return
 		}
 
-		s.confirmJobDeadAndKill(ctx, retry.jobKey, retry.jobHost, retry.jobPID, retry.checkTimeout,
-			serverLostJobCheckRetryTime)
+		d.checkRetryTime = serverLostJobCheckRetryTime
+
+		s.confirmJobDeadAndKill(ctx, d)
 	case <-s.stopClientHandling:
 		return
 	}
@@ -4805,31 +4861,79 @@ func (s *Server) inputToQueuedJobs(ctx context.Context, inputJobs []*Job) []*Job
 //
 // If the job wasn't running, returned bool will be false and nothing will have
 // been done.
+//
+// The bool does NOT say the job was released: a job that is running normally is
+// only marked, and the release is the lost job's case alone. A caller that needs
+// to know the job really was released - because it is about to act on the
+// directory the job was using - must use killLostRun.
 func (s *Server) killJob(ctx context.Context, jobkey string) (bool, error) {
+	killCalled, _, err := s.killRunningJob(ctx, jobkey, nil)
+
+	return killCalled, err
+}
+
+// killLostRun is killJob for the one caller that is killing a particular RUN of
+// a job rather than the job: the manager, once it has confirmed the run it
+// declared lost is dead.
+//
+// It reports whether it released THAT run, and it releases nothing else. The
+// confirmation it acts on was made about one run, minutes ago in the retry case
+// and a 15 second ssh round trip away in the ordinary one, and in that time the
+// job can recover, be released, and be reserved and started again. Killing on
+// the strength of a proof about a run that has been replaced kills a job that is
+// alive; running the lost run's behaviours afterwards deletes the working
+// directory that live job is using.
+func (s *Server) killLostRun(ctx context.Context, pin pinnedBehaviours) (bool, error) {
+	_, released, err := s.killRunningJob(ctx, pin.workSpace.key, &pin.run)
+
+	return released, err
+}
+
+// killRunningJob marks the keyed job killed and, if it is lost, releases it. It
+// reports whether it marked the job and whether it released it.
+//
+// onlyRun, when non-nil, names the run the caller is killing: the job is then
+// left entirely untouched - not even marked - unless it is still lost and still
+// that run. Marking matters as much as releasing, because killCalled turns the
+// job's next touch into a self-kill, so mistaking a recovered job for the lost
+// one would kill the run that had just come back.
+func (s *Server) killRunningJob(ctx context.Context, jobkey string,
+	onlyRun *runToken) (bool, bool, error) {
 	q := s.queueIfPresent()
 	if q == nil {
-		return false, queueClosedError("Get", jobkey)
+		return false, false, queueClosedError("Get", jobkey)
 	}
 
 	item, err := q.Get(jobkey)
 	if err != nil || item.Stats().State != queue.ItemStateRun {
-		return false, err
+		return false, false, err
 	}
 
 	job := item.Data().(*Job) //nolint:errcheck,forcetypeassert // queue only ever stores *Job
 	job.Lock()
-	job.killCalled = true
 
-	if job.Lost {
+	if onlyRun != nil && !job.isLostRunLocked(*onlyRun) {
 		job.Unlock()
-		err = s.releaseJob(ctx, job, &JobEndState{Exitcode: -1, Exited: true}, FailReasonLost, false, false)
 
-		return true, err
+		return false, false, nil
 	}
 
+	job.killCalled = true
+	lost := job.Lost
 	job.Unlock()
 
-	return true, err
+	if !lost {
+		return true, false, err
+	}
+
+	// released reports that this WAS the run to release, not that the queue
+	// change succeeded. A failed release leaves the job lost and in the run
+	// queue, and ttrCallback does not re-mark an already-lost job, so there is
+	// no second confirmation coming: withholding the behaviours there would
+	// leak the dead run's workspace permanently, for nothing. The run is dead,
+	// confirmed, and proven to be the pinned one; the error is logged.
+	return true, true, s.releaseJob(ctx, job, &JobEndState{Exitcode: -1, Exited: true},
+		FailReasonLost, false, false)
 }
 
 // deleteJobs deletes the given jobs from the bury/delay/dependent/ready queue

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -164,16 +164,12 @@ const (
 	// maxConcurrentLostCleanups is how many lost jobs may have their pinned
 	// behaviours running in the manager at once.
 	//
-	// The cleanup among those behaviours holds open every component of the path
-	// it deletes: one descriptor per level below the Job's Cwd (createdCwdDepth
-	// of them) plus one or two more, so 6 or 7 per cleanup. A farm-wide loss of
-	// contact declares tens of thousands of jobs lost in one breath, each with a
-	// goroutine of its own, and wr never raises its own RLIMIT_NOFILE, so it
-	// lives with the 1024 a manager commonly inherits and descriptors run out
-	// first. 32 cleanups is ~224 of them, about a fifth of that table, leaving
-	// the rest for client sockets, the database and the web server. Jobs beyond
-	// the bound WAIT rather than being skipped: a parked goroutine costs a couple
-	// of KB, which is the cheaper resource.
+	// The cleanup among those behaviours holds open every level of the path it
+	// deletes, 6 or 7 descriptors, and a farm-wide loss of contact declares tens of
+	// thousands of jobs lost in one breath, each with a goroutine of its own. wr
+	// never raises its own RLIMIT_NOFILE, so descriptors run out first at the 1024 a
+	// manager commonly inherits, of which 32 cleanups is about a fifth. Jobs beyond
+	// the bound WAIT rather than being skipped, a parked goroutine being cheaper.
 	maxConcurrentLostCleanups = 32
 )
 
@@ -926,8 +922,7 @@ type Server struct {
 	done               chan error
 	stopSigHandling    chan bool
 	stopClientHandling chan bool
-	// lostCleanupTokens bounds how many lost jobs may have their pinned
-	// behaviours running at once; see maxConcurrentLostCleanups.
+	// lostCleanupTokens bounds concurrent lost-job cleanups; see maxConcurrentLostCleanups.
 	lostCleanupTokens  chan struct{}
 	clientHandlingDone chan struct{}
 	wg                 *waitgroup.WaitGroup
@@ -990,8 +985,7 @@ type Server struct {
 	recoveredRunningJobs map[string]bool
 	nextSubscriptionID   uint64
 
-	// lastRunToken is the last runToken this manager minted. It is only ever
-	// touched atomically, by mintRunToken.
+	// lastRunToken is the last runToken this manager minted; only mintRunToken touches it.
 	lastRunToken atomic.Uint64
 
 	// timings holds this server's resolved timing parameters. The fixed ones
@@ -2353,9 +2347,8 @@ func (s *Server) lostJobRetryCheck(jobKey string) (lostJobDetails, bool) {
 	defer job.RUnlock()
 
 	// Job.State is written at Started and at each exit, never at Reserve, so
-	// through a whole reservation it still reads the PREVIOUS run's value.
-	// job.Exited is the question ttrCallback asks, so the two cannot disagree,
-	// and it still refuses an archived run sitting in the run sub-queue with Lost.
+	// through a whole reservation it reads the PREVIOUS run's value. job.Exited is
+	// the question ttrCallback asks, and refuses the same archived run.
 	if job.Exited || !job.Lost {
 		return lostJobDetails{}, false
 	}
@@ -3850,7 +3843,7 @@ func (s *Server) ttrCallback(ctx context.Context, job *Job) queue.SubQueue {
 // markJobLost records a running->lost transition for job (which must be locked;
 // it is unlocked here) and asynchronously confirms whether the job is dead,
 // killing or releasing it as appropriate. It runs as a deferred call from
-// ttrCallback while the queue mutex is still held, which has already
+// ttrCallback while the queue mutex is still held; ttrCallback has already
 // established that the job was not already lost.
 func (s *Server) markJobLost(ctx context.Context, job *Job, lostUpdate *JobUpdate) {
 	killCalled := job.killCalled
@@ -3858,9 +3851,8 @@ func (s *Server) markJobLost(ctx context.Context, job *Job, lostUpdate *JobUpdat
 	jobPID := job.Pid
 	repGroup := job.RepGroup
 
-	// the pin is taken here, in the same breath as the decision that the job is
-	// lost, and carried all the way to the kill; see lostJobDetails.pin. Its
-	// snapshot already holds the key, so Key()'s hash runs once, not twice.
+	// pinned in the same breath as the decision, and carried to the kill; see pin
+	// below. Its snapshot holds the key too, so Key()'s hash runs once, not twice.
 	pin := job.pinBehavioursLocked()
 	jobKey := pin.workSpace.key
 
@@ -3894,12 +3886,10 @@ type lostJobDetails struct {
 	checkTimeout   time.Duration
 	checkRetryTime time.Duration
 
-	// pin is the lost RUN: its Behaviours and the state they must act on, taken
-	// at the moment the job was declared lost. It is carried rather than
-	// re-fetched because the job does not stand still for confirmJobDead's ssh
-	// round trip (ServerLostJobCheckTimeout, 15 seconds by default): it can
-	// recover, or be released and re-reserved, so that the *Job under this key is
-	// a DIFFERENT run by the time the kill happens. See pinnedBehaviours.
+	// pin is the lost RUN: its Behaviours and the state they must act on, taken when
+	// the job was declared lost and carried to the kill rather than re-fetched,
+	// because the job does not stand still for confirmJobDead's ssh round trip
+	// (ServerLostJobCheckTimeout, 15s by default). See pinnedBehaviours.
 	pin pinnedBehaviours
 }
 
@@ -3907,8 +3897,7 @@ type lostJobDetails struct {
 // it, or (if the user already called kill) releases it back to the run queue.
 //
 // It is given the lost RUN rather than the queue's *Job, which every run of the
-// job shares: both branches ask the queue for the job by key and check it is
-// still the pinned run before touching it.
+// job shares: both branches check the job is still the pinned run first.
 func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) {
 	s.rrjMu.RLock()
 	recovered := s.recoveredRunningJobs[d.key]
@@ -3916,8 +3905,6 @@ func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) 
 
 	switch {
 	case !d.killCalled && !recovered:
-		// the kill logs what it decided, since only it knows whether the kill
-		// happened.
 		s.confirmJobDeadAndKill(ctx, d)
 	case d.killCalled:
 		s.releaseKilledLostRun(ctx, d)
@@ -3925,15 +3912,10 @@ func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) 
 }
 
 // releaseKilledLostRun releases a lost run the user had already called kill on,
-// so that the kill takes effect on a job wr has lost contact with. It triggers
-// no behaviours: the user asked for the job to stop, not for its work to be
-// swept.
-//
-// The release is the same release killLostRun makes and needs the same proof, so
-// it is made through the same guarded path. The wait below is long enough for
-// the job to be buried by a runner that got the kill, and for the *Job under
-// this key to be a run this confirmation was never about; releasing that one
-// would end a job that is running normally.
+// so that the kill takes effect on a job wr has lost contact with. It triggers no
+// behaviours: the user asked for the job to stop, not for its work to be swept.
+// The wait below is long enough for a different run to be under this key, so the
+// release is gated on the pinned one.
 func (s *Server) releaseKilledLostRun(ctx context.Context, d lostJobDetails) {
 	defer internal.LogPanic(ctx, "jobqueue ttr callback releaseJob", true)
 
@@ -4635,9 +4617,8 @@ func (s *Server) mintRunToken() runToken {
 // the configured retry time. This is so that if we can't currently confirm the
 // job is dead due to an ssh issue, but later on the job really does die because
 // the server it was running on gets rebooted, we eventually auto-kill the job.
-//
 // It reports nothing: the goroutine it starts is the only thing that knows
-// whether the kill happened, and logs it there.
+// whether the kill happened, and it logs that.
 func (s *Server) confirmJobDeadAndKill(ctx context.Context, d lostJobDetails) {
 	if !s.confirmJobDead(ctx, d.pid, d.host, d.checkTimeout) {
 		go s.confirmJobDeadAndKillAfterRetryTime(ctx, d.key, d.checkRetryTime)
@@ -4650,14 +4631,11 @@ func (s *Server) confirmJobDeadAndKill(ctx context.Context, d lostJobDetails) {
 
 // killLostJobAndTriggerBehaviours releases the lost RUN whose behaviours d
 // carries and, only if it really released that run, triggers them, logging any
-// problems.
-//
-// killLostRun refuses a job that is no longer that run, so the behaviours never
-// fire against a job that may still be RUNNING: killJob reports success without
-// releasing anything when the job is not lost, and acting on that swept the
-// working directory of a live job while its runner was writing to it. A refused
-// run leaks its workspace, which is the right way round - the job has moved on
-// and is using that directory.
+// problems. killLostRun refuses a job that is no longer that run, so the
+// behaviours never fire against a job that may still be RUNNING: killJob reports
+// success without releasing anything when the job is not lost, and acting on
+// that swept the working directory of a live job while its runner was still
+// writing to it. A refused run's workspace is left behind, which is the safe way.
 func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobDetails) {
 	if lostJobDeadCheckedHook != nil {
 		lostJobDeadCheckedHook()
@@ -4685,15 +4663,12 @@ func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobD
 }
 
 // triggerLostRunBehaviours runs the pinned behaviours of a lost run that really
-// was killed, no more than maxConcurrentLostCleanups of them at a time.
-//
-// Only the behaviours are bounded, not the kill above: the cleanup among them is
-// what holds a descriptor per level of the tree it deletes, while a job whose
-// runner is confirmed dead has to be killed promptly however long the queue of
-// cleanups is. A manager shutting down gives up its place in the queue instead
-// of waiting; the workspace it leaves behind is deleted by the next manager's
-// cleanup of the same lost run, whereas a shutdown blocked on a full channel
-// never finishes.
+// was killed, no more than maxConcurrentLostCleanups of them at a time. Only the
+// behaviours are bounded, not the kill above: the cleanup is what holds a
+// descriptor per level of the tree it deletes, while a job whose runner is
+// confirmed dead has to be killed promptly however long the queue of cleanups is.
+// A manager shutting down gives up its place in that queue: the workspace it
+// leaves is deleted by the next manager's cleanup of the same lost run.
 func (s *Server) triggerLostRunBehaviours(ctx context.Context, d lostJobDetails) {
 	select {
 	case s.lostCleanupTokens <- struct{}{}:
@@ -4729,9 +4704,8 @@ func (s *Server) confirmJobDeadAndKillAfterRetryTime(ctx context.Context, jobKey
 
 	select {
 	case <-timer.C:
-		// the check re-establishes that the job is still lost and pins the run it
-		// is lost in, in one lock; the confirmJobDead call below reopens the same
-		// window, so killLostRun has to be satisfied again afterwards.
+		// the check pins the run the job is still lost in; the confirmJobDead call
+		// below reopens the same window, so killLostRun is satisfied again after it.
 		d, ok := s.lostJobRetryCheck(jobKey)
 		if !ok {
 			return
@@ -4896,14 +4870,9 @@ func (s *Server) killJob(ctx context.Context, jobkey string) (bool, error) {
 	return killCalled, err
 }
 
-// killLostRun is killJob for the caller that is killing one particular RUN of a
-// job rather than the job: the manager, once it has confirmed the run it
-// declared lost is dead.
-//
-// It reports whether it released THAT run, and releases nothing else: the
-// confirmation it acts on was made a 15 second ssh round trip or a retry timer
-// ago, and in that time the job can have been released and started again as a
-// live run.
+// killLostRun is killJob for the caller killing one particular RUN of a job rather
+// than the job: the manager, once it has confirmed the run it declared lost is
+// dead. It reports whether it released THAT run, and releases nothing else.
 func (s *Server) killLostRun(ctx context.Context, pin pinnedBehaviours) (bool, error) {
 	_, released, err := s.killRunningJob(ctx, pin.workSpace.key, &pin.run)
 
@@ -4915,8 +4884,8 @@ func (s *Server) killLostRun(ctx context.Context, pin pinnedBehaviours) (bool, e
 //
 // onlyRun, when non-nil, names the run the caller is killing: the job is then
 // left entirely untouched - not even marked - unless it is still lost and still
-// that run. Marking matters as much as releasing, because killCalled turns the
-// job's next touch into a self-kill.
+// that run. Marking matters as much as releasing, since killCalled turns the job's
+// next touch into a self-kill.
 func (s *Server) killRunningJob(ctx context.Context, jobkey string,
 	onlyRun *runToken) (bool, bool, error) {
 	q := s.queueIfPresent()
@@ -4946,11 +4915,9 @@ func (s *Server) killRunningJob(ctx context.Context, jobkey string,
 		return true, false, err
 	}
 
-	// released reports that this WAS the run to release, not that the queue
-	// change succeeded. A failed release leaves the job lost and in the run
-	// queue, and ttrCallback does not re-mark an already-lost job, so no second
-	// confirmation is coming: withholding the behaviours would leak the dead
-	// run's workspace for ever, for nothing.
+	// released reports that this WAS the run to release, not that the queue change
+	// succeeded. ttrCallback does not re-mark an already-lost job, so no second
+	// confirmation is coming and withholding the behaviours would leak for ever.
 	return true, true, s.releaseJob(ctx, job, &JobEndState{Exitcode: -1, Exited: true},
 		FailReasonLost, false, false)
 }

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -164,19 +164,16 @@ const (
 	// maxConcurrentLostCleanups is how many lost jobs may have their pinned
 	// behaviours running in the manager at once.
 	//
-	// The cleanup among those behaviours holds the whole path it deletes through
-	// OPEN, one descriptor per component below the Job's Cwd (createdCwdDepth of
-	// them) plus one on the workspace it empties: 6 for a Job with no mounts, 7
-	// for one whose working directory has to be opened separately to spare a
-	// cache. A farm-wide loss of contact declares many jobs lost in the same
-	// breath (the submission that prompted this bound had 19,632 jobs), and each
-	// one gets a goroutine of its own, so the descriptors are what runs out
-	// first: wr never raises its own RLIMIT_NOFILE, so the manager lives with
-	// whatever it inherited, commonly 1024. 32 cleanups is ~224 descriptors,
-	// about a fifth of that table, leaving the rest for client sockets, the
-	// database and the web server. The jobs beyond the bound wait rather than
-	// being skipped: a goroutine parked on the channel costs a couple of KB,
-	// which is the cheaper of the two resources.
+	// The cleanup among those behaviours holds open every component of the path
+	// it deletes: one descriptor per level below the Job's Cwd (createdCwdDepth
+	// of them) plus one or two more, so 6 or 7 per cleanup. A farm-wide loss of
+	// contact declares tens of thousands of jobs lost in one breath, each with a
+	// goroutine of its own, and wr never raises its own RLIMIT_NOFILE, so it
+	// lives with the 1024 a manager commonly inherits and descriptors run out
+	// first. 32 cleanups is ~224 of them, about a fifth of that table, leaving
+	// the rest for client sockets, the database and the web server. Jobs beyond
+	// the bound WAIT rather than being skipped: a parked goroutine costs a couple
+	// of KB, which is the cheaper resource.
 	maxConcurrentLostCleanups = 32
 )
 
@@ -2356,9 +2353,9 @@ func (s *Server) lostJobRetryCheck(jobKey string) (lostJobDetails, bool) {
 	defer job.RUnlock()
 
 	// Job.State is written at Started and at each exit, never at Reserve, so
-	// through a whole reservation it reads the PREVIOUS run's value. job.Exited is
-	// the same question ttrCallback asks, so the two cannot disagree, and it still
-	// refuses the window where an archived run sits in the run sub-queue with Lost.
+	// through a whole reservation it still reads the PREVIOUS run's value.
+	// job.Exited is the question ttrCallback asks, so the two cannot disagree,
+	// and it still refuses an archived run sitting in the run sub-queue with Lost.
 	if job.Exited || !job.Lost {
 		return lostJobDetails{}, false
 	}
@@ -3861,11 +3858,9 @@ func (s *Server) markJobLost(ctx context.Context, job *Job, lostUpdate *JobUpdat
 	jobPID := job.Pid
 	repGroup := job.RepGroup
 
-	// the behaviours of the run being declared lost are pinned HERE, in the same
-	// breath as the decision that it is lost, and carried all the way to the
-	// kill. See lostJobDetails.pin. Its snapshot already holds the job's key, so
-	// this runs Key()'s hash once rather than twice - and it runs while
-	// queue.mutex is still held, since ttrCallback defers this call.
+	// the pin is taken here, in the same breath as the decision that the job is
+	// lost, and carried all the way to the kill; see lostJobDetails.pin. Its
+	// snapshot already holds the key, so Key()'s hash runs once, not twice.
 	pin := job.pinBehavioursLocked()
 	jobKey := pin.workSpace.key
 
@@ -3900,26 +3895,20 @@ type lostJobDetails struct {
 	checkRetryTime time.Duration
 
 	// pin is the lost RUN: its Behaviours and the state they must act on, taken
-	// at the moment the job was declared lost.
-	//
-	// It is carried rather than re-fetched because everything between here and
-	// the kill takes time the job does not stand still for. confirmJobDead is an
-	// ssh round trip bounded by ServerLostJobCheckTimeout - 15 seconds by
-	// default - and in it the job can recover (a touch clears Lost), or be
-	// released and re-reserved, so that the *Job under this key is a DIFFERENT
-	// run by the time the kill happens. Fetching the job afterwards fetched that
-	// other run and swept its live working directory. See pinnedBehaviours, and
-	// isLostRunLocked for the check that the pin is still the run at the queue.
+	// at the moment the job was declared lost. It is carried rather than
+	// re-fetched because the job does not stand still for confirmJobDead's ssh
+	// round trip (ServerLostJobCheckTimeout, 15 seconds by default): it can
+	// recover, or be released and re-reserved, so that the *Job under this key is
+	// a DIFFERENT run by the time the kill happens. See pinnedBehaviours.
 	pin pinnedBehaviours
 }
 
 // confirmOrReleaseLostJob confirms whether a lost job is really dead and kills
 // it, or (if the user already called kill) releases it back to the run queue.
 //
-// It is given the lost RUN rather than the queue's *Job, because the *Job is
-// shared by every run of the job and everything below happens after a wait: what
-// either branch must act on is the run that was declared lost, and both ask the
-// queue for it by key and prove it is still that run.
+// It is given the lost RUN rather than the queue's *Job, which every run of the
+// job shares: both branches ask the queue for the job by key and check it is
+// still the pinned run before touching it.
 func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) {
 	s.rrjMu.RLock()
 	recovered := s.recoveredRunningJobs[d.key]
@@ -3927,9 +3916,7 @@ func (s *Server) confirmOrReleaseLostJob(ctx context.Context, d lostJobDetails) 
 
 	switch {
 	case !d.killCalled && !recovered:
-		// what the kill decided is logged where it is decided. Saying "killed a
-		// job after confirming it was dead" here said it before the goroutine
-		// that may REFUSE the kill had run, and said it whether or not the kill
+		// the kill logs what it decided, since only it knows whether the kill
 		// happened.
 		s.confirmJobDeadAndKill(ctx, d)
 	case d.killCalled:
@@ -4638,10 +4625,7 @@ func (s *Server) applyDependencyUpdates(ctx context.Context, updates []jobDepend
 	return nil
 }
 
-// mintRunToken hands out the identity of one run of one job. Counting from 1
-// leaves the zero token to mean "the run this manager found already in progress
-// when it recovered", which is a run it never minted a token for and which no
-// minted token can be mistaken for.
+// mintRunToken hands out the identity of one run of one job; see runToken.
 func (s *Server) mintRunToken() runToken {
 	return runToken(s.lastRunToken.Add(1))
 }
@@ -4652,9 +4636,8 @@ func (s *Server) mintRunToken() runToken {
 // job is dead due to an ssh issue, but later on the job really does die because
 // the server it was running on gets rebooted, we eventually auto-kill the job.
 //
-// It reports nothing, because a confirmation is not a kill: the goroutine below
-// still has to establish that the run it confirmed dead is the run at the queue,
-// and it is the only thing that knows whether the kill happened.
+// It reports nothing: the goroutine it starts is the only thing that knows
+// whether the kill happened, and logs it there.
 func (s *Server) confirmJobDeadAndKill(ctx context.Context, d lostJobDetails) {
 	if !s.confirmJobDead(ctx, d.pid, d.host, d.checkTimeout) {
 		go s.confirmJobDeadAndKillAfterRetryTime(ctx, d.key, d.checkRetryTime)
@@ -4669,17 +4652,12 @@ func (s *Server) confirmJobDeadAndKill(ctx context.Context, d lostJobDetails) {
 // carries and, only if it really released that run, triggers them, logging any
 // problems.
 //
-// Both halves are about one run, and neither re-asks the queue what that run is.
-// The behaviours were pinned when the job was declared lost, so they act on the
-// state of the run that was lost even though a retry may since have written its
-// own working directory onto the same *Job. And killLostRun refuses a job that
-// is no longer that run, so the behaviours never fire against a job that was not
-// released and may still be RUNNING: killJob reports success without releasing
-// anything when the job is not lost, and acting on that swept the working
-// directory of a live job while its runner was still writing to it.
-//
-// A run that is refused leaks its workspace, which is the right way round: the
-// job has moved on and whatever it is doing now is doing it there.
+// killLostRun refuses a job that is no longer that run, so the behaviours never
+// fire against a job that may still be RUNNING: killJob reports success without
+// releasing anything when the job is not lost, and acting on that swept the
+// working directory of a live job while its runner was writing to it. A refused
+// run leaks its workspace, which is the right way round - the job has moved on
+// and is using that directory.
 func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobDetails) {
 	if lostJobDeadCheckedHook != nil {
 		lostJobDeadCheckedHook()
@@ -4712,12 +4690,10 @@ func (s *Server) killLostJobAndTriggerBehaviours(ctx context.Context, d lostJobD
 // Only the behaviours are bounded, not the kill above: the cleanup among them is
 // what holds a descriptor per level of the tree it deletes, while a job whose
 // runner is confirmed dead has to be killed promptly however long the queue of
-// cleanups is.
-//
-// A shutting-down manager takes the wait back rather than joining it, so
-// stopClientHandling closing leaves the workspace behind, which is recoverable
-// (the next manager's cleanup of the same lost run deletes it), where a shutdown
-// blocked behind a full channel is not.
+// cleanups is. A manager shutting down gives up its place in the queue instead
+// of waiting; the workspace it leaves behind is deleted by the next manager's
+// cleanup of the same lost run, whereas a shutdown blocked on a full channel
+// never finishes.
 func (s *Server) triggerLostRunBehaviours(ctx context.Context, d lostJobDetails) {
 	select {
 	case s.lostCleanupTokens <- struct{}{}:
@@ -4753,10 +4729,9 @@ func (s *Server) confirmJobDeadAndKillAfterRetryTime(ctx context.Context, jobKey
 
 	select {
 	case <-timer.C:
-		// the retry check re-establishes that the job is still lost AND pins the
-		// run it is lost in, in one lock. Its answer is about that moment only:
-		// the confirmJobDead call below reopens the same window the pin exists
-		// to survive, and it is killLostRun that has to be satisfied afterwards.
+		// the check re-establishes that the job is still lost and pins the run it
+		// is lost in, in one lock; the confirmJobDead call below reopens the same
+		// window, so killLostRun has to be satisfied again afterwards.
 		d, ok := s.lostJobRetryCheck(jobKey)
 		if !ok {
 			return
@@ -4913,26 +4888,22 @@ func (s *Server) inputToQueuedJobs(ctx context.Context, inputJobs []*Job) []*Job
 // been done.
 //
 // The bool does NOT say the job was released: a job that is running normally is
-// only marked, and the release is the lost job's case alone. A caller that needs
-// to know the job really was released - because it is about to act on the
-// directory the job was using - must use killLostRun.
+// only marked. A caller about to act on the directory the job was using must use
+// killLostRun instead.
 func (s *Server) killJob(ctx context.Context, jobkey string) (bool, error) {
 	killCalled, _, err := s.killRunningJob(ctx, jobkey, nil)
 
 	return killCalled, err
 }
 
-// killLostRun is killJob for the one caller that is killing a particular RUN of
-// a job rather than the job: the manager, once it has confirmed the run it
+// killLostRun is killJob for the caller that is killing one particular RUN of a
+// job rather than the job: the manager, once it has confirmed the run it
 // declared lost is dead.
 //
-// It reports whether it released THAT run, and it releases nothing else. The
-// confirmation it acts on was made about one run, minutes ago in the retry case
-// and a 15 second ssh round trip away in the ordinary one, and in that time the
-// job can recover, be released, and be reserved and started again. Killing on
-// the strength of a proof about a run that has been replaced kills a job that is
-// alive; running the lost run's behaviours afterwards deletes the working
-// directory that live job is using.
+// It reports whether it released THAT run, and releases nothing else: the
+// confirmation it acts on was made a 15 second ssh round trip or a retry timer
+// ago, and in that time the job can have been released and started again as a
+// live run.
 func (s *Server) killLostRun(ctx context.Context, pin pinnedBehaviours) (bool, error) {
 	_, released, err := s.killRunningJob(ctx, pin.workSpace.key, &pin.run)
 
@@ -4945,8 +4916,7 @@ func (s *Server) killLostRun(ctx context.Context, pin pinnedBehaviours) (bool, e
 // onlyRun, when non-nil, names the run the caller is killing: the job is then
 // left entirely untouched - not even marked - unless it is still lost and still
 // that run. Marking matters as much as releasing, because killCalled turns the
-// job's next touch into a self-kill, so mistaking a recovered job for the lost
-// one would kill the run that had just come back.
+// job's next touch into a self-kill.
 func (s *Server) killRunningJob(ctx context.Context, jobkey string,
 	onlyRun *runToken) (bool, bool, error) {
 	q := s.queueIfPresent()
@@ -4978,10 +4948,9 @@ func (s *Server) killRunningJob(ctx context.Context, jobkey string,
 
 	// released reports that this WAS the run to release, not that the queue
 	// change succeeded. A failed release leaves the job lost and in the run
-	// queue, and ttrCallback does not re-mark an already-lost job, so there is
-	// no second confirmation coming: withholding the behaviours there would
-	// leak the dead run's workspace permanently, for nothing. The run is dead,
-	// confirmed, and proven to be the pinned one; the error is logged.
+	// queue, and ttrCallback does not re-mark an already-lost job, so no second
+	// confirmation is coming: withholding the behaviours would leak the dead
+	// run's workspace for ever, for nothing.
 	return true, true, s.releaseJob(ctx, job, &JobEndState{Exitcode: -1, Exited: true},
 		FailReasonLost, false, false)
 }

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -2334,15 +2334,10 @@ func (s *Server) lostJobRetryCheck(jobKey string) (lostJobDetails, bool) {
 	job.RLock()
 	defer job.RUnlock()
 
-	// job.Exited is the same "is this run over?" question ttrCallback asks, and
-	// the only one that answers for a run the manager has heard nothing from:
 	// Job.State is written at Started and at each exit, never at Reserve, so
-	// through a whole reservation it still reads the PREVIOUS run's value. Gating
-	// on State therefore never fired for a reserved-not-started run - the one
-	// case whose host and pid are the reserving runner's, so that a first
-	// confirmation that could not reach the host is worth retrying at all. It
-	// still refuses the stretch markJobComplete leaves open, where an archived
-	// run is in the run sub-queue with Lost set: that run reported its own exit.
+	// through a whole reservation it reads the PREVIOUS run's value. job.Exited is
+	// the same question ttrCallback asks, so the two cannot disagree, and it still
+	// refuses the window where an archived run sits in the run sub-queue with Lost.
 	if job.Exited || !job.Lost {
 		return lostJobDetails{}, false
 	}

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -838,9 +838,9 @@ func (s *Server) respondWithReservedJob(ctx context.Context, cr *clientRequest, 
 // until-buried count (read under the same lock).
 //
 // A RUN of a job begins here, so this is where the manager mints the run's
-// identity (see runToken) and clears the fields that described the run before.
-// The runner makes its working directory, mounts filesystems and starts the Cmd
-// on the strength of the reservation alone, before its Started reaches us.
+// identity (see runToken) and clears the fields that described the run before. The
+// runner makes its working directory, mounts filesystems and starts the Cmd on
+// the strength of the reservation alone, before its Started reaches us.
 func (s *Server) resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, uint8, uint8) {
 	sjob.Lock()
 	defer sjob.Unlock()
@@ -857,21 +857,18 @@ func (s *Server) resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, 
 	sjob.Exitcode = -1
 	sjob.killCalled = false
 
-	// the identity of the run beginning now. Nothing pinned to an earlier run of
-	// this job answers to it, so a confirmation of that run's loss cannot be
-	// carried out on this one.
+	// the identity of the run beginning now, which nothing pinned to an earlier
+	// run of this job answers to.
 	sjob.runID = s.mintRunToken()
 
 	// this run has not been lost. Lost gates every lost-run decision, and
-	// ttrCallback refuses to re-mark an already-lost job, so a Lost carried into
-	// a fresh reservation - by `wr kill` on a lost job, or by the cloud scheduler
-	// destroying its server - parks the job for ever.
+	// ttrCallback refuses to re-mark an already-lost job, so a Lost carried into a
+	// fresh reservation would park the job for ever.
 	sjob.Lost = false
 
-	// nor has it made a working directory or landed on a machine yet. ActualCwd
-	// is what cleanup deletes and what a `run` behaviour executes in, and HostID
-	// is what killJobsOnBadServers matches condemned cloud servers against, so
-	// the previous run's values would aim both at the wrong run.
+	// nor has it made a working directory or landed on a machine yet. ActualCwd is
+	// what cleanup deletes and what a `run` behaviour executes in, and HostID is
+	// what killJobsOnBadServers matches condemned cloud servers against.
 	sjob.ActualCwd = ""
 	sjob.HostID = ""
 
@@ -928,9 +925,8 @@ func (s *Server) applyJobStart(job, crJob *Job) bool {
 	job.setActualCwd(crJob.ActualCwd)
 
 	// a reservation whose reserve-to-Started stretch outlasts the TTR is declared
-	// lost while its Cmd is starting, under this run's own token, so taking the
-	// job off lost here is all that stands between a confirmation of that loss
-	// and a Cmd that is running.
+	// lost while its Cmd starts, under this run's own token, so taking the job off
+	// lost here is all that stands between that confirmation and a live Cmd.
 	job.Lost = false
 	job.State = JobStateRunning
 

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -804,7 +804,7 @@ func (s *Server) respondWithReservedJob(ctx context.Context, cr *clientRequest, 
 	// clean up any past state to have a fresh job ready to run
 	sjob := item.Data().(*Job) //nolint:errcheck,forcetypeassert // queue only ever stores *Job
 
-	sgroup, retries, ub := resetJobForReservation(sjob, cr.ClientID)
+	sgroup, retries, ub := s.resetJobForReservation(sjob, cr.ClientID)
 
 	delay := s.setItemDelay(ctx, item.Key, retries, ub)
 
@@ -836,7 +836,15 @@ func (s *Server) respondWithReservedJob(ctx context.Context, cr *clientRequest, 
 // resetJobForReservation clears a job's past run state ready for a fresh run by
 // the reserving client, returning its scheduler group, retries and
 // until-buried count (read under the same lock).
-func resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, uint8, uint8) {
+//
+// This is where a RUN of a job begins, so it is where the manager mints the
+// run's identity (see runToken) and where every field that described the run
+// BEFORE it stops describing this one. A reservation is the first thing the
+// runner has that is about to make a working directory, mount filesystems and
+// start a Cmd, and it does all of that before its Started ever reaches the
+// manager: a decision pinned to the previous run and carried out in that window
+// lands on a Cmd that is already executing.
+func (s *Server) resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, uint8, uint8) {
 	sjob.Lock()
 	defer sjob.Unlock()
 
@@ -851,6 +859,33 @@ func resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, uint8, uint8
 	sjob.PeakDisk = 0
 	sjob.Exitcode = -1
 	sjob.killCalled = false
+
+	// the identity of the run that is beginning. Nothing pinned to any earlier
+	// run of this job answers to it, which is what stops a confirmation made
+	// about a run that is over being carried out on this one.
+	sjob.runID = s.mintRunToken()
+
+	// this run has not been lost. A lost run that is released - by `wr kill`, or
+	// by the cloud scheduler destroying its server - carries Lost all the way
+	// back into the run sub-queue on its next reservation, and Lost is what every
+	// lost-run decision is gated on. It also parks the job for ever: ttrCallback
+	// refuses to re-mark an already-lost job, so no fresh confirmation is ever
+	// started for the run that is really happening.
+	sjob.Lost = false
+
+	// and it has not made a working directory yet. ActualCwd is what cleanup
+	// deletes and what a `run` behaviour executes in, so carrying the previous
+	// run's here aims both at a directory this run has never been in - which is,
+	// for a job whose runs share a Cwd, an OLDER workspace of the same job.
+	sjob.ActualCwd = ""
+
+	// nor is it on the machine the previous run was on. HostID is the scheduler's
+	// name for that machine, filled in at Started from the host the runner
+	// reports, and killJobsOnBadServers kills every running or lost job whose
+	// HostID is a server the cloud scheduler has condemned - through the same
+	// un-gated release. Blanking it means a run whose Started has yet to arrive
+	// matches no server at all, which errs towards killing nothing.
+	sjob.HostID = ""
 
 	return sjob.schedulerGroup, sjob.Retries, sjob.UntilBuried
 }
@@ -880,6 +915,12 @@ func (s *Server) handleStart(ctx context.Context, cr *clientRequest) (*serverRes
 
 // applyJobStart records the host/pid/start-time of a started job under lock,
 // returning false (changing nothing) if the request lacked a pid or host.
+//
+// It is where the manager first learns the working directory the runner made for
+// this run, which the runner has already created by the time it calls Started
+// (Client.resolveWorkingDir runs before Client.Started). It does NOT mint the
+// run's identity: the run began at Reserve, and resetJobForReservation both
+// minted it and cleared the fields this one is about to fill in.
 func (s *Server) applyJobStart(job, crJob *Job) bool {
 	job.Lock()
 	defer job.Unlock()
@@ -898,6 +939,13 @@ func (s *Server) applyJobStart(job, crJob *Job) bool {
 	job.StartTime = time.Now()
 	job.EndTime = time.Time{}
 	job.Attempts++
+	job.setActualCwd(crJob.ActualCwd)
+
+	// a reservation whose reserve-to-Started stretch outlasts the TTR is declared
+	// lost while its Cmd is starting, and pinned under the very token this run
+	// keeps - its reservation minted it and this does not change it. So taking the
+	// job off lost here is the whole of what stands between a confirmation of
+	// that loss and a Cmd that is running.
 	job.Lost = false
 	job.State = JobStateRunning
 

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -837,13 +837,10 @@ func (s *Server) respondWithReservedJob(ctx context.Context, cr *clientRequest, 
 // the reserving client, returning its scheduler group, retries and
 // until-buried count (read under the same lock).
 //
-// This is where a RUN of a job begins, so it is where the manager mints the
-// run's identity (see runToken) and where every field that described the run
-// BEFORE it stops describing this one. A reservation is the first thing the
-// runner has that is about to make a working directory, mount filesystems and
-// start a Cmd, and it does all of that before its Started ever reaches the
-// manager: a decision pinned to the previous run and carried out in that window
-// lands on a Cmd that is already executing.
+// A RUN of a job begins here, so this is where the manager mints the run's
+// identity (see runToken) and clears the fields that described the run before.
+// The runner makes its working directory, mounts filesystems and starts the Cmd
+// on the strength of the reservation alone, before its Started reaches us.
 func (s *Server) resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, uint8, uint8) {
 	sjob.Lock()
 	defer sjob.Unlock()
@@ -860,31 +857,22 @@ func (s *Server) resetJobForReservation(sjob *Job, clientID uuid.UUID) (string, 
 	sjob.Exitcode = -1
 	sjob.killCalled = false
 
-	// the identity of the run that is beginning. Nothing pinned to any earlier
-	// run of this job answers to it, which is what stops a confirmation made
-	// about a run that is over being carried out on this one.
+	// the identity of the run beginning now. Nothing pinned to an earlier run of
+	// this job answers to it, so a confirmation of that run's loss cannot be
+	// carried out on this one.
 	sjob.runID = s.mintRunToken()
 
-	// this run has not been lost. A lost run that is released - by `wr kill`, or
-	// by the cloud scheduler destroying its server - carries Lost all the way
-	// back into the run sub-queue on its next reservation, and Lost is what every
-	// lost-run decision is gated on. It also parks the job for ever: ttrCallback
-	// refuses to re-mark an already-lost job, so no fresh confirmation is ever
-	// started for the run that is really happening.
+	// this run has not been lost. Lost gates every lost-run decision, and
+	// ttrCallback refuses to re-mark an already-lost job, so a Lost carried into
+	// a fresh reservation - by `wr kill` on a lost job, or by the cloud scheduler
+	// destroying its server - parks the job for ever.
 	sjob.Lost = false
 
-	// and it has not made a working directory yet. ActualCwd is what cleanup
-	// deletes and what a `run` behaviour executes in, so carrying the previous
-	// run's here aims both at a directory this run has never been in - which is,
-	// for a job whose runs share a Cwd, an OLDER workspace of the same job.
+	// nor has it made a working directory or landed on a machine yet. ActualCwd
+	// is what cleanup deletes and what a `run` behaviour executes in, and HostID
+	// is what killJobsOnBadServers matches condemned cloud servers against, so
+	// the previous run's values would aim both at the wrong run.
 	sjob.ActualCwd = ""
-
-	// nor is it on the machine the previous run was on. HostID is the scheduler's
-	// name for that machine, filled in at Started from the host the runner
-	// reports, and killJobsOnBadServers kills every running or lost job whose
-	// HostID is a server the cloud scheduler has condemned - through the same
-	// un-gated release. Blanking it means a run whose Started has yet to arrive
-	// matches no server at all, which errs towards killing nothing.
 	sjob.HostID = ""
 
 	return sjob.schedulerGroup, sjob.Retries, sjob.UntilBuried
@@ -917,10 +905,8 @@ func (s *Server) handleStart(ctx context.Context, cr *clientRequest) (*serverRes
 // returning false (changing nothing) if the request lacked a pid or host.
 //
 // It is where the manager first learns the working directory the runner made for
-// this run, which the runner has already created by the time it calls Started
-// (Client.resolveWorkingDir runs before Client.Started). It does NOT mint the
-// run's identity: the run began at Reserve, and resetJobForReservation both
-// minted it and cleared the fields this one is about to fill in.
+// this run, created before the runner calls Started. It does not mint the run's
+// identity: the run began at Reserve.
 func (s *Server) applyJobStart(job, crJob *Job) bool {
 	job.Lock()
 	defer job.Unlock()
@@ -942,10 +928,9 @@ func (s *Server) applyJobStart(job, crJob *Job) bool {
 	job.setActualCwd(crJob.ActualCwd)
 
 	// a reservation whose reserve-to-Started stretch outlasts the TTR is declared
-	// lost while its Cmd is starting, and pinned under the very token this run
-	// keeps - its reservation minted it and this does not change it. So taking the
-	// job off lost here is the whole of what stands between a confirmation of
-	// that loss and a Cmd that is running.
+	// lost while its Cmd is starting, under this run's own token, so taking the
+	// job off lost here is all that stands between a confirmation of that loss
+	// and a Cmd that is running.
 	job.Lost = false
 	job.State = JobStateRunning
 

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -94,6 +94,13 @@ func (j *Job) workSpaceSnapshot() jobWorkSpaceSnapshot {
 	j.RLock()
 	defer j.RUnlock()
 
+	return j.workSpaceSnapshotLocked()
+}
+
+// workSpaceSnapshotLocked is workSpaceSnapshot for a caller that already holds
+// at least the Job's read lock, so that the snapshot can be taken in the same
+// breath as everything else that has to be pinned with it - see pinBehaviours.
+func (j *Job) workSpaceSnapshotLocked() jobWorkSpaceSnapshot {
 	return jobWorkSpaceSnapshot{
 		cwdMatters: j.CwdMatters,
 		cwd:        j.Cwd,
@@ -243,6 +250,10 @@ type jobWorkSpace struct {
 // this Job, holds the Cwd open, and resolves and classifies every mount point
 // and cache location in the same breath, so that no caller has to - or is able
 // to - work any of it out again.
+//
+// Asked of a SNAPSHOT, not the live Job: applyLiveSnapshot rewrites ActualCwd
+// under the Job's lock while cleanup walks. Lost jobs snapshot at the lost
+// decision, as the kill releases the Job and a later read gets the RETRY's cwd.
 //
 // A nil result with a nil error means wr created nothing here that it may
 // delete: see paths() for the cases, plus a Job Cwd that has itself already

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -86,6 +86,22 @@ type jobWorkSpaceSnapshot struct {
 	mounts     MountConfigs
 }
 
+// cleanupWorkSpace resolves the snapshot's workspace and clears it out, doing
+// nothing at all when wr created nothing there it may delete.
+//
+// It is the one deletion the snapshot licenses, shared by the cleanup Behaviour
+// and by the runner tidying up after a run whose command never started, so that
+// there is a single answer to what a Job's workspace cleanup does.
+func (s jobWorkSpaceSnapshot) cleanupWorkSpace() error {
+	ws, err := s.resolveWorkSpace()
+	if err != nil || ws == nil {
+		return err
+	}
+	defer ws.Close()
+
+	return ws.cleanup()
+}
+
 // workSpaceSnapshot copies, under the Job's read lock, everything the workspace
 // resolution reads from it; nothing downstream looks at the Job again. Copying
 // the MountConfigs slice header is enough, since it is only ever replaced

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -87,11 +87,9 @@ type jobWorkSpaceSnapshot struct {
 }
 
 // cleanupWorkSpace resolves the snapshot's workspace and clears it out, doing
-// nothing at all when wr created nothing there it may delete.
-//
-// It is the one deletion the snapshot licenses, shared by the cleanup Behaviour
-// and by the runner tidying up after a run whose command never started, so that
-// there is a single answer to what a Job's workspace cleanup does.
+// nothing at all when wr created nothing there it may delete. It is the whole of
+// a Job's workspace cleanup, for the cleanup Behaviour and for the runner tidying
+// up after a run whose command never started.
 func (s jobWorkSpaceSnapshot) cleanupWorkSpace() error {
 	ws, err := s.resolveWorkSpace()
 	if err != nil || ws == nil {
@@ -114,8 +112,7 @@ func (j *Job) workSpaceSnapshot() jobWorkSpaceSnapshot {
 }
 
 // workSpaceSnapshotLocked is workSpaceSnapshot for a caller that already holds
-// at least the Job's read lock, so that the snapshot can be taken in the same
-// breath as everything else that has to be pinned with it - see pinBehaviours.
+// at least the Job's read lock; see pinBehavioursLocked.
 func (j *Job) workSpaceSnapshotLocked() jobWorkSpaceSnapshot {
 	return jobWorkSpaceSnapshot{
 		cwdMatters: j.CwdMatters,
@@ -268,8 +265,8 @@ type jobWorkSpace struct {
 // to - work any of it out again.
 //
 // Asked of a SNAPSHOT, not the live Job: applyLiveSnapshot rewrites ActualCwd
-// under the Job's lock while cleanup walks. Lost jobs snapshot at the lost
-// decision, as the kill releases the Job and a later read gets the RETRY's cwd.
+// under the Job's lock while cleanup walks; see pinnedBehaviours for when a lost
+// job's snapshot has to be taken.
 //
 // A nil result with a nil error means wr created nothing here that it may
 // delete: see paths() for the cases, plus a Job Cwd that has itself already

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -69,8 +69,8 @@ var workSpaceResolveHook func() //nolint:gochecknoglobals // the only seam onto 
 
 // muxfysCachePrefix is what muxfys names the cache directories it chooses for
 // itself, inside whichever CacheBase it was given (see its remote.go). They hold
-// a writable mount's output until Unmount uploads it, and cleanup runs before
-// Unmount, so deleting one destroys the job's own results.
+// a writable mount's output until Unmount uploads it, so cleanup keeps them
+// unconditionally rather than judging whether Unmount has already run.
 const muxfysCachePrefix = ".muxfys"
 
 // jobWorkSpaceSnapshot is the copy of a Job's fields that the workspace
@@ -557,12 +557,13 @@ func (ws *jobWorkSpace) Close() {
 }
 
 // keptDirs is everything cleanup must leave alone inside a Job's workspace: its
-// mount points, which are still live when cleanup runs (Job.Unmount comes after
-// it in client.go) so that deleting through one would recurse into the user's
-// remote file system; and the cache directories muxfys writes a writable mount's
-// output to, which are not uploaded until that Unmount. Each is classified ONCE,
-// against the proven workspace and working directory, in the one place that
-// knows both.
+// mount points, where deleting through a still-live one would recurse into the
+// user's remote file system; and the cache directories muxfys writes a writable
+// mount's output to, which are not uploaded until Unmount. Both come from the
+// snapshot's MountConfigs rather than from what is mounted now, and are kept
+// unconditionally, so a caller may clean up on either side of Job.Unmount. Each
+// is classified ONCE, against the proven workspace and working directory, in the
+// one place that knows both.
 type keptDirs struct {
 	// wholeActualCwd is set when something that must survive IS the working
 	// directory, so that none of its contents may be touched.

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -88,8 +88,7 @@ type jobWorkSpaceSnapshot struct {
 
 // cleanupWorkSpace resolves the snapshot's workspace and clears it out, doing
 // nothing at all when wr created nothing there it may delete. It is the whole of
-// a Job's workspace cleanup, for the cleanup Behaviour and for the runner tidying
-// up after a run whose command never started.
+// a Job's workspace cleanup, for the cleanup Behaviour and for the runner.
 func (s jobWorkSpaceSnapshot) cleanupWorkSpace() error {
 	ws, err := s.resolveWorkSpace()
 	if err != nil || ws == nil {
@@ -265,8 +264,7 @@ type jobWorkSpace struct {
 // to - work any of it out again.
 //
 // Asked of a SNAPSHOT, not the live Job: applyLiveSnapshot rewrites ActualCwd
-// under the Job's lock while cleanup walks; see pinnedBehaviours for when a lost
-// job's snapshot has to be taken.
+// under the Job's lock while cleanup walks. See pinnedBehaviours.
 //
 // A nil result with a nil error means wr created nothing here that it may
 // delete: see paths() for the cases, plus a Job Cwd that has itself already
@@ -558,9 +556,8 @@ func (ws *jobWorkSpace) Close() {
 // user's remote file system; and the cache directories muxfys writes a writable
 // mount's output to, which are not uploaded until Unmount. Both come from the
 // snapshot's MountConfigs rather than from what is mounted now, and are kept
-// unconditionally, so a caller may clean up on either side of Job.Unmount. Each
-// is classified ONCE, against the proven workspace and working directory, in the
-// one place that knows both.
+// unconditionally, so a caller may clean up on either side of Job.Unmount. Each is
+// classified ONCE, against the proven workspace and working directory.
 type keptDirs struct {
 	// wholeActualCwd is set when something that must survive IS the working
 	// directory, so that none of its contents may be touched.


### PR DESCRIPTION
Three lost-job bugs found while fixing the `--cwd_matters` data loss in #558, split out because they are a different family. All three are **pre-existing in production**, not introduced by that work.

**A lost-job decision was carried out on whatever run held the key later.** The manager declares a run lost, spends up to `ServerLostJobCheckTimeout` (15s) on an ssh round trip confirming it dead, then kills the job and runs its behaviours — with nothing establishing that the job it acts on is still the run it decided about. In that window the job can recover on a touch, or be released, reserved and started again, so the manager released and `killCalled`-marked a job whose `Cmd` was executing, and swept the working directory that live run was writing to. Fixed by pinning the behaviours and their workspace with the decision (`pinnedBehaviours`), by the manager minting the run's identity rather than trusting anything the runner reports (`runToken`), and by treating a run as beginning at **Reserve** rather than at `Started`, since everything a runner does that another run's decision could destroy happens in between.

**A lost run that was reserved but never started was parked lost for ever.** `lostJobRetryCheck` gated on `job.State`, which is written at `Started` and never at Reserve, so it read the previous run's value for a whole reservation and the 30-minute re-confirmation never fired — meaning a first `confirmJobDead` that could not reach the host was the last one. It now asks `job.Exited`, the same question `ttrCallback` asks, so the two cannot disagree.

**A run that died before `Started` leaked its working directory permanently.** Seven early-return paths in `Client.Execute` created a workspace and left it; three of them do not even bury the job. The abandoned leaf also blocked reclamation of the shared hashed levels above it for ever. The runner now cleans up after itself on all seven, unmounting first and deleting nothing if that fails, through #558's proven deletion path. No user behaviours run there, so a mount failure does not execute the user's `run` command.

`.docs/bugfixes/260831-1.md` has the per-layer detail: what each fix was measured against, the alternatives rejected and why, and the residuals left open.

`make test` and `make race` both 412 passed / 9 skipped; `make lint` 0 issues.

**Stacked on #558 — merge that first.** The pin carries a `jobWorkSpaceSnapshot`, and both that type and the property that behaviours act on a snapshot rather than a live `*Job` belong to #558's refactor.
