### PR TITLE
Stop a runner spinning for ever when it cannot create a hold file

### DIFF
--- a/.docs/bugfixes/260902-4.md
+++ b/.docs/bugfixes/260902-4.md
@@ -1,0 +1,313 @@
+# Bugfixes 260902-4
+
+Branch `fix-mkhelddir-livelock`: any persistent failure to create a workspace's
+`.hold` file spun the runner at 100% CPU for ever instead of burying the job.
+`ENOSPC` on a full filesystem, `EDQUOT` on an exceeded quota, a read-only
+remount and an unwritable hashed level all do it. The job never failed, the
+runner never exited, and its scheduler slot was held indefinitely - at LSF
+scale with quotas, a way to lose a whole farm allocation to a queue that never
+drains.
+
+## Where this came from
+
+An adversarial probe of the retry loop in `mkHeldDir`, reported as: call
+`mkHashedDir` once to lay the hashed levels down (the normal state after any job
+has run in that Cwd), `chmod 0500` on the hashed directory the `.hold` file goes
+in, then call `mkHashedDir` again in a goroutine - and it does not return.
+That probe reported no return within 3 seconds; the committable version of it,
+`TestMkHashedDirHoldFileFailure`, gives the loop 30 seconds and it does not
+return within those either.
+
+## The mechanism
+
+`mkHeldDir` (jobqueue/utils.go) loops on `tryMkHeldDir` until it reports no
+retry or an error, and `retryOrFail` is the only thing that ends the loop:
+
+```go
+func retryOrFail(tries *int, err error) (bool, error) {
+	*tries++
+	if *tries <= mkHashedDirMaxTries {
+		return true, nil
+	}
+
+	return false, err
+}
+```
+
+Both failure paths of `tryMkHeldDir` went through it with ONE counter, and the
+counter was reset between them:
+
+```go
+	if err = mkdirAllManaged(dir, os.ModePerm); err != nil {
+		return retryOrFail(tries, err)
+	}
+
+	*tries = 0
+
+	f, err := openFileManaged(holdFile, os.O_RDONLY|os.O_CREATE, holdFilePerm)
+	if err != nil {
+		return retryOrFail(tries, err)
+	}
+```
+
+Once the hashed levels exist, `os.MkdirAll` succeeds on every iteration, so
+`*tries = 0` runs on every iteration. The hold-file failure then increments the
+counter from 0 to 1, `1 <= mkHashedDirMaxTries` is always true, and the loop
+retries for ever. The budget could never bind on the hold-file path: it was
+reset by the very step that always succeeded.
+
+The loop has no sleep in it, so this is a hot spin, not an idle wait: one
+`mkdirat`/`stat` plus one failing `openat` per iteration, at whatever rate the
+CPU allows. Measured on the branch point with `/usr/bin/time -v` around the
+30-second red run, one spinning goroutine burns a full core:
+
+```
+	User time (seconds): 10.58
+	System time (seconds): 21.54
+	Percent of CPU this job got: 107%
+	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:30.01
+```
+
+In production that core belongs to an LSF job that will never finish.
+
+### What the runner did with that
+
+`Client.Execute` reaches it through `resolveWorkingDir` (jobqueue/client.go),
+which is the only production caller of `mkHashedDir`:
+
+```go
+	actualCwd, tmpDir, err = mkHashedDir(job.Cwd, job.Key())
+	if err != nil {
+		buryErr := fmt.Errorf("could not create working directory: %w", err)
+
+		errb := c.Bury(job, nil, FailReasonCwd, buryErr)
+```
+
+That bury is correct and never ran, because `mkHashedDir` never returned. The
+job stayed reserved, the runner stayed alive, and the scheduler slot stayed
+taken.
+
+### The two failure modes are not the same
+
+The retry exists for one specific race, named in `mkHeldDir`'s own comment: a
+concurrent `rmEmptyDirsIn` removing the directories under us. That failure is
+transient and self-healing - the removal makes the hold file's open fail with
+`ENOENT`, and the next attempt's `MkdirAll` puts the directory straight back -
+so it genuinely wants a retry, and `.hold` exists precisely to stop that
+removal happening again.
+
+`ENOSPC`, `EDQUOT`, `EROFS` and `EACCES` on the hold file are permanent. Nothing
+in the loop can repair them, so every retry is pure waste and the only useful
+outcome is the error.
+
+### Not introduced by the extraction in #534
+
+The brief suggested the `tryMkHeldDir` extraction in `69ab3075` "Modernise
+(#534)" introduced it. It did not: `git show 69ab3075 -- jobqueue/utils.go`
+shows the extraction preserved the pre-existing `tries = 0` verbatim from the
+inline loop it replaced. The reset arrived with `8c6e1671` "Fix #93 -
+mkHasheDir now retries." (2017-07-11), the commit that added the retry loop in
+the first place, and the livelock has been reachable ever since. #534 is
+therefore not the cause; it is where the code got the name the bug is filed
+under.
+
+## The fix
+
+One counter per step, in `tryMkHeldDir`:
+
+```go
+func tryMkHeldDir(dir, holdFile string, mkdirTries, holdTries *int) (retry bool, err error) {
+	if err = mkdirAllManaged(dir, os.ModePerm); err != nil {
+		return retryOrFail(mkdirTries, err)
+	}
+
+	*mkdirTries = 0
+
+	f, err := openFileManaged(holdFile, os.O_RDONLY|os.O_CREATE, holdFilePerm)
+	if err != nil {
+		return retryOrFail(holdTries, err)
+	}
+
+	return false, f.Close()
+}
+```
+
+`mkHeldDir` owns both (`mkdirTries, holdTries := 0, 0`) so the budgets last for
+one `mkHeldDir` call, exactly as the single one did.
+
+### Why that shape
+
+The reset has a legitimate purpose, and it is kept where it belongs. Making the
+directories IS progress, so a `MkdirAll` failure after an earlier `MkdirAll`
+success is a fresh conflict with `rmEmptyDirsIn` rather than a continuation of
+the one already being retried, and deserves a fresh budget. What it may not do
+is credit that progress to a DIFFERENT step's budget - and that is the whole
+bug, because the step it was crediting is the one that always succeeds once the
+hashed levels are there.
+
+Nothing after the hold file makes progress, so `holdTries` has no reset to be
+given: it is monotone within a call, and `mkHashedDirMaxTries` finally means
+something on that path.
+
+The two budgets also keep the loop bounded overall, which one non-resetting
+counter would have done more crudely and one resetting counter did not do at
+all. `holdTries` never goes down, so there can be at most
+`mkHashedDirMaxTries+1` hold-file failures, and between any two of them at most
+`mkHashedDirMaxTries+1` `MkdirAll` failures, so `mkHeldDir` now makes at most
+~16 attempts before it returns. A single shared counter cannot express both
+intents - "progress earns a fresh budget for the racing step" and "a permanent
+failure exhausts a budget" - which is why the hold-file path got its own.
+
+Kept deliberately minimal: no new type, no change to `retryOrFail`,
+`mkHashedDir` or `mkHeldDir`'s structure, and no sleep or deadline added. The
+race the retry exists for heals in the next attempt, so a count is the right
+instrument; a time-based budget would have slowed the healthy path and made
+every test of it load-sensitive.
+
+## What a job does now
+
+`mkHashedDir` returns in microseconds and `resolveWorkingDir` buries the job
+with `FailReasonCwd` and the underlying reason. The error `mkHashedDir` returns,
+measured with the probe's `chmod 0500`, is:
+
+```
+open /tmp/.../jobqueue_cwd/0/1/2/.hold: permission denied
+```
+
+which `resolveWorkingDir` wraps as
+`could not create working directory: <that>` before passing it to
+`c.Bury(job, nil, FailReasonCwd, buryErr)`.
+
+On a full filesystem or an exceeded quota the same sentence ends in "no space
+left on device" or "disk quota exceeded". The runner then exits normally and
+gives its scheduler slot back, and `wr status` shows a buried job whose
+FailReason says why, which is the outcome the bury path was always written for.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestMkHashedDirHoldFileFailure
+
+`TestMkHashedDirHoldFileFailure` (jobqueue/utils_test.go) creates the hashed
+levels with a real `mkHashedDir` call, `chmod 0500`s the hashed directory, and
+calls `mkHashedDir` again through `mkHashedDirWithin`, which runs it in a
+goroutine and selects on a 30-second timeout so a livelock fails the test
+instead of hanging the suite for ever. `So(returned, ShouldBeTrue)` comes
+BEFORE `So(err, ShouldNotBeNil)`, so with `FailureHalts` the report names the
+livelock rather than a missing error. 30 seconds is ~10^6 times the bound the
+fix actually meets, so no amount of load on this box can turn it red.
+
+Failing output on the branch point, with the second Convey block held back so
+the file compiled against the unfixed signature:
+
+```
+=== RUN   TestMkHashedDirHoldFileFailure
+
+  mkHashedDir gives up when the hold file cannot be created ✔✔✘✔
+
+
+Failures:
+
+  * /home/ubuntu/wr_fix_lock/jobqueue/utils_test.go
+  Line 432:
+  Expected: true
+  Actual:   false
+
+
+4 total assertions
+
+--- FAIL: TestMkHashedDirHoldFileFailure (30.00s)
+FAIL
+FAIL	github.com/VertebrateResequencing/wr/jobqueue	30.010s
+```
+
+Green afterwards, in 0.00s:
+
+```
+  mkHashedDir gives up when the hold file cannot be created ✔✔✔✔✔
+  A hold-file failure that clears is retried, not treated as fatal ✔✔✔✔✔✔✔✔
+
+13 total assertions
+
+--- PASS: TestMkHashedDirHoldFileFailure (0.00s)
+```
+
+### The second case, and why it drives one attempt at a time
+
+The second Convey block pins that a hold-file failure which CLEARS is still
+retried, so the fix cannot pass by simply never retrying: it makes the open fail
+with `EACCES`, asserts `tryMkHeldDir` reports `retry=true` with a nil error,
+clears the `chmod`, and asserts the next attempt succeeds and the hold file is
+really there.
+
+It calls `tryMkHeldDir` directly rather than going through `mkHashedDir`, and
+that is a deliberate limit rather than a shortcut. Within one attempt the loop
+does `MkdirAll` and then the open, and a failed open changes nothing on disk, so
+attempt N+1 sees exactly the filesystem attempt N saw unless something outside
+repairs it. The only self-repair the loop has is `MkdirAll` recreating a removed
+directory, and that happens before the open in the SAME attempt. So the healing
+event is a microsecond-scale interleaving with another process, and a
+goroutine-plus-sleep version of this test would be a coin flip on a busy box:
+repair too early and no failure is exercised at all, too late and the (correctly)
+bounded loop has already given up. Driving the attempts one at a time makes the
+same claim deterministically, and the mutation below shows it is a live claim.
+
+## Mutation checks
+
+`go vet ./jobqueue/` was run after each edit and passed each time, so no verdict
+here is a build failure reporting zero failing assertions.
+
+- [x] M1: the original single-counter reset restored - the hold-file path put
+  back on `retryOrFail(mkdirTries, err)`, which is exactly the old
+  `*tries = 0` arrangement. Vet OK. **RED** on the livelock case, timing out at
+  30 seconds with the output quoted above (`4 total assertions`,
+  `--- FAIL ... (30.00s)`). The transient case stayed green, as it must: the old
+  code retried, it just never stopped.
+- [x] M2: the hold-file path made non-retrying - `return false, err` in place of
+  `retryOrFail(holdTries, err)`. Vet OK. **RED** on the transient case
+  (`A hold-file failure that clears is retried, not treated as fatal ✔✔✘`,
+  Line 445 `Expected: true, Actual: false`, `8 total assertions`,
+  `--- FAIL ... (0.00s)`). The livelock case stayed green, which is the point of
+  having both: a fix that just stops retrying passes the first case and fails
+  this one.
+
+Both mutations reverted, `jobqueue/utils.go` restored, and both cases green
+again.
+
+## Files touched
+
+- `jobqueue/utils.go`: `tryMkHeldDir` takes a budget per step, `mkHeldDir`
+  owns both, plus the doc comment explaining which one resets and why. No new
+  type, no other behaviour change.
+- `jobqueue/utils_test.go`: `TestMkHashedDirHoldFileFailure` and its
+  `mkHashedDirWithin` helper, beside the existing
+  `TestCreatedCwdDepthMatchesMkHashedDir`.
+
+`cleanorder -min-diff` was run on both files and moved the new test helper
+below the test that uses it; nothing else.
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `421 passed · 9 skipped · 29 packages · 4m33s`, PASSED.
+- `make race`: `421 passed · 9 skipped · 29 packages · 6m6s`, PASSED.
+- `make lint`: `0 issues.` (after `golangci-lint cache clean`, which this box
+  needs before any lint result can be believed - it has served issues cached
+  against deleted sibling clones).
+
+Baseline, measured on the branch point (`e8c3e55a`) with both files reverted:
+`make test` gave `420 passed · 9 skipped · 29 packages · 3m50s`. The one extra
+test is `TestMkHashedDirHoldFileFailure`.
+
+The first `make race` attempt failed in `TestServerWebI` at
+`jobqueue/serverWebI_test.go:1045`, `Expected: buried, Actual: delayed`, for a
+job whose `Cmd` ends in `&& false`. That is the load-sensitive kind: nothing in
+this change touches the exit-code or bury path, and `pgrep -x make` showed
+another agent's `make` had started on this shared box while that run was going.
+The full log was written to a file before anything was re-run, and the re-run
+on a quiet box passed. The
+`mkHashedDir` failure path cannot produce `delayed` anyway - it buries with
+`FailReasonCwd`.

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -756,10 +756,10 @@ func removeHoldFile(holdFile string, prior error) error {
 // conflicts with us) and drops a hold file in it so rmEmptyDirsIn will not
 // immediately remove it.
 func mkHeldDir(dir, holdFile string) error {
-	tries := 0
+	mkdirTries, holdTries := 0, 0
 
 	for {
-		retry, err := tryMkHeldDir(dir, holdFile, &tries)
+		retry, err := tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
 		if err != nil {
 			return err
 		}
@@ -803,16 +803,26 @@ func openFileManaged(path string, flag int, perm os.FileMode) (*os.File, error) 
 // tryMkHeldDir makes one attempt to create dir and its hold file. It returns
 // retry=true if mkHeldDir should loop again, or an error if we've run out of
 // retries. retry=false with a nil error means success.
-func tryMkHeldDir(dir, holdFile string, tries *int) (retry bool, err error) {
+//
+// The two steps get a retry budget each. mkdirTries is reset by a successful
+// MkdirAll, because making the directories is real progress and a later
+// conflict with rmEmptyDirsIn deserves a fresh budget; holdTries is never
+// reset, because nothing after it makes progress, so a hold file that cannot be
+// created (a full filesystem, an exceeded quota, a read-only remount, an
+// unwritable hashed level) runs the budget down and fails instead of looping
+// for ever. Resetting a single shared counter here would make every hold-file
+// failure permanently retryable, since the MkdirAll of every later attempt
+// succeeds once the hashed levels exist.
+func tryMkHeldDir(dir, holdFile string, mkdirTries, holdTries *int) (retry bool, err error) {
 	if err = mkdirAllManaged(dir, os.ModePerm); err != nil {
-		return retryOrFail(tries, err)
+		return retryOrFail(mkdirTries, err)
 	}
 
-	*tries = 0
+	*mkdirTries = 0
 
 	f, err := openFileManaged(holdFile, os.O_RDONLY|os.O_CREATE, holdFilePerm)
 	if err != nil {
-		return retryOrFail(tries, err)
+		return retryOrFail(holdTries, err)
 	}
 
 	return false, f.Close()

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -379,3 +379,84 @@ func TestCreatedCwdDepthMatchesMkHashedDir(t *testing.T) {
 		So(filepath.Base(actualCwd), ShouldEqual, createdCwdName)
 	})
 }
+
+// TestMkHashedDirHoldFileFailure covers what mkHashedDir does when it can make
+// the hashed directories but not the hold file inside them. A full filesystem,
+// an exceeded quota, a read-only remount or an unwritable hashed level all do
+// that, and every one of them is permanent: the job must be buried with the
+// error rather than the runner spinning on it for ever, holding its scheduler
+// slot.
+func TestMkHashedDirHoldFileFailure(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	key := "0123456789abcdef0123456789abcdef"
+
+	Convey("mkHashedDir gives up when the hold file cannot be created", t, func() {
+		base := t.TempDir()
+
+		// a first call leaves the hashed levels behind, which is the normal state
+		// after any job has run in this Cwd, and means the MkdirAll of every later
+		// call succeeds.
+		_, _, err := mkHashedDir(base, key)
+		So(err, ShouldBeNil)
+
+		hashed, _ := calculateHashedDir(filepath.Join(base, AppName+createdCwdBaseSuffix), key)
+		So(os.Chmod(hashed, 0o500), ShouldBeNil)
+
+		defer func() {
+			So(os.Chmod(hashed, 0o700), ShouldBeNil)
+		}()
+
+		returned, err := mkHashedDirWithin(30*time.Second, base, key)
+		So(returned, ShouldBeTrue)
+		So(err, ShouldNotBeNil)
+	})
+
+	// the transient half is driven one attempt at a time rather than through
+	// mkHashedDir, because the failure the retry exists for - a concurrent
+	// rmEmptyDirsIn removing the directory between our MkdirAll and our hold
+	// file - heals in the microseconds between two attempts of the loop, so
+	// nothing outside the loop can repair the arrangement in time to be seen.
+	Convey("A hold-file failure that clears is retried, not treated as fatal", t, func() {
+		dir := filepath.Join(t.TempDir(), "hashed")
+		So(os.MkdirAll(dir, 0o700), ShouldBeNil)
+
+		holdFile := filepath.Join(dir, ".hold")
+		So(os.Chmod(dir, 0o500), ShouldBeNil)
+
+		mkdirTries, holdTries := 0, 0
+		retry, err := tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
+		So(retry, ShouldBeTrue)
+		So(err, ShouldBeNil)
+
+		So(os.Chmod(dir, 0o700), ShouldBeNil)
+
+		retry, err = tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
+		So(retry, ShouldBeFalse)
+		So(err, ShouldBeNil)
+
+		_, err = os.Stat(holdFile)
+		So(err, ShouldBeNil)
+	})
+}
+
+// mkHashedDirWithin calls mkHashedDir in a goroutine and reports whether it
+// returned within limit, so a livelock fails the test instead of hanging the
+// suite for ever.
+func mkHashedDirWithin(limit time.Duration, base, tohash string) (returned bool, err error) {
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, _, errm := mkHashedDir(base, tohash)
+		errCh <- errm
+	}()
+
+	select {
+	case errm := <-errCh:
+		return true, errm
+	case <-time.After(limit):
+		return false, nil
+	}
+}


### PR DESCRIPTION
A runner could spin at 100% CPU for ever instead of failing, whenever the hold file in a job's hashed working directory could not be created.

`tryMkHeldDir` reset the shared retry counter to zero after every successful `MkdirAll`, between the directory step and the hold-file step. Once the hashed levels exist — the normal case after any job has run in that `Cwd` — `MkdirAll` succeeds on every iteration, so the reset ran on every iteration and the hold-file failure never exhausted `mkHashedDirMaxTries`. `mkHeldDir`'s loop has no sleep, so it spins hot: measured at 107% CPU, 10.58s user + 21.54s system over a 30-second run.

Real triggers: `ENOSPC` on a full filesystem, `EDQUOT` on an exceeded quota, a read-only remount, or an unwritable hashed level. The job never fails, the runner never exits, and its scheduler slot is held indefinitely — at LSF scale that can quietly consume an allocation.

The two steps now have their own budgets. `mkdirTries` is still reset by a successful `MkdirAll`, because making the directories is real progress and a later conflict with `rmEmptyDirsIn` deserves a fresh budget — that is the reset's legitimate purpose and it is kept. `holdTries` is never reset, because nothing after the hold file makes progress, so the loop is now bounded at about 16 attempts.

A job whose hold file cannot be created is now buried in microseconds with a useful reason: `could not create working directory: open .../jobqueue_cwd/0/1/2/.hold: permission denied` and `FailReasonCwd`, or "no space left on device" / "disk quota exceeded" on a full filesystem or quota.

Not a recent regression: the reset arrived with `8c6e1671` "Fix #93 - mkHasheDir now retries" in 2017, and the `tryMkHeldDir` extraction in #534 preserved it verbatim.

Found by an adversarial probe of develop.

`make test` and `make race` both 421 passed / 9 skipped (+1 on develop's 420, measured on this tree); `make lint` 0 issues. Two guard mutations: restoring the shared-counter reset turns the livelock case red, and making the hold path never retry turns the transient case red — so both halves of the split budget are load-bearing.

`.docs/bugfixes/260902-4.md` records the mechanism, the CPU measurement and the archaeology.
