### PR TITLE
Fix an upload to a named path corrupting the file it replaces

### DIFF
--- a/.docs/bugfixes/260902-5.md
+++ b/.docs/bugfixes/260902-5.md
@@ -1,0 +1,191 @@
+# Bugfixes 260902-5
+
+Branch `fix-upload-truncate`: an upload to a caller-named destination that
+already held a LONGER file left the tail of the old content in place, so the
+destination became a hybrid of the two files rather than a copy of the uploaded
+one.
+
+## Where this came from
+
+An adversarial probe of the upload path, hunting for a destination whose old
+content could survive a write. Uploading `"short\n"` over a 41-byte file left:
+
+```text
+short
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+
+35 bytes of the previous file survived, and the returned path claimed success.
+
+## The mechanism
+
+`Server.openUploadDestination` (jobqueue/server.go) opened a caller-named
+destination with:
+
+```go
+file, err := os.OpenFile(savePath, os.O_RDWR|os.O_CREATE, ownerReadWrite)
+```
+
+`os.O_TRUNC` was absent, and `Server.uploadFile` is a single
+`io.Copy(file, source)` from offset zero. Writing N bytes over an existing file
+of M bytes therefore replaced only the first N and left bytes N..M untouched.
+`io.Copy` reports the N bytes it wrote, so nothing in the call path could
+notice. That hybrid file is what then gets shipped to spawned cloud servers.
+
+Verified before changing anything:
+
+- One place opens the named destination, jobqueue/server.go:3661. The only
+  other `O_CREATE` opens in the tree are unrelated (`internal/cert.go`,
+  `internal/config.go`, `clog/clog.go`, `jobqueue/utils.go`,
+  `cloud/cloud.go`, `cloud/server.go`), and all of them that write a whole
+  file already carry `O_TRUNC` or `O_APPEND`.
+- `io.Copy` is the writer, at jobqueue/server.go:3622, with no `Seek` or
+  `Truncate` anywhere between the open and the close.
+
+## Who is exposed
+
+Anyone who names the destination:
+
+- `Client.UploadFile(local, remote)` with a non-empty `remote`
+  (jobqueue/client.go) -> `handleUpload` (jobqueue/serverCLI.go:598) ->
+  `uploadFile(ctx, ..., cr.Path)`.
+- `PUT /rest/v1/upload?path=...` -> `restFileUpload`
+  (jobqueue/serverREST.go:1974) ->
+  `uploadFile(ctx, r.Body, r.Form.Get("path"))`.
+
+Both got silent corruption instead of a replacement: no error, and a returned
+path that says the file is theirs.
+
+## Who is not
+
+The md5-named path, and so wr's own CLI, which passes an empty `savePath`
+(`cmd/add.go:1230`, `jq.UploadFile(localConfigPath, "")` in the tests). Two
+independent reasons, both confirmed by measurement:
+
+- An empty `savePath` goes to `createUploadTempFile`, which uses
+  `os.CreateTemp` - always a fresh, uniquely named file, so there is no old
+  content to survive.
+- `finalizeTempUpload` then names the final path after the md5 of what was
+  written, and `placeUploadedFile` stats that path first: if it exists the temp
+  file is removed and the existing file is left alone. So even a collision
+  cannot mix two contents, because a matching md5 means matching content.
+
+The md5 case passed both before and after the fix, which is what the new test's
+third case pins.
+
+## The fix
+
+Add `os.O_TRUNC` to the named-destination open, and say so in the doc comment
+on `openUploadDestination`:
+
+```go
+file, err := os.OpenFile(savePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, ownerReadWrite)
+```
+
+### Why `O_TRUNC` and not the temp-file route
+
+The temp-file route exists (`usedTempFile`, `finalizeTempUpload`), but it is
+md5-specific, not a general atomic-write helper. `finalizeTempUpload` computes
+the md5 of the temp file, derives a hashed directory under the server's
+`uploadDir`, and returns THAT path; `placeUploadedFile` then refuses to replace
+an existing file. Routing the named case through it would either return a
+different path than the caller asked for or decline to replace the file at all,
+both of which change the contract the caller relies on. `O_TRUNC` is one flag
+on the one open, and the named case is a single open-copy-close with nothing to
+restructure.
+
+### What did not change
+
+`ownerReadWrite` still applies, and `O_TRUNC` does not alter the mode or owner
+of a file that already exists. The returned path is still the expanded
+`savePath`. The empty-`savePath` branch is untouched, so the documented "if it
+turns out such a file already exists, no error is generated" behaviour is
+unchanged. Permissions, ownership and the returned path are all as before.
+
+## Red command
+
+```bash
+unset $(compgen -v | grep '^OS_')
+CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ \
+  -v -run TestServerUploadFile
+```
+
+`TestServerUploadFile` in the new `jobqueue/server_upload_test.go` is port-free:
+it drives `Server.uploadFile` on a `&Server{uploadDir: t.TempDir()}`, which is
+all that function touches. The destination's content is asserted BEFORE
+`So(err, ShouldBeNil)`, so with `FailureHalts` the report shows the corrupted
+content rather than an error.
+
+Failing output before the fix:
+
+```text
+=== RUN   TestServerUploadFile
+
+  Given a server with an upload directory
+    Uploading to a caller-named path that holds a longer file replaces its content ✔✔✘
+    Uploading to a caller-named path that holds a shorter file replaces its content ✔✔✔✔✔
+    Uploading with an empty savePath stores the data at an md5-based path ✔✔✔✔
+      And uploading identical content again generates no error and reuses the path ✔✔✔✔✔✔
+
+Failures:
+
+  * /home/ubuntu/wr_fix_upload/jobqueue/server_upload_test.go
+  Line 55:
+  Expected: "short\n"
+  Actual:   "short\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+  (Should equal)!
+
+18 total assertions
+
+--- FAIL: TestServerUploadFile (0.00s)
+FAIL
+```
+
+Green afterwards: `20 total assertions`,
+`--- PASS: TestServerUploadFile (0.00s)`.
+
+The other three cases are the guards against a fix that breaks something else:
+a short existing file must still be replaced by a longer payload, the md5 path
+must still store its content, and re-uploading identical content to the md5
+path must still return the same path with no error and leave no temp file
+behind. All three pass before AND after, as they must.
+
+## Mutation check
+
+`go vet ./jobqueue/` was run after each edit and reported clean, so neither
+verdict is a build failure masquerading as a dead guard.
+
+- [x] `os.O_TRUNC` removed from the open, leaving
+  `os.O_RDWR|os.O_CREATE`. Vet OK. **RED** on the short-over-long case with the
+  output quoted above, `18 total assertions`. The other three cases stay green,
+  including both md5 cases, which is the same evidence that the md5 path never
+  depended on the flag.
+- [x] Mutation reverted, `jobqueue/server.go` restored, green again at
+  `20 total assertions`.
+
+## Files touched
+
+- `jobqueue/server.go`: `os.O_TRUNC` on the named-destination open in
+  `openUploadDestination`, plus its doc comment. No new type, no
+  restructuring.
+- `jobqueue/server_upload_test.go`: new, `TestServerUploadFile`.
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `421 passed · 9 skipped · 29 packages · 4m1s`, PASSED.
+- `make race`: `421 passed · 9 skipped · 29 packages · 5m15s`, PASSED.
+- `make lint`: `0 issues.` after `golangci-lint cache clean`.
+
+Baseline, measured on this branch point (`e8c3e55a`) with `jobqueue/server.go`
+reverted and the new test file moved aside: `make test` gave
+`420 passed · 9 skipped · 29 packages · 4m35s`. The one extra test is
+`TestServerUploadFile`.
+
+The first `make lint` attempt failed with `parallel golangci-lint is running`,
+another agent's run on this box, and the retry after it finished reported four
+`nolintlint` issues for `//nolint:gosec` directives on the new test's
+`os.ReadFile` calls that `gosec` does not raise in `_test.go` files. The
+directives were removed and lint is clean.

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -3640,7 +3640,9 @@ func (s *Server) uploadFile(ctx context.Context, source io.Reader, savePath stri
 // openUploadDestination opens the file that uploaded data should be written to.
 // If savePath is empty a temporary file is created under the server's upload
 // directory (usedTempFile is then true and the returned path is its name);
-// otherwise the chosen savePath (with ~/ expanded) is created.
+// otherwise the chosen savePath (with ~/ expanded) is created, truncating any
+// existing file so the upload replaces its content instead of overwriting only
+// the start of it.
 func (s *Server) openUploadDestination(ctx context.Context, savePath string) (*os.File, string, bool, error) {
 	if savePath == "" {
 		file, tempPath, err := s.createUploadTempFile(ctx)
@@ -3658,7 +3660,7 @@ func (s *Server) openUploadDestination(ctx context.Context, savePath string) (*o
 	}
 
 	//nolint:gosec // savePath is the destination an authenticated client deliberately chose to upload to
-	file, err := os.OpenFile(savePath, os.O_RDWR|os.O_CREATE, ownerReadWrite)
+	file, err := os.OpenFile(savePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, ownerReadWrite)
 	if err != nil {
 		clog.Error(ctx, "uploadFile create file error", "err", err)
 

--- a/jobqueue/server_upload_test.go
+++ b/jobqueue/server_upload_test.go
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestServerUploadFile(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a server with an upload directory", t, func() {
+		s := &Server{uploadDir: t.TempDir()}
+
+		Convey("Uploading to a caller-named path that holds a longer file replaces its content", func() {
+			savePath := filepath.Join(t.TempDir(), "config.yml")
+			old := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+			err := os.WriteFile(savePath, []byte(old), ownerReadWrite)
+			So(err, ShouldBeNil)
+
+			newContent := "short\n"
+			returned, err := s.uploadFile(ctx, strings.NewReader(newContent), savePath)
+
+			content, errr := os.ReadFile(savePath)
+			So(errr, ShouldBeNil)
+			So(string(content), ShouldEqual, newContent)
+			So(returned, ShouldEqual, savePath)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Uploading to a caller-named path that holds a shorter file replaces its content", func() {
+			savePath := filepath.Join(t.TempDir(), "config.yml")
+			err := os.WriteFile(savePath, []byte("tiny\n"), ownerReadWrite)
+			So(err, ShouldBeNil)
+
+			newContent := "a much longer replacement payload\n"
+			returned, err := s.uploadFile(ctx, strings.NewReader(newContent), savePath)
+
+			content, errr := os.ReadFile(savePath)
+			So(errr, ShouldBeNil)
+			So(string(content), ShouldEqual, newContent)
+			So(returned, ShouldEqual, savePath)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Uploading with an empty savePath stores the data at an md5-based path", func() {
+			content := "md5 named content\n"
+
+			first, err := s.uploadFile(ctx, strings.NewReader(content), "")
+			So(err, ShouldBeNil)
+			So(first, ShouldStartWith, s.uploadDir)
+
+			stored, errr := os.ReadFile(first)
+			So(errr, ShouldBeNil)
+			So(string(stored), ShouldEqual, content)
+
+			Convey("And uploading identical content again generates no error and reuses the path", func() {
+				second, errs := s.uploadFile(ctx, strings.NewReader(content), "")
+
+				stored, errr := os.ReadFile(second)
+				So(errr, ShouldBeNil)
+				So(string(stored), ShouldEqual, content)
+				So(second, ShouldEqual, first)
+				So(errs, ShouldBeNil)
+
+				entries, errg := filepath.Glob(filepath.Join(s.uploadDir, "file_upload*"))
+				So(errg, ShouldBeNil)
+				So(entries, ShouldBeEmpty)
+			})
+		})
+	})
+}


### PR DESCRIPTION
An upload to a caller-named destination overwrote part of the existing file instead of replacing it, leaving a hybrid of old and new content.

`Server.openUploadDestination` opened the destination `os.O_RDWR|os.O_CREATE` with no `os.O_TRUNC`, and `uploadFile` then `io.Copy`s the new content from offset 0. Uploading a shorter payload over a longer file therefore left the old tail in place. Measured: uploading `"short\n"` over a 41-byte file produced `"short\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"`, with 35 bytes of the previous content surviving. That hybrid is then what gets shipped to cloud servers.

Exposed: `Client.UploadFile` with a non-empty remote path, and `PUT /rest/v1/upload?path=`. Not exposed: wr's own CLI, which passes an empty `savePath` — that route goes through `os.CreateTemp` and an md5-named final path, and `placeUploadedFile` leaves an existing identical file alone, so no mixing is possible.

Fixed by adding `O_TRUNC`. This is the only place a caller-named destination is opened; every other `O_CREATE` in the tree already carries `O_TRUNC` or `O_APPEND`. `O_TRUNC` was chosen over routing through the existing temp-file helper because `finalizeTempUpload` is md5-specific rather than a general atomic-write path — it names the final file after the md5 and refuses to replace an existing one, so a named upload through it would either return a different path than the caller asked for or decline to replace at all. Permissions, ownership and the returned path are unchanged.

Found by an adversarial probe of develop.

`make test` and `make race` both 421 passed / 9 skipped (+1 on develop's 420, measured on this tree); `make lint` 0 issues. The guard mutation — removing `O_TRUNC` — turns the short-over-long case red and leaves the md5 cases green.

`.docs/bugfixes/260902-5.md` records the mechanism and the measurements.
