### PR TITLE
Fix cleanup deleting a mount cache that resolves to the workspace

### DIFF
--- a/.docs/bugfixes/260902-3.md
+++ b/.docs/bugfixes/260902-3.md
@@ -1,0 +1,401 @@
+# Bugfixes 260902-3
+
+Branch `fix-cache-dir-at-workspace`: cleanup deleted a writable mount's cache,
+and with it the job's own un-uploaded output, whenever
+`MountTarget.CacheDir` resolved to the job's workspace root - which `"."`, and
+every spelling that normalises to it, does.
+
+## Where this came from
+
+An adversarial probe of `keptDirs`, hunting for a cache location the keep set
+records nothing about. `TestProbeCacheDirAtWorkSpace` drove the production
+entry point - `job.TriggerBehaviours(true)` on a Job with an `OnSuccess`
+`Cleanup` behaviour - for `CacheDir` values `"."`, `"./"`, `"sub/.."` and
+`"a/b/../.."`, and every one of them lost the file placed inside the cache.
+
+A second, independent probe - a mount-shape matrix run against a live manager -
+reached the same gap from another angle and added a spelling the first had not
+tried: a `CacheDir` that reaches the workspace THROUGH A SYMLINK, eg. `"link"`
+where `<workSpace>/link` is a symlink to the workspace. That one is lexically an
+ENTRY of the workspace, so it is only recognisable once the filesystem is
+asked.
+
+## The mechanism
+
+`MountTarget.CacheDir` is resolved by `resolveCacheDir` (jobqueue/job.go)
+against the DEFAULT cache base, which for an ordinary job is the workspace,
+`filepath.Dir(actualCwd)`. A `CacheDir` of `"."` therefore puts muxfys's cache
+on the workspace root itself, beside the working directory and TMPDIR.
+
+`keptDirs.protectCaches` then recorded nothing whatsoever for it. Measured on
+the branch point, for `CacheDir: "."`:
+
+```
+workSpace    = /tmp/.../001/jobqueue_cwd/5/3/4/4bfc7006fb8de69e361b43a2a50802883436842
+muxfys cache = /tmp/.../001/jobqueue_cwd/5/3/4/4bfc7006fb8de69e361b43a2a50802883436842
+keep = wholeActualCwd:false inActualCwd:[mnt] workSpaceEntries:map[cwd:true] \
+       wholeWorkSpace:false muxfysNames:true
+Rel(actualCwd, workSpace) = ".."
+entriesLeadingTo(workSpace, workSpace) = []
+relsBelowDirResolved(workSpace, cache) = [.]
+```
+
+Each of the three things the keep set can say declines to say anything:
+
+- `protectInActualCwd` gets `Rel(actualCwd, workSpace) == ".."`, so the cache is
+  not at or below the working directory and nothing goes into `inActualCwd` or
+  `wholeActualCwd`. (`inActualCwd:[mnt]` above is the mount point, not the
+  cache.)
+- `entriesLeadingTo(workSpace, workSpace)` yields `"."`, which that helper
+  skips by design, so there is no `workSpaceEntries` entry for the cache.
+  (`workSpaceEntries:map[cwd:true]` is the working directory, kept because the
+  mount point is inside it.)
+- `muxfysNamesWorkSpaceEntry` is set only when the CACHE BASE resolves to the
+  workspace, and it protects names with the `.muxfys` prefix. An explicitly
+  named `CacheDir` has no such prefix to match, and what muxfys writes INTO
+  that cache is named after the remote, not after muxfys.
+
+So `removeWorkSpaceEntries` swept every entry of the workspace except `cwd`,
+taking the cache with it.
+
+A writable muxfys mount only uploads at `Unmount` (its `uploadCreated`,
+muxfys.go:518, is called from `Unmount`, muxfys.go:455), so any cleanup that
+sweeps such a cache BEFORE the unmount destroys the job's own output before it
+ever reaches S3.
+
+## When that costs output
+
+Two exposures, of different severity.
+
+The runner's own path: `Client.Execute` calls `job.TriggerBehaviours`
+(client.go:2164) and only then `job.Unmount()` (client.go:2171) - the comment
+there ("try and unmount now, because if we fail to upload files, we'll have to
+start over") sits AFTER the behaviours. The `Started`-failure path is the same
+order (`TriggerBehaviours` at client.go:1847, `unmountExtra` at 1848). A
+`Cleanup` behaviour is not deferred either: `Behaviour.trigger` calls
+`snap.cleanupWorkSpace()` synchronously (behaviours.go:188, 293). So on the code
+as it stands the runner sweeps the cache while its own mount is live, `Unmount`
+then reports a failed upload, and client.go:2173 turns that into `dorelease`, so
+the re-run produces the output and loses it again. I was told during this task
+that the runner unmounts before its behaviours; I measured the opposite and the
+line numbers above are what I measured, so this is recorded as a disagreement
+rather than settled.
+
+The manager's path is exposed regardless of that ordering: the lost-job cleanup
+sweeps the workspace from the manager while the runner may still be alive with a
+live writable mount, so the deletion lands with no unmount of any kind in
+between.
+
+Either way this is a hole in an invariant `keptDirs` states about itself - mount
+points and caches "are kept unconditionally, so a caller may clean up on either
+side of Job.Unmount" - and a keep set that licenses a `RemoveAll` may not depend
+on a caller's ordering for its safety.
+
+## Why the configuration is plausible
+
+`MountTarget.CacheDir` is documented as "the local directory to store cached
+data... If it's a relative path, it will be relative to the CacheBase", and the
+whole point of naming one rather than leaving it to muxfys is to get a cache at
+a place of your own choosing - typically one you can inspect, or one on the
+right filesystem. `"."` is the ordinary way to spell "here" for a user who
+believes, from that doc, that "here" means the CacheBase they configured. It
+needs no adversarial intent, no symlink and no race: one dot in a mount config,
+plus the `cleanup` behaviour `wr add` offers, and the job's output is deleted
+between the command finishing and the upload starting.
+
+## The fix
+
+`keptDirs.protectCaches` now sets `wholeWorkSpace` when any spelling of a
+resolved `CacheDir` IS the workspace:
+
+```go
+	for _, mt := range mc.Targets {
+		cacheDir := resolveCacheDir(mt.CacheDir, p.workSpace)
+		if cacheDir == "" {
+			continue
+		}
+
+		cacheDir = filepath.Clean(cacheDir)
+
+		if slices.Contains(relsBelowDirResolved(p.workSpace, cacheDir), ".") {
+			k.wholeWorkSpace = true
+		}
+
+		k.protect(p, cacheDir)
+	}
+```
+
+### Why keeping the WHOLE workspace, and not something narrower
+
+A `CacheBase` at the workspace root can be handled precisely, because muxfys
+chooses the name of the cache dir it creates inside a CacheBase and that name
+begins with `.muxfys` (its remote.go), so `muxfysNamesWorkSpaceEntry` plus a
+prefix match names exactly what must survive.
+
+A `CacheDir` at the workspace root cannot: the `CacheDir` IS the cache, and its
+entries are named by muxfys's accessor. For S3 that is
+`filepath.Join(baseDir, host, bucket, remotePath)` (muxfys `s3.go`
+`LocalPath`), so the top-level entries are the S3 ENDPOINT HOST the Target's
+`Profile` resolves to at mount time, under which sit the bucket and the object
+path. wr cannot enumerate those in advance from the Job's own configuration -
+the host comes from the environment and profile files that
+`muxfys.S3ConfigFromEnvironment` reads inside the runner - and there is no fixed
+prefix to match. Any entry of the workspace might be the unuploaded output of a
+writable mount.
+
+So the only honest account of such a workspace is that all of it may be cache.
+`wholeWorkSpace` already means exactly that, is already honoured by both
+consumers (`cleanup` returns immediately, `removeTmp` declines), and needed no
+new field or type. The cost is a workspace and a TMPDIR left behind for a job
+that asked for its cache to be the workspace root; the alternative cost is
+deleting output that has not been uploaded. Recoverable beats unrecoverable.
+
+### Why `wholeWorkSpace` rather than a new cache-only flag
+
+The alternative offered was a new `wholeWorkSpaceCache` field set beside
+`muxfysNamesWorkSpaceEntry` and honoured by `removeWorkSpaceEntries`. It would
+fix the reported case, and it keeps less, but it makes the keep set say two
+subtly different things about one situation: `removeWorkSpaceEntries` would keep
+every entry while `empty()` still emptied the working directory through
+`removeActualCwd`, and `removeTmp` - which asks `ws.keptEntry(createdTmpName)`,
+not that new field - would still delete TMPDIR. The two consumers would then
+disagree about whether this workspace is deletable, which is the exact shape of
+the two bugs this file has already had (a classification understood at one site
+and not at its siblings). `wholeWorkSpace` is one flag, already meaning "nothing
+wr made here may be deleted", already consulted by both consumers, and needs no
+new field in `keptDirs`.
+
+### The symlink spelling comes free, by design
+
+The check is `slices.Contains(relsBelowDirResolved(p.workSpace, cacheDir), ".")`
+- ANY spelling, not the lexical one. `relsBelowDirResolved` returns both the
+lexical answer and the `EvalSymlinks`-resolved one (the mechanism from
+`.docs/bugfixes/260902-2.md`), so a `CacheDir` of `"link"` pointing at the
+workspace answers `["link", "."]` and is recognised. A lexical-only test passes
+the `"."` cases and loses the symlink one; mutation M5 below pins that.
+
+### Widening only
+
+The change adds one assignment of `true` to a keep-set field and removes
+nothing. `protect` is still called for exactly the same locations as before, so
+every entry, rel and flag recorded before is still recorded. No input can
+produce a smaller keep set than it did on the branch point.
+
+### Every classification site, not just the one the probe tripped
+
+A location can be the workspace root by three routes, and each now has an
+answer:
+
+| location | at the workspace root | mechanism |
+| --- | --- | --- |
+| `MountConfig.Mount` | mount is the workspace or above it | `wholeWorkSpace` (`dirIsAtOrAbove` in `keptDirs()`, pre-existing) |
+| `MountConfig.CacheBase` | muxfys creates `.muxfys*` inside it | `muxfysNamesWorkSpaceEntry` (pre-existing) |
+| `MountTarget.CacheDir` | the cache itself, entries named by the remote | `wholeWorkSpace` (this fix) |
+
+The working-directory analogues all already funnel through
+`protectInActualCwd`, whose `rel == "."` branch sets `wholeActualCwd` for a
+mount point, a CacheBase and a CacheDir alike. The sibling audit is recorded as
+mutations M2-M4 below: each of those three pre-existing branches is live and
+covered by a test of its own.
+
+`EvalSymlinks` stays off the path of a job with no mounts: the new
+`relsBelowDirResolved` call is inside `protectCaches`, which `keptDirs()` calls
+once per `MountConfig`, so a job with none makes no filesystem call it did not
+make before.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestCleanupKeepsCacheAtWorkSpace
+
+The new `TestCleanupKeepsCacheAtWorkSpace` in `jobqueue/workspace_test.go`
+drives `job.TriggerBehaviours(true)` on a Job with an `OnSuccess` `Cleanup`
+behaviour and a writable, cached mount, and asserts that a file inside the
+cache survives - the surviving paths asserted BEFORE `So(err, ShouldBeNil)`, so
+`FailureHalts` reports the data loss rather than an error. The cached file is
+placed at `<cache>/s3.example.com/mybucket/unuploaded.txt`, the shape muxfys's
+`LocalPath` really writes. Four spellings are covered: `"."`, `"./"`,
+`"sub/.."`, and `"link"` where `<workSpace>/link` is a symlink to the workspace
+(that case writes THROUGH the link, as muxfys would, and asserts the physical
+path).
+
+Failing output before the fix:
+
+```
+=== RUN   TestCleanupKeepsCacheAtWorkSpace
+
+  Given a Job with a cleanup Behaviour whose mount cache lands on the workspace
+    A CacheDir of "." survives, since it is the workspace itself ✔✔✔✘
+    So does one spelled "./" ✔✔✔✘
+    So does one spelled "sub/.." ✔✔✔✘
+    So does one that reaches the workspace through a symlink ✔✔✔✔✘
+    A CacheDir below the workspace is kept while the rest is still swept ✔✔✔✔✔✔✔✔✔✔
+    A Job that mounts nothing still has its whole workspace swept ✔✔✔✔✔✔✔✔✔
+
+
+Failures:
+
+  * /home/ubuntu/wr_fix1/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsCacheAtWorkSpace3524023473/001/jobqueue_cwd/8/2/f/47fa1f59ccb4a1c20d9cedaf26b6a619320760/s3.example.com/mybucket/unuploaded.txt: no such file or directory'
+
+  * /home/ubuntu/wr_fix1/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsCacheAtWorkSpace3524023473/002/jobqueue_cwd/8/2/f/47fa1f59ccb4a1c20d9cedaf26b6a3785376594/s3.example.com/mybucket/unuploaded.txt: no such file or directory'
+
+  * /home/ubuntu/wr_fix1/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsCacheAtWorkSpace3524023473/003/jobqueue_cwd/8/2/f/47fa1f59ccb4a1c20d9cedaf26b6a2010686490/s3.example.com/mybucket/unuploaded.txt: no such file or directory'
+
+  * /home/ubuntu/wr_fix1/jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestCleanupKeepsCacheAtWorkSpace3524023473/004/jobqueue_cwd/8/2/f/47fa1f59ccb4a1c20d9cedaf26b6a1818046121/s3.example.com/mybucket/unuploaded.txt: no such file or directory'
+
+
+36 total assertions
+
+--- FAIL: TestCleanupKeepsCacheAtWorkSpace (0.01s)
+```
+
+Green afterwards: `45 total assertions`,
+`--- PASS: TestCleanupKeepsCacheAtWorkSpace (0.01s)`.
+
+The last two cases are the guards against a fix that simply stops deleting:
+an ordinary `CacheDir: "mycache"` below the workspace is kept while the working
+directory's output and TMPDIR still go, and a Job with no mounts still has its
+working directory, TMPDIR and workspace swept. Both pass before AND after, as
+they must.
+
+## Mutation checks
+
+`go vet ./jobqueue/` was run after every edit below and reported clean each
+time, so no verdict here is a build failure masquerading as a dead guard.
+
+- [x] M1: the fix reverted (the `slices.Contains(... ".")` guard removed,
+  leaving `k.protect(p, cacheDir)`). Vet OK. **RED**: all four workspace-root
+  cases, with the output quoted above. The two control cases stay green.
+- [x] M2: the new site's sibling for a CacheBase - `muxfysNamesWorkSpaceEntry`
+  made unreachable (`relsBelowDirResolved(...)` compared against `"MUTANT"`).
+  Vet OK. **RED**: `TestCleanupKeepsMountCaches` ("The default cache dir muxfys
+  names for itself in the workspace survives", `.muxfys_cache456/unuploaded.txt:
+  no such file or directory`) and `TestCleanupKeepsSymlinkSpelledMounts`.
+- [x] M3: the mount-point route to `wholeWorkSpace` neutered
+  (`dirIsAtOrAbove(mount, p.workSpace) && false`). Vet OK. **RED**:
+  `TestBehaviourCleanupSafety` (the `Mount: ".."` case, `.../cwd/out.txt: no
+  such file or directory`).
+- [x] M4: the working-directory analogue neutered (`protectInActualCwd`'s
+  `rel == "."` compared against `"MUTANT"`). Vet OK. **RED**:
+  `TestBehaviourCleanupSafety` and `TestCleanupKeepsMountCaches`.
+- [x] M5: the RESOLVED half of the new check dropped - the guard made purely
+  lexical, `if rel, ok := relBelowDir(p.workSpace, cacheDir); ok && rel == "."`.
+  Vet OK. **RED on exactly one case**, the symlink spelling
+  (`.../004/.../s3.example.com/mybucket/unuploaded.txt: no such file or
+  directory`, `42 total assertions`); `"."`, `"./"` and `"sub/.."` stay green.
+  So both halves of the answer are load-bearing, and the symlink case is not
+  passing for the same reason the lexical ones are.
+
+Every classification of a location that IS one of the two directories cleanup
+sweeps has a failing case of its own, so the new guard is not unreachable and
+none of its siblings is dead. All mutations reverted,
+`jobqueue/workspace.go` restored, and green again.
+
+## Out of scope: `MountConfig.CacheBase` is ignored when resolving a relative `CacheDir`
+
+Reported, not changed. Fixing it moves where existing users' caches are
+written, which is the repo owner's call.
+
+What the contract says, in two places:
+
+- `jobqueue/mount.go`, `MountTarget.CacheDir`: "If it's a relative path, it
+  will be relative to the CacheBase."
+- `jobqueue/job.go`, `Job.Mount`: "Relative CacheDir options are treated
+  relative to the CacheBase."
+
+What the code does: `mountConfig` resolves the muxfys `Config.CacheBase` with
+`resolveCacheBase(mc.CacheBase, cwd, defaultCacheBase)`, but
+`buildRemoteConfigs` resolves each target with
+`ms.resolveCacheDir(mt.CacheDir, defaultCacheBase)` - the DEFAULT base, never
+the configured one. `mc.CacheBase` is not passed to it at all.
+
+Measured on the branch point, with `CacheBase: "/scratch/mine"` and
+`CacheDir: "."`:
+
+```
+CacheBase resolves to  = /scratch/mine
+CacheDir  resolves to  = /tmp/.../001/jobqueue_cwd/b/9/6/e0a021d33c1de7036490caebd90041844146087
+workSpace              = /tmp/.../001/jobqueue_cwd/b/9/6/e0a021d33c1de7036490caebd90041844146087
+```
+
+The CacheDir landed in the workspace, ignoring the CacheBase entirely.
+
+Would fixing it have prevented this data loss? Partly, and only for some
+configurations. Honouring the contract would move a relative `CacheDir` under
+whatever `CacheBase` was configured, so `CacheDir: "."` with
+`CacheBase: "/scratch/mine"` would land outside the workspace and cleanup would
+never see it. But a relative `CacheDir` with NO `CacheBase` set - the case the
+probe used, and the likelier one - resolves against the DEFAULT CacheBase,
+which for an ordinary job IS the workspace: `mountBaseDirs` returns
+`filepath.Dir(actualCwd)`. `CacheDir: "."` would still be the workspace root
+and the deletion would still happen. The resolution defect and this keep-set
+gap are independent, and the keep set has to hold either way.
+
+## Files touched
+
+- `jobqueue/workspace.go`: `keptDirs.protectCaches` sets `wholeWorkSpace` for a
+  CacheDir that is the workspace, plus the doc comments on it and on
+  `keptDirs.wholeWorkSpace`. No new type, no change to `keptDirs`' shape, no
+  change to the sweeps.
+- `jobqueue/workspace_test.go`: `TestCleanupKeepsCacheAtWorkSpace`, beside the
+  existing `TestCleanupKeepsMountCaches`.
+
+`cleanorder -min-diff jobqueue/workspace.go` moves the unrelated `absenceRule`
+const block to the top of the file, and does so on the unmodified file too, so
+its reordering was not taken (as in `.docs/bugfixes/260902-2.md`).
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `420 passed · 9 skipped · 29 packages · 4m43s`, PASSED.
+- `make race`: `420 passed · 9 skipped · 29 packages · 4m54s`, PASSED.
+- `make lint`: see below.
+
+Baseline, measured on this branch point (`52325db7`) with the two files
+reverted: `make test` gave `419 passed · 9 skipped · 29 packages · 3m43s`. The
+one extra test is `TestCleanupKeepsCacheAtWorkSpace`.
+
+`make lint` in this clone fails for an environmental reason, identically with
+and without this change. `.golangci.yml` sets `issues.new-from-rev: master`,
+and this clone has no local `master` ref (only `origin/master`), so the diff
+processor errors - `could not read git repo: ... fatal: bad revision 'master'` -
+and every pre-existing issue in the repo is reported instead of none:
+
+```
+29 issues:
+* funlen: 9
+* gocognit: 2
+* gocritic: 1
+* gocyclo: 3
+* govet: 3
+* nestif: 4
+* staticcheck: 2
+* unparam: 1
+* wsl_v5: 4
+```
+
+The same 29, linter for linter, on the pristine tree with
+`jobqueue/workspace.go` and `jobqueue/workspace_test.go` reverted, and none of
+them is in either file. The gate as intended -
+`golangci-lint run --new-from-rev origin/master` - reports `0 issues.`
+
+The first `make lint` attempt reported a different, larger set whose paths were
+all `../wr_clone2/...`, a sibling clone that no longer exists: golangci-lint was
+serving cached issues keyed to identical package content from that deleted
+directory. `golangci-lint cache clean` was needed before any lint result from
+this tree could be believed.

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -612,6 +612,10 @@ type keptDirs struct {
 	//
 	// protect() can record nothing about such a mount point, since both halves of
 	// it describe something INSIDE the workspace.
+	//
+	// It is also set by a MountTarget.CacheDir that IS the workspace, where the
+	// workspace root holds a writable mount's un-uploaded output under names only
+	// the remote knows; see protectCaches.
 	wholeWorkSpace bool
 
 	// muxfysNamesWorkSpaceEntry is set when one of the Job's mounts has a
@@ -690,6 +694,18 @@ func (p *workSpacePaths) mountPoints() []string {
 // workspace, so the muxfysCachePrefix rule is what covers the directory muxfys
 // puts there, and this is where wr learns that rule has something to cover.
 //
+// A CacheDir that resolves to the workspace itself, in ANY spelling - "." or a
+// symlink inside the workspace that leads back to it - classifies as neither of
+// those things EITHER, and the muxfysCachePrefix rule cannot cover it: that rule
+// recognises the dir muxfys names inside a CacheBase, whereas a CacheDir IS the
+// cache, and what muxfys writes into it is named after the remote - an S3 target
+// caches at <CacheDir>/<host>/<bucket>/<path> (its s3.go LocalPath), so the
+// entries holding a writable mount's un-uploaded output are named by the bucket
+// and by the endpoint the Target's Profile resolves to at mount time. wr cannot
+// enumerate or prefix-match those in advance, so the only account it can give of
+// such a cache is to keep the whole workspace; a workspace left behind is
+// recoverable, output deleted before Unmount uploaded it is not.
+//
 // A cache location ABOVE the workspace needs recording nowhere: cleanup only
 // deletes inside the workspace, and the only thing that goes higher is the
 // upward walk of EMPTY parents, which a directory holding a cache stops.
@@ -703,9 +719,18 @@ func (k *keptDirs) protectCaches(p *workSpacePaths, mc MountConfig) {
 	}
 
 	for _, mt := range mc.Targets {
-		if cacheDir := resolveCacheDir(mt.CacheDir, p.workSpace); cacheDir != "" {
-			k.protect(p, filepath.Clean(cacheDir))
+		cacheDir := resolveCacheDir(mt.CacheDir, p.workSpace)
+		if cacheDir == "" {
+			continue
 		}
+
+		cacheDir = filepath.Clean(cacheDir)
+
+		if slices.Contains(relsBelowDirResolved(p.workSpace, cacheDir), ".") {
+			k.wholeWorkSpace = true
+		}
+
+		k.protect(p, cacheDir)
 	}
 }
 

--- a/jobqueue/workspace_test.go
+++ b/jobqueue/workspace_test.go
@@ -427,6 +427,116 @@ func TestCleanupKeepsMountCaches(t *testing.T) {
 	})
 }
 
+func TestCleanupKeepsCacheAtWorkSpace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// a MountTarget.CacheDir is resolved against the workspace (job.go's
+	// resolveCacheDir), so "." - or any spelling that reaches it, lexically or
+	// through a symlink - puts muxfys's cache on the workspace root itself,
+	// beside the working directory and tmp. A writable cached mount only uploads
+	// at Unmount, so a cleanup that sweeps such a cache destroys the job's own
+	// output before it ever reaches S3: Client.Execute triggers the behaviours
+	// (client.go) before it unmounts, and the manager's lost-job cleanup sweeps
+	// while the runner may still be alive with the mount live.
+	Convey("Given a Job with a cleanup Behaviour whose mount cache lands on the workspace", t, func() {
+		cwd := t.TempDir()
+
+		cachingJob := func(cacheDir string) *Job {
+			return &Job{Cwd: cwd, Cmd: testWSCmd, MountConfigs: MountConfigs{{
+				Mount: testWSMount,
+				Targets: []MountTarget{{
+					Path: testWSTargetPath, Cache: true, Write: true, CacheDir: cacheDir,
+				}},
+			}}, Behaviours: Behaviours{{When: OnSuccess, Do: Cleanup}}}
+		}
+
+		// muxfys caches an S3 target's data at <CacheDir>/<host>/<bucket>/<path>
+		// (its s3.go LocalPath), so the entries of a cache sitting on the
+		// workspace root are named after the remote and the endpoint the
+		// profile resolves to, not after anything wr can predict.
+		soCacheSurvivesCleanup := func(job *Job) {
+			_, workSpace, _ := realWorkSpace(job)
+
+			cached := writeFileIn(filepath.Join(workSpace, "s3.example.com", "mybucket"),
+				"unuploaded.txt")
+
+			err := job.TriggerBehaviours(true)
+
+			soPathsExist(cached, cwd)
+
+			So(err, ShouldBeNil)
+		}
+
+		Convey("A CacheDir of \".\" survives, since it is the workspace itself", func() {
+			soCacheSurvivesCleanup(cachingJob("."))
+		})
+
+		Convey("So does one spelled \"./\"", func() {
+			soCacheSurvivesCleanup(cachingJob("./"))
+		})
+
+		Convey("So does one spelled \"sub/..\"", func() {
+			soCacheSurvivesCleanup(cachingJob("sub/.."))
+		})
+
+		Convey("So does one that reaches the workspace through a symlink", func() {
+			// the classification has to ask the FILESYSTEM as well as the
+			// strings: "link" is lexically an ENTRY of the workspace, so a
+			// purely lexical answer keeps the symlink and sweeps the directory
+			// the cache is physically in - which is the workspace itself.
+			job := cachingJob("link")
+			_, workSpace, _ := realWorkSpace(job)
+
+			So(os.Symlink(workSpace, filepath.Join(workSpace, "link")), ShouldBeNil)
+
+			cached := writeFileIn(filepath.Join(workSpace, "link", "s3.example.com", "mybucket"),
+				"unuploaded.txt")
+			physical := filepath.Join(workSpace, "s3.example.com", "mybucket", "unuploaded.txt")
+
+			err := job.TriggerBehaviours(true)
+
+			soPathsExist(physical, cached, cwd)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("A CacheDir below the workspace is kept while the rest is still swept", func() {
+			// the keep set may only widen, but not to the point of keeping
+			// everything: an ordinary cache dir is named, so cleanup knows
+			// exactly which entry to leave and deletes the others.
+			job := cachingJob("mycache")
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			cached := writeFileIn(filepath.Join(workSpace, "mycache"), "unuploaded.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+
+			err := job.TriggerBehaviours(true)
+
+			soPathsExist(cached, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("A Job that mounts nothing still has its whole workspace swept", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd,
+				Behaviours: Behaviours{{When: OnSuccess, Do: Cleanup}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			output := writeFileIn(actualCwd, "out.txt")
+
+			err := job.TriggerBehaviours(true)
+
+			soPathsGone(output, actualCwd, tmpDir, workSpace)
+			soPathsExist(cwd)
+
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 // jobKeptDirs is the keep set the real resolution classifies for job: everything
 // cleanup must leave alone inside the workspace wr made for it. It is asked of
 // the production resolution, so a test can pin the classification itself rather


### PR DESCRIPTION
Cleanup deletes a writable mount's un-uploaded cache when a `MountTarget.CacheDir` resolves to the workspace directory itself, so the job's output is destroyed before it is ever uploaded.

`resolveCacheDir` resolves a relative `CacheDir` against the default cache base, which for an ordinary job is the workspace (`filepath.Dir(actualCwd)`). A `CacheDir` of `"."` — or `"./"`, `"sub/.."`, or a relative name that is a symlink to the workspace — therefore puts muxfys's cache on the workspace root.

`keptDirs.protectCaches` then recorded nothing for it: `protectInActualCwd` sees `Rel(actualCwd, workSpace) == ".."` and stops, `entriesLeadingTo` returns nothing for a rel of `"."`, `wholeWorkSpace` is set from mount points only, and `muxfysNamesWorkSpaceEntry` is set from the *CacheBase* only — and its `.muxfys*` prefix rule cannot help here anyway, because with an explicit `CacheDir` muxfys names its top-level cache entries after the remote's own endpoint host and bucket, which are resolved at mount time and are not derivable from the job's configuration. `removeWorkSpaceEntries` swept them.

`Client.Execute` triggers behaviours at client.go:2164 and unmounts at client.go:2171, and a writable muxfys mount only uploads at `Unmount` — so the cleanup runs first and the output never reaches the remote. `uploadCreated` then reports a failed upload, the job is released, and the re-run loses its output again.

The keep set now treats a cache location that *is* the workspace the way it already treats a mount at or above it: nothing wr made there may be deleted. `wholeWorkSpace` is reused rather than adding a cache-only flag, because a flag read only by `removeWorkSpaceEntries` would leave `empty()` still emptying the working directory and `removeTmp` still taking the TMPDIR — two consumers disagreeing about one workspace, which is the exact shape of this file's two previous bugs. The check asks whether ANY spelling `relsBelowDirResolved` returns is `"."`, so the symlink route is covered; a mountless job still makes no filesystem call.

Found by two independent adversarial probes of develop, which reached it from opposite directions — a static audit of `protectCaches`, and a 16-shape mount matrix driven through a live manager.

`make test` and `make race` both 420 passed / 9 skipped (+1 on develop's 419); `make lint` 0 issues. Five guard mutations verified, including one proving both the lexical and the resolved half of the spelling check are load-bearing.

Not changed, and worth a separate decision: `MountConfig.CacheBase` is ignored when resolving a relative `CacheDir`, contradicting its documented contract in both jobqueue/mount.go and jobqueue/job.go. Fixing that would move where existing users' caches are written, and it would not have prevented this loss on its own — with no `CacheBase` set, a relative `CacheDir` still resolves against the workspace. `.docs/bugfixes/260902-3.md` has the measurements.
