### PR TITLE
Stop a slow machine reporting a kill request as a lost job

### DIFF
--- a/.docs/bugfixes/260901-1.md
+++ b/.docs/bugfixes/260901-1.md
@@ -1,0 +1,100 @@
+# Bugfixes 260901-1
+
+- [x] `TestJobqueueRunnerKillRequests` measured the machine instead of the kill:
+  reported by a user running the suite on a slow NFS-backed machine.
+
+  ```text
+  ===== runner_kill_requests =====
+  Failures:
+    Kill requests bury running runner jobs
+    * jobqueue/runner_lifecycle_test.go
+    Line 551:
+    Expected: "killed by user request"
+    Actual:   "lost contact with runner"  (Should equal)
+  --- FAIL: TestJobqueueRunnerKillRequests (21.36s)
+  ```
+
+  - Diagnosis (read from the code): the Convey "Kill requests bury running
+    runner jobs" (jobqueue/runner_lifecycle_test.go:431) adds a 20-second `perl`
+    sleep job, waits for it to reach Running, calls `jq.Kill(...)`, then polls
+    for the job to become buried *by any cause* and only afterwards asserts
+    `FailReason == FailReasonKilled`. Two paths bury it and the poll cannot tell
+    them apart: the intended one, where the runner learns of the kill on its
+    next Touch and buries with `FailReasonKilled`; and `Server.ttrCallback`
+    (jobqueue/server.go:3794), which on TTR expiry sets `job.Lost = true;
+    job.FailReason = FailReasonLost` and hands the job to
+    `confirmOrReleaseLostJob`, whose `d.killCalled` branch releases it with
+    `FailReasonLost` (jobqueue/server.go:3888-3899), burying it as "lost contact
+    with runner" because the job has `Retries: 0`.
+  - The fixture `withRunnerServer` pins `TouchInterval` at 50ms and takes
+    `itemTTR` from its options, and `defaultRunnerServerOptions` supplied
+    `itemTTR: 10 * time.Second`, a 200x margin. On a box slow enough for the
+    runner to miss touches for a full 10 seconds the TTR path preempts the kill
+    and the assertion fails on the *reason*, not on the kill. Nothing in this
+    test depends on a TTR expiring; it is not a lost-job-detection test.
+  - Not reproducible on this fast local-disk box at the shipped timings. The
+    prior diagnosis pass reports 20/20 unloaded, 8/8 under CPU load, 20/20 with
+    the TTR compressed to 400ms, 12/12 at 400ms plus CPU load, and a pass even
+    with the runner SIGSTOPped for 12 seconds, because a lost job that touches
+    again is recovered; this pass independently confirms 20/20 unloaded. So the
+    fix removes the dependency rather than chasing a reproduction.
+  - Measured instead: the dependency itself, by forcing `itemTTR` at the
+    `defaultRunnerServerOptions` site and rebuilding the `jobqueue` test binary.
+    The failure mode is a knife edge at the 50ms touch interval, so several
+    values were needed to find one that fails fast and cleanly.
+
+    - 20ms: hangs at the Running poll, 6 assertions and no verdict inside 100s.
+    - 30ms: fails at line 499, `So(<-started, ShouldBeTrue)`, after 183s. Wrong
+      symptom.
+    - 33ms and 34ms: hang, or one 14s pass. No clean verdict.
+    - 36ms: 5 of 10 runs fail at line 551 with the user's exact symptom, in
+      ~20s each.
+    - 38ms: 1 of 10 runs fails with the symptom.
+    - 40ms and up: 8 of 8 pass in ~0.5s at every value tried (40, 45, 50, 51,
+      52, 53, 55, 58, 60, 65, 70, 80, 90, 100, 200, 300ms).
+
+    Below the touch interval the job is repeatedly declared lost and recovered,
+    so it is rarely visible in Running and the *first* poll waits out its
+    3-minute bound instead of failing on the reason. Above ~40ms the runner's
+    touches always land first. At 36ms the job is seen Running, `Kill` sets
+    `killCalled`, and the next TTR expiry takes the release-as-lost branch:
+
+    ```text
+    === RUN   TestJobqueueRunnerKillRequests
+    ..............x
+
+    Failures:
+
+      * /home/ubuntu/wr_clone4/jobqueue/runner_lifecycle_test.go
+      Line 551:
+      Expected: "killed by user request"
+      Actual:   "lost contact with runner"
+      (Should equal)!
+
+    15 total assertions
+
+    --- FAIL: TestJobqueueRunnerKillRequests (20.39s)
+    FAIL
+    ```
+
+  - Fix (test-only; no production file touched): the Convey passes its own
+    `runnerServerOptions` with `itemTTR: 10 * runnerStartWait` instead of
+    `defaultRunnerServerOptions()`, and a three-line comment says why it wants a
+    TTR that cannot expire. The test's two polls are each bounded by
+    `runnerStartWait` (3 minutes), so a TTR of 30 minutes cannot fire inside any
+    run the test can have, making the lost path impossible rather than merely
+    unlikely. `defaultRunnerServerOptions` is left at 10s for its other callers,
+    and `TestJobqueueRunnerFailureRetry`'s deliberate 1s TTR is untouched. No
+    assertion was weakened: `JobStateBuried`, `FailReasonKilled` and
+    `Exitcode == -1` are all still asserted, and the `runnerStartWait` bounds
+    and 50ms poll intervals are unchanged.
+  - Fix proven to remove the dependency: the same forced-36ms build, rebuilt
+    with the fix in place, passes 10 of 10 in 0.4s to 0.7s, because the Convey
+    no longer inherits that value.
+  - Gates: `make test` `359 passed · 9 skipped · 29 packages · 3m16s`,
+    `make race` `359 passed · 9 skipped · 29 packages · 4m6s`, `make lint`
+    `0 issues.`, plus `go build ./...` and `go vet ./jobqueue/` clean.
+  - Repeat-run tally on the fixed binary: 20 of 20 passes of
+    `^TestJobqueueRunnerKillRequests$`, 0 failures. Note for future runs: this
+    test binary installs signal handlers, so plain `timeout N` does not stop
+    it; use `timeout -s KILL N`.

--- a/jobqueue/runner_lifecycle_test.go
+++ b/jobqueue/runner_lifecycle_test.go
@@ -429,8 +429,14 @@ func TestJobqueueRunnerKillRequests(t *testing.T) {
 	registerExpectedRunnerWaitLog := silenceExpectedRunCmdWaitLogs(t)
 
 	Convey("Kill requests bury running runner jobs", t, func() {
+		// A TTR expiry buries the job with FailReasonLost, which would preempt the
+		// kill this test is about, so use a TTR that outlasts the test's own
+		// runnerStartWait-bounded polls and so cannot expire during the run.
 		withRunnerServer(
-			t, ctx, registerExpectedRunnerWaitLog, defaultRunnerServerOptions(),
+			t, ctx, registerExpectedRunnerWaitLog, runnerServerOptions{
+				itemTTR:     10 * runnerStartWait,
+				checkRunner: 10 * time.Second,
+			},
 			func(fixture runnerServerFixture) {
 				jq, err := Connect(
 					fixture.addr,


### PR DESCRIPTION
`TestJobqueueRunnerKillRequests` can fail on a slow machine with the kill it is testing reported as a loss:

```
  Kill requests bury running runner jobs
  jobqueue/runner_lifecycle_test.go:551
  Expected: "killed by user request"
  Actual:   "lost contact with runner"
```

Two things can bury the job and the test's poll cannot tell them apart — it waits for the job to be buried by any cause, then asserts the reason. The intended path is the runner learning of the kill on its next Touch. The other is a TTR expiry: `ttrCallback` sets `FailReasonLost`, and `confirmOrReleaseLostJob`'s `killCalled` branch then releases with that reason, which buries a job with `Retries: 0`. So if the runner fails to Touch within the TTR *after* the Kill, the loss wins and the reason is wrong.

Nothing in this test is about lost-job detection, so it now supplies its own TTR — long enough that it cannot expire during a run bounded by the test's own polls — instead of inheriting the shared 10s default. `defaultRunnerServerOptions()` is unchanged, as is the deliberate 1s TTR another test uses. No assertion is weakened and no production code changes.

Reproduced by forcing the shared TTR down at its source: at 36ms the current test fails 5 of 10 runs with exactly the symptom above, and with this change the same forced build passes 10 of 10. The reproducible window is narrow because the TTR has to expire after the Kill but while the runner is still alive — below the 50ms touch interval the test hangs at an earlier poll instead.

`make test` and `make race` both 359 passed / 9 skipped; `make lint` 0 issues. The target test passes 20/20.

`.docs/bugfixes/260901-1.md` records the sweep and the measurements.
