### PR TITLE
Fix cleanup deleting through a live mount named via a symlink

### DIFF
--- a/.docs/bugfixes/260902-2.md
+++ b/.docs/bugfixes/260902-2.md
@@ -1,0 +1,222 @@
+# Bugfixes 260902-2
+
+Branch `fix-mount-symlink-inside-workspace`: cleanup deleted the directory a
+live FUSE mount was physically in whenever the mount point was spelled through
+a symlink that was itself INSIDE the job's workspace.
+
+## Where this came from
+
+An adversarial probe of `keptDirs`, hunting for a spelling of
+`MountConfig.Mount` that the keep set records under a name the workspace sweep
+does not protect. It found one, and demonstrated it end to end through the real
+`Cleanup` behaviour.
+
+`jobqueue/workspace.go`'s classification helper answered LEXICALLY FIRST and
+only asked the filesystem when the two strings disagreed:
+
+```go
+func relBelowDirResolved(dir, path string) (string, bool) {
+	if rel, ok := relBelowDir(dir, path); ok {
+		return rel, true
+	}
+
+	return relBelowDir(resolvedDir(dir), resolvedDir(path))
+}
+```
+
+A mount point at `<workSpace>/link/x`, where `link` is a symlink to
+`<workSpace>/real`, is lexically inside the workspace: the lexical branch
+returned `rel = "link/x"` and nothing was ever resolved. `entryLeadingTo` cut
+that to the entry name `"link"`, so `keptDirs.workSpaceEntries` protected the
+SYMLINK while `real`, the directory the mount is physically in, was protected by
+nothing. `removeWorkSpaceEntries` then `wsRoot.RemoveAll("real")`, which reads
+through the live mount and destroys the user's REMOTE objects. The dangling
+`link` survived, being the thing the keep set kept.
+
+The probe's demonstration, before the fix:
+
+```
+workSpaceEntries=map[link:true] mountPoints=[.../346a.../link/x]
+cleanup deleted ".../346a.../real/x/remote.txt" (mount point ".../346a.../real/x")
+```
+
+Cleanup runs while the mount is live: `Execute` calls `job.TriggerBehaviours`
+(client.go, around line 2142) and only then `job.Unmount()` (around line 2149).
+
+## Why the earlier fix missed it
+
+The previous fix (`relBelowDirResolved`, `.docs/bugfixes/260828-3.md` and
+`260829-2.md`) was about a mount whose spelling and the workspace's spelling
+DISAGREE - an absolute `MountConfig.Mount` naming the real path while the Job's
+`Cwd` is a symlinked one, or the reverse. For those, the lexical comparison
+fails and the resolved one is what recognises the mount at all, so making the
+resolved answer the fallback was enough.
+
+A symlink INSIDE the dir being classified is the opposite shape: both spellings
+put the mount inside the workspace, so they AGREE about containment and disagree
+only about WHICH ENTRY leads to it. First-answer-wins therefore never consulted
+the filesystem, and the answer it kept was the one that names the link.
+`TestCleanupKeepsSymlinkSpelledMounts` covered only symlinks lexically OUTSIDE
+the workspace, which is exactly the case that fell through to the resolved
+comparison.
+
+## The fix
+
+Classification returns EVERY spelling that puts the path at or inside the dir,
+and every classification site consumes all of them.
+
+- [x] `relBelowDirResolved` becomes `relsBelowDirResolved`, returning
+  `[]string`: the lexical answer and the resolved one, deduplicated. One
+  mechanism, not a parallel one; `relBelowDir` (the purely lexical helper) is
+  untouched.
+- [x] `entryLeadingTo` becomes `entriesLeadingTo`, returning a name per
+  spelling, and `keptDirs.protect` sets `workSpaceEntries` for each. This is
+  the site the probe exploited: `real` is now kept alongside `link`.
+- [x] `keptDirs.protectInActualCwd` appends a rel per spelling to `inActualCwd`
+  (and sets `wholeActualCwd` if any spelling is "."). The same bug exists one
+  level down for a mount inside the working directory: `removeAllExcept` was
+  given `link/x` only, and `RemoveAll`ed `real`.
+- [x] `keptDirs.protectCaches` asks whether ANY spelling of the CacheBase is
+  the workspace itself before deciding `muxfysNamesWorkSpaceEntry`. A CacheBase
+  spelled `../wslink`, where `wslink` is a symlink to the workspace, is where
+  muxfys really writes its cache dirs, and those hold a writable mount's output
+  until `Unmount` uploads it.
+- [x] `dirIsAtOrAbove` (the `wholeWorkSpace` classification) is
+  `len(relsBelowDirResolved(...)) > 0`: the same truth value it had before,
+  since it only ever asked whether SOME spelling was below, and the union of
+  the two spellings was already what the old helper returned. It needed the
+  rename and nothing more.
+
+Widening only, by construction: every site now considers a SUPERSET of the
+answers it considered before, and each answer can only add to what is kept. The
+worst case is a workspace left behind, which the next cleanup of the same job
+finishes.
+
+`keptDirs()`'s `mountPoints` list deliberately still keeps the LEXICAL answer
+alone (`relBelowDir` at workspace.go:620). That list licenses an upward walk of
+EMPTY directories rather than protecting anything, and `rmEmptyDirsIn` needs a
+path with no symlink among its components. Widening it would widen what may be
+deleted, which is the opposite of this fix.
+
+Cost: `EvalSymlinks` is called only from `relsBelowDirResolved`, which is
+reached only from the keep-set classification of a mount point or a cache
+location. `keptDirs()` loops over `p.mountPoints()` and `p.mounts`, so a Job
+with no mounts still makes no filesystem call. Both answers are now computed
+where before the lexical one could short-circuit, which costs a couple of
+`EvalSymlinks` per configured mount per cleanup; knowing whether the two answers
+differ requires resolving them.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestCleanupKeepsSymlinkSpelledMounts
+
+The new cases live in the existing `TestCleanupKeepsSymlinkSpelledMounts`, so
+the two spellings - symlink inside the workspace, symlink outside it - are
+pinned in the one test and cannot drift apart again. Each case asserts that the
+directory the mount is physically in still exists WITH ITS CONTENTS after a real
+`Cleanup` trigger, and asserts the surviving paths before `So(err, ShouldBeNil)`
+so that `FailureHalts` reports the data loss rather than an error.
+
+Failing output before the fix:
+
+```
+  Given a Job whose mount point is spelled through a symlink inside its workspace
+    the dir a mount beside the working directory is really in is kept ✔✔✔✔✔✔✘
+    the dir a mount inside the working directory is really in is kept ✔✔✔✔✔✔✔✔✘
+    a cache base that resolves to the workspace is recognised, so muxfys' own dir survives ✔✔✔✔✔✔✔✔✘
+    and so is the same dir when the symlink to it is outside the workspace ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
+
+Failures:
+
+  * /home/ubuntu/wr_clone4/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsSymlinkSpelledMounts2299786096/004/jobqueue_cwd/8/a/a/346a67af978331ddeb6633d375d222532464590/real/x/remote.txt: no such file or directory'
+
+  * /home/ubuntu/wr_clone4/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsSymlinkSpelledMounts2299786096/005/jobqueue_cwd/7/7/7/4ed6b862de85a51e056e1b26881ab2289939706/cwd/real/x/remote.txt: no such file or directory'
+
+  * /home/ubuntu/wr_clone4/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsSymlinkSpelledMounts2299786096/006/jobqueue_cwd/8/2/f/47fa1f59ccb4a1c20d9cedaf26b6a3846603865/.muxfys_cache456/unuploaded.txt: no such file or directory'
+
+--- FAIL: TestCleanupKeepsSymlinkSpelledMounts (0.01s)
+```
+
+The mount's own directory and the file inside it are gone in all three
+inside-the-workspace cases; the lexically-outside case, which the earlier fix
+established, passes throughout. Green afterwards: `132 total assertions`,
+`--- PASS: TestCleanupKeepsSymlinkSpelledMounts (0.01s)`.
+
+## Mutation checks
+
+`go vet ./jobqueue/` was run after every edit below and reported clean each
+time, so no verdict here is a build failure masquerading as a dead guard.
+
+- [x] M1: `git checkout jobqueue/workspace.go`, the whole fix reverted. Vet OK.
+  **RED**, all three inside-the-workspace cases, with the output quoted above.
+- [x] M2: drop the resolved answer from `relsBelowDirResolved` (return the
+  lexical one alone). Vet OK. **RED**: all four cases of the new block, plus
+  `Expected: []string{"mnt"} Actual: []string(nil)` in both pre-existing
+  outside-the-workspace blocks. This is the mechanism, so everything depends on
+  it.
+- [x] M3: `keptDirs.protect` keeps only `entriesLeadingTo(...)[0]`. Vet OK.
+  **RED**, exactly the one case: "the dir a mount beside the working directory
+  is really in is kept" (`.../real/x/remote.txt: no such file or directory`).
+- [x] M4: `protectInActualCwd` keeps only the first rel. Vet OK. **RED**,
+  exactly the one case: "the dir a mount inside the working directory is really
+  in is kept" (`.../cwd/real/x/remote.txt: no such file or directory`).
+- [x] M5: `protectCaches` asks only the first spelling
+  (`rels[0] == "."`). Vet OK. **RED**, exactly the one case: the cache base
+  (`.../.muxfys_cache456/unuploaded.txt: no such file or directory`).
+- [x] M6, informational, on the site that needed no widening: make
+  `dirIsAtOrAbove` purely lexical. Vet OK. **RED** in the pre-existing
+  `jobqueue` tests, so that classification's resolved answer already has
+  coverage and this fix preserved its truth value.
+
+Every site touched has a case of its own; none is an unreachable guard. All
+mutations reverted, `jobqueue/workspace.go` byte-identical to the fixed tree,
+and green again.
+
+## Reachability caveat
+
+This is the same narrow window the earlier fix accepted, not a new severity.
+`MountConfig.Mount` is settled before the Job's key and therefore before the
+name of the workspace, so something has to create the symlink after
+`mkHashedDir` builds the workspace and before `Job.Mount` resolves the mount
+point - the job's own `Cmd` cannot, since it has not started yet. Nothing in wr
+creates such a link. The reason to fix it anyway is that the classification
+which LICENSES a `RemoveAll` must not depend on which of two spellings of one
+directory the user happened to type.
+
+## Files touched
+
+- `jobqueue/workspace.go`: `relBelowDirResolved` -> `relsBelowDirResolved`,
+  `entryLeadingTo` -> `entriesLeadingTo`, and the four consumers
+  (`keptDirs.protect`, `protectInActualCwd`, `protectCaches`,
+  `dirIsAtOrAbove`). No new type, no change to `keptDirs`' shape, no change to
+  the sweeps.
+- `jobqueue/workspace_test.go`: a fourth top-level `Convey` in
+  `TestCleanupKeepsSymlinkSpelledMounts`, holding the three
+  inside-the-workspace cases and the outside-the-workspace pin.
+
+`cleanorder -min-diff jobqueue/workspace.go` wants to move the unrelated
+`absenceRule` const block, and does so on the unmodified file too, so its
+reordering was not taken.
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `416 passed · 9 skipped · 29 packages · 3m48s`.
+- `make race`: `416 passed · 9 skipped · 29 packages · 4m42s`.
+- `make lint`: `0 issues.`
+
+The counts match the branch point's, as they must: the fix adds cases to an
+existing test function rather than a new one.

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -45,6 +45,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -697,7 +698,7 @@ func (k *keptDirs) protectCaches(p *workSpacePaths, mc MountConfig) {
 
 	k.protect(p, base)
 
-	if rel, ok := relBelowDirResolved(p.workSpace, base); ok && rel == "." {
+	if slices.Contains(relsBelowDirResolved(p.workSpace, base), ".") {
 		k.muxfysNamesWorkSpaceEntry = true
 	}
 
@@ -718,7 +719,7 @@ func (k *keptDirs) protectCaches(p *workSpacePaths, mc MountConfig) {
 func (k *keptDirs) protect(p *workSpacePaths, dir string) {
 	k.protectInActualCwd(p.actualCwd, dir)
 
-	if name, ok := entryLeadingTo(p.workSpace, dir); ok {
+	for _, name := range entriesLeadingTo(p.workSpace, dir) {
 		k.workSpaceEntries[name] = true
 	}
 }
@@ -731,18 +732,15 @@ func (k *keptDirs) protect(p *workSpacePaths, dir string) {
 // "." there is no way to delete the job's own output without deleting a cache
 // that has yet to be uploaded, so wr deletes neither.
 func (k *keptDirs) protectInActualCwd(actualCwd, dir string) {
-	rel, ok := relBelowDirResolved(actualCwd, dir)
-	if !ok {
-		return
+	for _, rel := range relsBelowDirResolved(actualCwd, dir) {
+		if rel == "." {
+			k.wholeActualCwd = true
+
+			continue
+		}
+
+		k.inActualCwd = append(k.inActualCwd, rel)
 	}
-
-	if rel == "." {
-		k.wholeActualCwd = true
-
-		return
-	}
-
-	k.inActualCwd = append(k.inActualCwd, rel)
 }
 
 // cleanup wipes out the Job's working directory and the workspace holding it, as
@@ -995,39 +993,51 @@ func relBelowDir(dir, path string) (string, bool) {
 	return rel, rel == "." || relIsBelow(rel)
 }
 
-// relBelowDirResolved is relBelowDir, asking the FILESYSTEM rather than the two
-// strings when the strings disagree: a mount at <symlink-to-Cwd>/<AppName>_cwd is
-// the same directory ".." names two levels down, and a lexical comparison
-// recognises only one of those two spellings.
+// relsBelowDirResolved is relBelowDir asking BOTH the two strings and the
+// FILESYSTEM: a mount at <symlink-to-Cwd>/<AppName>_cwd is the same directory
+// ".." names two levels down, and a lexical comparison recognises only one of
+// those two spellings.
+//
+// Every spelling that puts path at or inside dir is returned, not the first one
+// that does, because a symlink INSIDE dir makes the two agree LEXICALLY while
+// naming different entries of dir: a mount at <dir>/link/x, where link is a
+// symlink to <dir>/real, is lexically inside dir under a name that is the
+// symlink's rather than that of the directory the mount is physically in. A keep
+// set given only the lexical answer would protect the link and delete the mount.
 //
 // It is what the keep set classifies a mount point or cache location with, so
 // that every consumer of that set agrees about which directories are the Job's
-// live mounts, whichever spelling its MountConfig gave them.
+// live mounts, whichever spelling its MountConfig gave them. Each answer only
+// ever adds to what is kept, so a spelling that names something wr did not make
+// costs a workspace left behind rather than a deletion.
 //
-// The rel it returns is safe to name to a handle on the UNRESOLVED dir even when
-// it came from the resolved comparison: resolving a path does not change WHICH
-// DIRECTORY it names, so the components of the rel are entries of dir itself, and
-// EvalSymlinks leaves none of them a symlink. An absolute resolved path is not
-// safe that way - it is named in a different tree from the handles the deletions
-// are made through - which is why nothing here keeps one.
+// Each rel is safe to name to a handle on the UNRESOLVED dir, the resolved one
+// included: resolving a path does not change WHICH DIRECTORY it names, so the
+// components of the rel are entries of dir itself, and EvalSymlinks leaves none
+// of them a symlink. An absolute resolved path is not safe that way - it is
+// named in a different tree from the handles the deletions are made through -
+// which is why nothing here keeps one.
 //
-// The lexical comparison is made first, so the filesystem is only asked about a
-// mount or cache that was not already recognised, and never for a Job that
-// configured none.
-func relBelowDirResolved(dir, path string) (string, bool) {
+// The filesystem is asked about a mount point or cache location and nothing
+// else, so a Job that configured none pays no EvalSymlinks at all.
+func relsBelowDirResolved(dir, path string) []string {
+	var rels []string
+
 	if rel, ok := relBelowDir(dir, path); ok {
-		return rel, true
+		rels = append(rels, rel)
 	}
 
-	return relBelowDir(resolvedDir(dir), resolvedDir(path))
+	if rel, ok := relBelowDir(resolvedDir(dir), resolvedDir(path)); ok && !slices.Contains(rels, rel) {
+		rels = append(rels, rel)
+	}
+
+	return rels
 }
 
-// dirIsAtOrAbove reports whether dir is other, or a directory above it, in either
-// spelling; see relBelowDirResolved.
+// dirIsAtOrAbove reports whether dir is other, or a directory above it, in any
+// spelling; see relsBelowDirResolved.
 func dirIsAtOrAbove(dir, other string) bool {
-	_, ok := relBelowDirResolved(dir, other)
-
-	return ok
+	return len(relsBelowDirResolved(dir, other)) > 0
 }
 
 // resolvedDir is dir with the symlinks in it resolved, falling back to dir
@@ -1042,22 +1052,27 @@ func resolvedDir(dir string) string {
 	return resolved
 }
 
-// entryLeadingTo returns the name of the entry of dir that path is inside (path
-// itself, if it is a direct child). ok is false if path is not strictly inside
-// dir - dir itself, which relBelowDir reports as ".", included - or if either
-// path could not be made absolute.
+// entriesLeadingTo returns the name of the entry of dir that path is inside
+// (path itself, if it is a direct child), in each spelling that puts path
+// strictly inside dir. Nothing is returned for a path that is dir itself, which
+// relBelowDir reports as ".", or is not inside it at all.
 //
-// The containment is the resolved one, because this is what protects a mount
-// point from the workspace sweep and the sweep works entry by entry: an entry
-// leading to a live mount has the same NAME whichever way the mount point was
-// spelled, since both spellings name the one directory.
-func entryLeadingTo(dir, path string) (string, bool) {
-	rel, ok := relBelowDirResolved(dir, path)
-	if !ok || rel == "." {
-		return "", false
+// There is a name per spelling because this is what protects a mount point from
+// the workspace sweep and the sweep works entry by entry: a symlink inside dir
+// leading to another entry of dir gives the one mount point two names, and only
+// the resolved one names the directory the mount is physically in - the one a
+// RemoveAll would recurse into, through the live mount.
+func entriesLeadingTo(dir, path string) []string {
+	var names []string
+
+	for _, rel := range relsBelowDirResolved(dir, path) {
+		if rel == "." {
+			continue
+		}
+
+		name, _, _ := strings.Cut(rel, string(filepath.Separator))
+		names = append(names, name)
 	}
 
-	name, _, _ := strings.Cut(rel, string(filepath.Separator))
-
-	return name, true
+	return names
 }

--- a/jobqueue/workspace_test.go
+++ b/jobqueue/workspace_test.go
@@ -52,6 +52,10 @@ const (
 	testWSCmd        = "run"
 )
 
+// keyGrindMax bounds jobWithKeyPrefix's search, which is expected to take about
+// 16^len(prefix) tries.
+const keyGrindMax = 1 << 20
+
 // realWorkSpace gives job the working directory mkHashedDir really creates for it
 // below job.Cwd, and returns that dir, the workspace holding it, and the tmp dir
 // wr makes beside it. The path wr builds is what proves a workspace is wr's own,
@@ -525,6 +529,104 @@ func TestCleanupKeepsSymlinkSpelledMounts(t *testing.T) {
 		})
 	})
 
+	// the symlink can also be INSIDE the workspace, and then both spellings name
+	// something inside it: the classification agrees lexically and never asks the
+	// filesystem, so the name it records is the symlink's rather than that of the
+	// directory the mount is physically in - and the sweep deletes that directory,
+	// through the live mount, while leaving the link it kept dangling.
+	Convey("Given a Job whose mount point is spelled through a symlink inside its workspace", t, func() {
+		cwd := t.TempDir()
+		cleanup := &Behaviour{When: OnExit, Do: Cleanup}
+
+		Convey("the dir a mount beside the working directory is really in is kept", func() {
+			// a relative Mount is resolved against the working directory, so this
+			// names <workSpace>/link/x without needing the workspace's name.
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{Mount: "../link/x"}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			realDir := filepath.Join(workSpace, "real")
+			mount := filepath.Join(realDir, "x")
+			remote := writeFileIn(mount, "remote.txt")
+
+			So(os.Symlink(realDir, filepath.Join(workSpace, "link")), ShouldBeNil)
+
+			keep := jobKeptDirs(job)
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(remote, mount, realDir, workSpace, cwd)
+			soPathsGone(actualCwd, tmpDir)
+
+			So(keep.workSpaceEntries["real"], ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("the dir a mount inside the working directory is really in is kept", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{Mount: "link/x"}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			realDir := filepath.Join(actualCwd, "real")
+			mount := filepath.Join(realDir, "x")
+			remote := writeFileIn(mount, "remote.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+			So(os.Symlink(realDir, filepath.Join(actualCwd, "link")), ShouldBeNil)
+
+			keep := jobKeptDirs(job)
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(remote, mount, realDir, actualCwd, workSpace, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(keep.inActualCwd, ShouldContain, filepath.Join("real", "x"))
+			So(err, ShouldBeNil)
+		})
+
+		Convey("a cache base that resolves to the workspace is recognised, so muxfys' own dir survives", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{
+				Mount:     testWSMount,
+				CacheBase: "../wslink",
+				Targets:   []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}},
+			}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			So(os.Symlink(workSpace, filepath.Join(workSpace, "wslink")), ShouldBeNil)
+
+			cached := writeFileIn(filepath.Join(workSpace, muxfysCachePrefix+"_cache456"), "unuploaded.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+
+			keep := jobKeptDirs(job)
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(cached, workSpace, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(keep.muxfysNamesWorkSpaceEntry, ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("and so is the same dir when the symlink to it is outside the workspace", func() {
+			// the spelling the earlier fix established, pinned against the same
+			// fixture: here the two spellings disagree lexically, which is what
+			// makes the resolved comparison happen at all.
+			link := filepath.Join(cwd, "mount_link")
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{Mount: link}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			realDir := filepath.Join(workSpace, "real")
+			mount := filepath.Join(realDir, "x")
+			remote := writeFileIn(mount, "remote.txt")
+			So(os.Symlink(mount, link), ShouldBeNil)
+
+			keep := jobKeptDirs(job)
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(remote, mount, realDir, workSpace, cwd)
+			soPathsGone(actualCwd, tmpDir)
+
+			So(keep.workSpaceEntries["real"], ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+	})
+
 	// the same two spellings the other way round. Job.Cwd is stored exactly as
 	// the user typed it, because it feeds Job.Key(), so the symlinked spelling is
 	// the one wr is GIVEN rather than one it chose - and then it is the workspace
@@ -910,10 +1012,6 @@ func TestCleanupWorkSpaceReappearsAfterProof(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 }
-
-// keyGrindMax bounds jobWithKeyPrefix's search, which is expected to take about
-// 16^len(prefix) tries.
-const keyGrindMax = 1 << 20
 
 // jobWithKeyPrefix returns a Job whose Key() starts with prefix, found the way
 // an attacker would: Key() hashes the Cmd (and the mounts and image), all of


### PR DESCRIPTION
Cleanup could delete the directory a live FUSE mount sits in, recursing into it and destroying the user's remote data, when the mount was spelled through a symlink *inside* the job's workspace.

`relBelowDirResolved` returned its lexical answer first and consulted the filesystem only when the two spellings disagreed. A mount at `<workSpace>/link/x`, where `link` is a symlink to `<workSpace>/real`, agrees lexically — so `entryLeadingTo` cut it to `link` and the keep set protected the *symlink*, leaving `real`, the directory the mount is physically in, unprotected. `removeWorkSpaceEntries` then removed it through the live mount, leaving the dangling symlink behind.

This is the gap in #558's classification fix: `TestCleanupKeepsSymlinkSpelledMounts` only covered symlinks that are lexically *outside* the workspace, which is precisely the case that falls through to the resolved comparison.

Found by an adversarial probe, which also exposed the same defect one level down — a mount at `<actualCwd>/link/x` put only `link/x` in `inActualCwd`, so `removeAllExcept` deleted `real`; and a `CacheBase` spelled through a symlink to the workspace left `muxfysNamesWorkSpaceEntry` false, so muxfys' un-uploaded cache dirs were swept.

The classification now takes both spellings at every site that classifies a mount or a cache, so the directory a mount is really in is kept whatever the user typed. This widens the keep set only — every site consumes a superset of the answers it had, so the worst case is a leaked workspace, never a deletion. `keep.mountPoints` is deliberately left lexical, since that list licenses the empty-dir upward walk: widening it would widen deletion rather than protection. A job with no mounts still makes no `EvalSymlinks` call.

Reachability, stated plainly: something must create the symlink between `mkHashedDir` and `Job.Mount`, and the job's own `Cmd` has not started by then — so this needs a process racing the runner, the same window already accepted for #558's fix. Fixed regardless, because a classification that licenses deletion should not depend on which spelling the user happened to type.

`make test` and `make race` both 416 passed / 9 skipped (unchanged — the fix extends an existing test rather than adding one); `make lint` 0 issues. Six guard mutations verified, five of them RED on exactly one case each, so no site is an unreachable guard.

`.docs/bugfixes/260902-2.md` has the mechanism, the measurements and the caveat.
