### PR TITLE
Stop a job's own command redirecting wr's TMPDIR removal out of its cwd

### DIFF
--- a/.docs/bugfixes/260902-1.md
+++ b/.docs/bugfixes/260902-1.md
@@ -1,0 +1,214 @@
+# Bugfixes 260902-1
+
+Branch `fix-unproven-tmpdir-removal`: `Client.Execute`'s deferred TMPDIR removal
+was an `os.RemoveAll` of a path STRING, so the job's own `Cmd` could redirect it
+out of the job's `Cwd` and delete somewhere else entirely.
+
+## Where this came from
+
+An adversarial probe of develop, run after the `cwd_matters` hardening that put
+every deletion below a Job's `Cwd` behind `jobqueue/workspace.go`'s resolution.
+The probe looked for a deletion that reaches the filesystem without going through
+that resolution, and found one: `jobqueue/client.go:1756`.
+
+## The mechanism
+
+`resolveWorkingDir` hands `Execute` the two paths `mkHashedDir` built, and
+`Execute` deferred:
+
+```go
+myerr = joinExecErr(myerr, os.RemoveAll(filepath.Clean(tmpDir)), "removing the tmpdir failed")
+```
+
+`tmpDir` is `<workSpace>/tmp`, where `workSpace` is the `os.MkdirTemp` leaf below
+`<Cwd>/jobqueue_cwd/<hash levels>/`. Every component above `tmp` is re-resolved
+by the kernel when the removal runs, and all of them sit in the job's own working
+tree, which the job's `Cmd` may write to for its whole runtime. Replace one with
+a symlink and `os.RemoveAll` follows it.
+
+Nothing about this was theoretical. The probe ran a real `/bin/bash` `Cmd` the
+way `Execute` runs one (`cmd.Dir = actualCwd`, `TMPDIR=tmpDir`):
+
+```sh
+cd "$TMPDIR/../.."; leaf=$(basename "$(dirname "$TMPDIR")")
+mv "$leaf" "$leaf.moved"; ln -s "$VICTIM" "$leaf"
+```
+
+With the workspace's own name now a symlink to a directory outside `Cwd`, the two
+halves of wr disagreed:
+
+```
+the workspace resolution refuses to delete anything
+  cleanupWorkSpace refused: dir is not below the base dir: refusing to use
+  .../001/cwd/jobqueue_cwd/b/b/8/b183b8f37bb788728fb863897c67d2750895152/cwd,
+  whose parent is not a real dir inside the job's cwd .../001/cwd
+but Execute's deferred tmpdir removal deletes through it
+  os.RemoveAll(".../002/cwd/jobqueue_cwd/b/b/8/.../tmp") deleted
+  ".../002/precious/tmp/irreplaceable.txt"
+```
+
+`componentsAreRealDirs` saw the swapped component and refused, correctly, to
+delete anything; the unproven `os.RemoveAll` deleted a file in a directory the
+job had no claim on.
+
+## The ordering defect
+
+The same `defer` was registered at line 1755, AFTER the
+`cleanupUnstartedWorkSpace` defer at 1591. Defers run LIFO, so the unproven
+removal ran FIRST. `cleanupUnstartedWorkSpace` exists to hold one invariant -
+"Unmounting comes FIRST, and a failed unmount deletes nothing at all ... deleting
+through a live mount would delete the user's remote data" - and the TMPDIR
+removal beat it, with mounts still live and no keep set consulted, on the two
+bare `return err` paths between the two defers: `c.addBsubEnv` failing (1767) and
+`c.setupDockerMonitor` failing (1779). A `MountConfig` whose mount point or cache
+resolves into `tmp` (`CacheDir: "tmp"`, `CacheBase: "../tmp"`,
+`Mount: "../tmp/mnt"`) was deleted through.
+
+## The fix
+
+- [x] Remove the TMPDIR through the same proven descent every other deletion
+  below a Job's `Cwd` goes through, reusing what is already there rather than
+  adding a parallel mechanism.
+  - `jobWorkSpaceSnapshot.removeTmpDir` mirrors `cleanupWorkSpace`: resolve the
+    snapshot, and a nil workspace with a nil error - a `cwd_matters` Job, a Job
+    that never ran, a `Cwd` that has gone - is a silent no-op.
+  - `jobWorkSpace.removeTmp` asks `provenDirs.openChain` and `dirChain.openLeaf`
+    for an `*os.Root` on the workspace, proven by inode against what the descent
+    lstat'ed, then does `wsRoot.RemoveAll(createdTmpName)`: one entry named by its
+    own name alone, with no path above it left to resolve. That is exactly the
+    pattern `removeWorkSpaceEntries` already uses.
+  - `openLeaf`'s `os.IsNotExist` is a no-op, as in `jobWorkSpace.empty`: a
+    `cleanup` behaviour that ran first has taken the whole workspace, which is
+    the ordinary case rather than a failure.
+  - `tmp` is left alone when the keep set claims it, or when a mount is at or
+    above the workspace (`keptDirs.wholeWorkSpace`). This is not extra caution
+    bolted on: it is the answer `cleanupWorkSpace` already gives for the same
+    directory, and without it the ordering fix below would still delete through a
+    live mount whenever the unmount had failed.
+  - `"tmp"` became the `createdTmpName` const beside `createdCwdName`, so
+    `mkCwdAndTmp` and the removal cannot drift apart about the name.
+- [x] Fix the ordering by registering the removal BEFORE the
+  `cleanupUnstartedWorkSpace` defer, so LIFO runs it AFTER. Registering it
+  earlier rather than folding it into that function is what keeps the success
+  path honest: `cleanupUnstartedWorkSpace` only runs when the command never
+  started, while TMPDIR must be reclaimed on every exit, so folding would have
+  needed a second call site for the normal path.
+- [x] Report failures the way `cleanupUnstartedWorkSpace` does, with
+  `clog.Warn`, instead of extending the `myerr` wart: `myerr` is a plain local
+  that `Execute` has already returned by the time the defer runs, so the old
+  assignment was dropped.
+
+The `if tmpDir != ""` guard stays at the registration, so a `cwd_matters` Job
+does not even resolve a workspace, let alone delete anything.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=0 go test -tags netgo --count 1 ./jobqueue/ -v -run TestJobTmpDirRemoval
+
+`TestJobTmpDirRemoval` (in `jobqueue/client_payload_test.go`, beside
+`TestUnstartedRunWorkSpaceCleanupOrder`) is the probe rewritten as a committable
+test, against the extracted `removeJobTmpDir` seam. Red, with that seam still
+holding the old `os.RemoveAll(filepath.Clean(tmpDir))` body:
+
+```
+  Given a job wr made a workspace for
+    its tmp dir is removed, and nothing else is
+    and the job's own Cmd cannot redirect that removal out of its Cwd
+
+Failures:
+
+  * /home/ubuntu/wr_clone4/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestJobTmpDirRemoval3363492389/002/precious/tmp/irreplaceable.txt: no such file or directory'
+
+--- FAIL: TestJobTmpDirRemoval (0.01s)
+```
+
+The failing assertion is `soPathsExist(victimFile, ...)` - reported against
+`behaviours_test.go`, where that helper lives - and it names a file outside the
+job's `Cwd`, and it comes FIRST in that block: with the default `FailureHalts`,
+putting the assertion about the warning ahead of it would have hidden the
+deletion behind an error message.
+
+Green: `28 total assertions`, `--- PASS: TestJobTmpDirRemoval (0.01s)`.
+
+The other two cases stop the fix passing by deleting nothing at all, and pin the
+behaviour the removal has to keep:
+
+- an intact workspace and no cleanup behaviour: `tmp` goes, and the working
+  directory, the file in it, the workspace and the `Cwd` all stay.
+- a `MountConfig` with `CacheDir: "tmp"`: `tmp` stays, since deleting it could
+  delete a writable mount's output before `Unmount` uploaded it.
+
+## Mutation check
+
+`go vet ./jobqueue/` was run after each edit, so no verdict below is a build
+failure reporting zero failing assertions.
+
+- [x] M1: `removeJobTmpDir` reverted to
+  `os.RemoveAll(filepath.Clean(tmpDir))` over the reconstructed path string. Vet
+  OK. **RED** in two cases: the swap case lost
+  `.../002/precious/tmp/irreplaceable.txt`, and the mount-cache case lost the
+  `tmp` dir holding an unuploaded cache.
+- [x] M2: `removeTmp`'s `wsRoot.RemoveAll(createdTmpName)` replaced by
+  `return nil`. Vet OK. **RED**: the normal path no longer removes `tmp`
+  (`soPathsGone`, reported at `behaviours_test.go:1748`, `Expected: true
+  Actual: false`), so the fix cannot pass by deleting nothing.
+- [x] Both reverted; `go build ./...`, `go vet ./jobqueue/` and the test green
+  again.
+
+## Files touched
+
+- `jobqueue/client.go`: `removeJobTmpDir`, its `defer` registered above the
+  `cleanupUnstartedWorkSpace` one, and the deleted `defer` in the `TMPDIR=` block
+  (whose `envOverride` calls are untouched).
+- `jobqueue/workspace.go`: `jobWorkSpaceSnapshot.removeTmpDir` beside
+  `cleanupWorkSpace`, and `jobWorkSpace.removeTmp` beside
+  `removeWorkSpaceEntries`.
+- `jobqueue/utils.go`: the `createdTmpName` const, used by `mkCwdAndTmp`.
+- `jobqueue/client_payload_test.go`: `TestJobTmpDirRemoval`.
+
+No new types, and `Execute` is otherwise unchanged.
+
+## Gates
+
+From the repo root with all `OS_*` unset:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `417 passed - 9 skipped - 29 packages - 3m47s`.
+- `make race`: `417 passed - 9 skipped - 29 packages - 4m39s`.
+- `make lint`: `0 issues.`
+
+The baseline measured on this tree at `cffa03c` was `416 passed - 9 skipped`; the
+one extra is `TestJobTmpDirRemoval`.
+
+## How bad was it
+
+Not a privilege escalation. The job's `Cmd` runs as the submitting user, and
+`os.RemoveAll` here runs in the runner process, also as that user, so everything
+the swap could destroy was already deletable by the command itself. What the bug
+gave away was wr as the INSTRUMENT: a command that only writes inside the working
+directory wr gave it - the normal, well-behaved thing for a job to do - could
+still get wr to recurse into a directory of the user's that no part of the job
+ever named, at a moment the user is not watching and with the deletion attributed
+to wr's own cleanup. That is the same shape as the incident the workspace
+resolution was built for, which destroyed a user's scripts by deleting the parent
+of their working directory, and it is why the hardening has to cover every
+deletion rather than most of them. A concurrent `wr add` of a job whose `Cmd` is
+hostile, or simply a job that renames its own workspace out from under itself by
+accident, reaches the same place.
+
+The pre-start ordering half is narrower - it needs a mount configured into `tmp`
+and a failure between `addBsubEnv`/`setupDockerMonitor` and `cmd.Start()` - but it
+deletes REMOTE data through a live mount, which no local permission check bounds.
+
+## What this fix does NOT claim
+
+It fixes the TMPDIR removal. The probe also found that
+`relBelowDirResolved` answers lexically first, so a `MountConfig.Mount` spelled
+through a symlink inside the workspace records the symlink's name in the keep set
+instead of the name of the directory the mount is really in, and the workspace
+sweep then deletes the live mount point. That is a separate defect in
+`keptDirs`, not touched here.

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1486,6 +1486,23 @@ func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
 	}
 }
 
+// removeJobTmpDir reclaims the TMPDIR Execute gave a run, which every exit must
+// do: a Job with no cleanup Behaviour keeps its working directory, so nothing
+// else would remove the tmp dir beside it. The removal is made through the proven
+// workspace descent rather than by path string; see
+// jobWorkSpaceSnapshot.removeTmpDir.
+//
+// Failures are logged rather than returned for the reason
+// cleanupUnstartedWorkSpace logs its own: Execute's myerr is a plain local
+// already returned by the time this defer runs.
+func removeJobTmpDir(ctx context.Context, job *Job) {
+	snap := job.workSpaceSnapshot()
+
+	if err := snap.removeTmpDir(); err != nil {
+		clog.Warn(ctx, "could not remove the job's tmp dir", "dir", snap.actualCwd, "err", err)
+	}
+}
+
 // Execute runs the given Job's Cmd and blocks until it exits. Then any Job
 // Behaviours get triggered as appropriate for the exit status.
 //
@@ -1582,6 +1599,13 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	actualCwd, tmpDir, err := c.resolveWorkingDir(job, cmd)
 	if err != nil {
 		return err
+	}
+
+	// registered BEFORE the cleanup below, so that LIFO runs it AFTER: that
+	// cleanup unmounts first and deletes nothing at all when the unmount fails,
+	// and a Job's TMPDIR can be inside a live mount or hold a mount's cache.
+	if tmpDir != "" {
+		defer removeJobTmpDir(ctx, job)
 	}
 
 	// one seam covers every way this run can fail before its command starts; see
@@ -1752,9 +1776,6 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	if tmpDir != "" {
 		// (this works fine even if tmpDir has a space in one of the dir names)
 		env = envOverride(env, []string{"TMPDIR=" + tmpDir})
-		defer func() {
-			myerr = joinExecErr(myerr, os.RemoveAll(filepath.Clean(tmpDir)), "removing the tmpdir failed")
-		}()
 
 		if job.ChangeHome {
 			env = envOverride(env, []string{"HOME=" + actualCwd})

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1493,13 +1493,14 @@ func cleanupUnstartedWorkSpace(ctx context.Context, job *Job) {
 // jobWorkSpaceSnapshot.removeTmpDir.
 //
 // Failures are logged rather than returned for the reason
-// cleanupUnstartedWorkSpace logs its own: Execute's myerr is a plain local
-// already returned by the time this defer runs.
+// cleanupUnstartedWorkSpace logs its own: Execute's myerr is a plain local, so
+// assigning to it in this defer changes nothing.
 func removeJobTmpDir(ctx context.Context, job *Job) {
 	snap := job.workSpaceSnapshot()
 
 	if err := snap.removeTmpDir(); err != nil {
-		clog.Warn(ctx, "could not remove the job's tmp dir", "dir", snap.actualCwd, "err", err)
+		clog.Warn(ctx, "could not remove the job's tmp dir",
+			"dir", filepath.Join(filepath.Dir(snap.actualCwd), createdTmpName), "err", err)
 	}
 }
 

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -40,6 +40,7 @@ import (
 	"time"
 
 	"github.com/VertebrateResequencing/muxfys/v5"
+	"github.com/VertebrateResequencing/wr/clog"
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	"github.com/VertebrateResequencing/wr/queue"
@@ -164,6 +165,92 @@ func TestUnstartedRunWorkSpaceCleanupOrder(t *testing.T) {
 
 			So(mountedWhenProven, ShouldEqual, -1)
 			soPathsExist(actualCwd, tmpDir, workSpace, cwd)
+		})
+	})
+}
+
+// TestJobTmpDirRemoval covers how Execute reclaims the TMPDIR it gave a run. It
+// has to be removed on every exit, including for the great majority of Jobs that
+// have no cleanup Behaviour and so keep the workspace it sits in, and it must be
+// removed by descending into the workspace wr proved is its own: the path a Job
+// was given for TMPDIR is a string whose every component above tmp lies in the
+// tree the Job's own Cmd writes to for the whole run, so re-resolving it at
+// deletion time lets a component swapped for a symlink aim the deletion outside
+// the Job's Cwd entirely.
+func TestJobTmpDirRemoval(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a job wr made a workspace for", t, func() {
+		base := t.TempDir()
+		cwd := filepath.Join(base, "cwd")
+		So(os.MkdirAll(cwd, os.ModePerm), ShouldBeNil)
+
+		job := &Job{Cwd: cwd, Cmd: testWSCmd}
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		Reset(clog.ToDefault)
+
+		Convey("its tmp dir is removed, and nothing else is", func() {
+			output := writeFileIn(actualCwd, "out.txt")
+
+			removeJobTmpDir(context.Background(), job)
+
+			soPathsGone(tmpDir)
+			soPathsExist(output, actualCwd, workSpace, cwd)
+			So(buff.String(), ShouldBeEmpty)
+		})
+
+		Convey("and the job's own Cmd cannot redirect that removal out of its Cwd", func() {
+			victim := filepath.Join(base, "precious")
+			victimTmp := filepath.Join(victim, createdTmpName)
+			victimFile := writeFileIn(victimTmp, "irreplaceable.txt")
+
+			// the Job's Cmd, run the way Execute runs it: in the working
+			// directory wr made, with TMPDIR naming the tmp dir beside it. It
+			// puts a symlink to the victim where its workspace was.
+			cmd := exec.CommandContext(context.Background(), "/bin/bash", "-c", `
+				set -e
+				cd "$TMPDIR/../.."
+				leaf=$(basename "$(dirname "$TMPDIR")")
+				mv "$leaf" "$leaf.moved"
+				ln -s "$VICTIM" "$leaf"
+			`)
+			cmd.Dir = actualCwd
+
+			cmd.Env = append(os.Environ(), "TMPDIR="+tmpDir, "VICTIM="+victim)
+
+			out, err := cmd.CombinedOutput()
+			So(string(out), ShouldBeEmpty)
+			So(err, ShouldBeNil)
+
+			removeJobTmpDir(context.Background(), job)
+
+			// what survived comes first: it is the whole point of the test, and
+			// the default FailureHalts would hide it behind the warning below.
+			soPathsExist(victimFile, victimTmp, victim)
+			So(buff.String(), ShouldContainSubstring, "could not remove the job's tmp dir")
+		})
+
+		Convey("and a tmp dir one of the job's mounts caches in is left alone", func() {
+			// deleting it could delete a writable mount's output before Unmount
+			// has uploaded it, so it is kept unconditionally, exactly as the
+			// cleanup Behaviour keeps it; see keptDirs. The MountConfigs go in
+			// before the workspace is made because they feed Job.Key(), and the
+			// key is what proves the workspace is this Job's.
+			cacher := &Job{
+				Cwd: cwd, Cmd: testWSCmd,
+				MountConfigs: MountConfigs{{Targets: []MountTarget{{CacheDir: createdTmpName}}}},
+			}
+			cacherCwd, cacherWorkSpace, cacherTmp := realWorkSpace(cacher)
+
+			removeJobTmpDir(context.Background(), cacher)
+
+			soPathsExist(cacherTmp, cacherCwd, cacherWorkSpace, cwd)
+			So(buff.String(), ShouldBeEmpty)
 		})
 	})
 }

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -834,6 +834,12 @@ func retryOrFail(tries *int, err error) (bool, error) {
 // so the last component of every ActualCwd wr has ever created.
 const createdCwdName = "cwd"
 
+// createdTmpName is what mkCwdAndTmp calls the dir it makes beside a Job's
+// working directory to be that Job's TMPDIR. It is a const because removing that
+// dir names it to an open handle on the workspace, rather than re-resolving the
+// path string the Job was given; see jobWorkSpaceSnapshot.removeTmpDir.
+const createdTmpName = "tmp"
+
 // mkCwdAndTmp creates "cwd" and "tmp" dirs within dir, returning their paths.
 func mkCwdAndTmp(dir string) (cwd, tmpDir string, err error) {
 	cwd = filepath.Join(dir, createdCwdName)
@@ -841,7 +847,7 @@ func mkCwdAndTmp(dir string) (cwd, tmpDir string, err error) {
 		return cwd, tmpDir, err
 	}
 
-	tmpDir = filepath.Join(dir, "tmp")
+	tmpDir = filepath.Join(dir, createdTmpName)
 
 	return cwd, tmpDir, mkdirManaged(tmpDir, os.ModePerm)
 }

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -99,6 +99,30 @@ func (s jobWorkSpaceSnapshot) cleanupWorkSpace() error {
 	return ws.cleanup()
 }
 
+// removeTmpDir resolves the snapshot's workspace and removes just the tmp dir wr
+// made in it to be the Job's TMPDIR, leaving the workspace and the working
+// directory alone: Execute must reclaim TMPDIR on every exit, including for a Job
+// with no cleanup Behaviour, whose workspace has to survive.
+//
+// It goes through the same resolution cleanupWorkSpace asks for, rather than an
+// os.RemoveAll of the TMPDIR path, because every component of that path above tmp
+// is inside the tree the Job's own Cmd may write to for the whole run: a string
+// is re-resolved by the kernel at deletion time, so a component replaced by a
+// symlink since redirects the deletion out of the Job's Cwd altogether.
+//
+// Doing nothing at all is the right answer to a workspace that has already gone -
+// the ordinary case when a cleanup Behaviour ran first - and to a tmp dir the
+// Job's live mounts and caches claim; see keptDirs.
+func (s jobWorkSpaceSnapshot) removeTmpDir() error {
+	ws, err := s.resolveWorkSpace()
+	if err != nil || ws == nil {
+		return err
+	}
+	defer ws.Close()
+
+	return ws.removeTmp()
+}
+
 // workSpaceSnapshot copies, under the Job's read lock, everything the workspace
 // resolution reads from it; nothing downstream looks at the Job again. Copying
 // the MountConfigs slice header is enough, since it is only ever replaced
@@ -870,6 +894,37 @@ func (ws *jobWorkSpace) removeWorkSpaceEntries(wsRoot *os.Root) error {
 	}
 
 	return nil
+}
+
+// removeTmp removes the workspace's tmp entry through a handle on the workspace
+// itself, opened by the same proven descent cleanup uses and confirmed by inode
+// against what that descent saw, so no component of the path above tmp is
+// resolved from a string. The entry is named to that handle by its own name
+// alone, so nothing here can be redirected elsewhere.
+//
+// A workspace that has gone since it was proven leaves nothing to remove.
+func (ws *jobWorkSpace) removeTmp() error {
+	if ws.keep.wholeWorkSpace || ws.keptEntry(createdTmpName) {
+		return nil
+	}
+
+	chain, err := ws.proven.openChain()
+	if err != nil {
+		return err
+	}
+	defer chain.closeAll()
+
+	wsRoot, err := chain.openLeaf()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+	defer wsRoot.Close()
+
+	return wsRoot.RemoveAll(createdTmpName)
 }
 
 // removeActualCwd deletes the Job's working directory, keeping the given relative


### PR DESCRIPTION
`Client.Execute` reclaimed a job's TMPDIR with `os.RemoveAll(filepath.Clean(tmpDir))` — a path string. `tmpDir` is `<workSpace>/tmp`, and every component above `tmp` was re-resolved by the kernel at deletion time, inside the job's own working tree, which the job's `Cmd` can write to for its entire runtime. Replace a component with a symlink and the removal follows it out of the job's `Cwd`.

Found by an adversarial probe of develop after the `--cwd_matters` hardening landed. It is demonstrable, not theoretical: with a real `Cmd` doing

```
cd "$TMPDIR/../.."; leaf=$(basename "$(dirname "$TMPDIR")"); mv "$leaf" "$leaf.moved"; ln -s "$VICTIM" "$leaf"
```

the workspace resolution correctly refused to delete anything, and this `RemoveAll` deleted a file under `$VICTIM`, a directory outside the job's `Cwd` entirely.

The TMPDIR is now removed through the same proven descent as everything else: the workspace is proven by inode, an `os.Root` handle is held from that descent, and the `tmp` entry is removed through it by name, so nothing above it is resolved from a string.

Two related defects fixed with it:

* **Defer ordering.** The removal's `defer` was registered after `cleanupUnstartedWorkSpace`'s, so LIFO ran it first — defeating that function's documented "unmount first, and a failed unmount deletes nothing" invariant on the `addBsubEnv` and `setupDockerMonitor` return paths, where mounts are still live. It is now registered earlier so it runs last.
* **The keep set.** Ordering alone was not enough: when the unmount fails, `cleanupUnstartedWorkSpace` deletes nothing and returns, and the TMPDIR removal would still have run through the live mount. It now consults the same keep set cleanup uses, so a `MountConfig` whose mount point or cache resolves into `tmp` is left alone.

On severity, plainly: the job's `Cmd` runs as the submitting user and could delete those files directly, so this is not an escalation of privilege — it is wr being made the instrument, and a command that only ever writes inside its own working directory could still get wr's cleanup to recurse into a directory the job never named. The pre-start mount half is narrower but destroys remote data through a live mount, which no local permission bounds.

`make test` and `make race` both 417 passed / 9 skipped (+1 on this tree's baseline of 416); `make lint` 0 issues. Both guard mutations verified RED.

`.docs/bugfixes/260902-1.md` records the probe, the mechanism and the measurements.
