### PR TITLE
Encode the refused deletion attacks as a regression suite

### DIFF
--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -1,0 +1,177 @@
+# 260904-4: PR #570 review findings
+
+Branch `add-deletion-safety-probes` (PR #570), based on `origin/develop`, at
+`16408a4e`. Tests-only: no production file may appear in the diff.
+
+- [x] `probeBareLeaf` is derived by trimming trailing digits from the actual
+      MkdirTemp directory name. Because the MkdirTemp *prefix* here is `leaf`
+      (derived from `Job.Key()`), and `leaf` is hex, it can itself end with
+      digits; `strings.TrimRight(..., "0123456789")` can therefore remove part
+      of the prefix and place the "bare prefix" decoy at the wrong name. That
+      weakens the intended regression (empty suffix vs digit suffix) and also
+      makes the computed `sibling` name less representative.
+
+      Consider deriving the MkdirTemp prefix directly via
+      `calculateHashedDir(..., job.Key())` (same helper used by the production
+      guard) and using that for `probeBareLeaf` and the sibling leaf; optionally
+      assert that the real workspace name is `leaf + <digits>` to keep the
+      fixture pinned to the guard's assumptions.
+
+  - Source: Copilot, PR #570 thread `PRRT_kwDOAKD33M6fGQT-`, comment id
+    `3929169459`, on `jobqueue/deletion_probes_test.go:172`.
+  - Constraint: the fixture must be SHAPE-AGNOSTIC. PR #578
+    (`fix-same-key-workspace-identity`) replaces the `<leaf><digits>` name
+    `os.MkdirTemp` minted with `<leaf>-<v4 UUID>`, and merges BEFORE this PR.
+    So do not assert `leaf + <digits>`.
+  - Fixed in `jobqueue/deletion_probes_test.go` only, 36 insertions and 17
+    deletions, no production file. `seedProbeWorld` now asks
+    `calculateHashedDir(w.base, job.Key())` for the prefix and uses it
+    unmodified as the `probeBareLeaf` decoy, so that decoy is the prefix with an
+    EMPTY suffix whatever wr appends; and it mints the sibling with
+    `mkHashedDir(job.Cwd, job.Key())`, ie. by asking production for a second run
+    of the same key, rather than by building a name of the shape one is expected
+    to have. The pinning is a prefix relation (`ShouldStartWith` plus
+    `ShouldNotEqual`), which is what both `isMkTempName` and #578's
+    `isJobCreatedWorkSpaceName` gate on, and names no character class, length or
+    separator. `probeDigits` and `probeSiblingDigits` are gone, with them the
+    5 `os.MkdirTemp` comment mentions in the code that changed.
+  - Verified in both trees: all 8 `TestProbe*` functions pass in `wr_p6` and in
+    the #578-shape harness. On that harness the OLD derivation reddens
+    `TestProbeReportedDirectories` and `TestProbeCleanupActionsAgree`, because
+    `TrimRight` leaves a `<leaf>-<uuid>` name untouched and so builds the decoy
+    AT the Job's own workspace.
+  - Mutations, `go vet ./jobqueue/` clean before each verdict: restoring the
+    `TrimRight` derivation is RED in the harness (`ShouldNotEqual` catches the
+    decoy landing on the real workspace) and GREEN on this tree, where an eaten
+    hex character is indistinguishable from a suffix digit to every production
+    recogniser and the mis-placed decoy earns the same `errNotACreatedCwd` -
+    reported rather than dressed up; hand-building the pin's prefix as
+    `job.Key()[4:]` is RED; minting the sibling from a different key is RED at
+    the "another run of the same job" row.
+  - Reviewed: PASS.
+
+- [ ] `TestProbeWorkSpaceChangedInTheWindow`'s row "another run of the same key
+      is handed this workspace's name" is FLAKY, and when it fails it fails by
+      losing the live run's output: the row asserts a survival production does
+      not guarantee.
+
+  - Found while verifying finding 1. PRE-EXISTING on this branch, not caused by
+    that fix: 2 of 20 full `TestProbe` runs fail on pristine `HEAD` with the
+    unmodified file, 3 of 20 with the fix.
+
+- [ ] Retire `probeKeyBlindRows` / `TestProbeMountConfigsOneKeyCovers`, four
+      deliberately-RED rows, without dropping their residual on the floor.
+
+## Red command, finding 1
+
+    go test ./jobqueue/ -run TestZZBareLeafDecoyIsTheBarePrefix -count=1 -v
+
+A throwaway test (`jobqueue/zz_probe_red_test.go`, not committed) that seeds the
+real fixture with the suite's own `probeCmd` and asserts the bare-prefix decoy
+is the prefix `calculateHashedDir` names:
+
+```
+=== RUN   TestZZBareLeafDecoyIsTheBarePrefix
+  The bare-prefix decoy is the prefix the guard's own helper names ...✘
+
+Failures:
+
+  * /home/ubuntu/wr_p6/jobqueue/zz_probe_red_test.go
+  Line 26:
+  Expected: "a778deb1d90aa1679c4c611d24ef2"
+  Actual:   "a778deb1d90aa1679c4c611d24ef"
+  (Should equal)!
+
+--- FAIL: TestZZBareLeafDecoyIsTheBarePrefix (0.00s)
+FAIL	github.com/VertebrateResequencing/wr/jobqueue	0.009s
+```
+
+The key is not a grind: `probeCmd = "probe"` with no mounts and no
+`CwdMatters` hashes to `1aaa778deb1d90aa1679c4c611d24ef2`, so the leaf is
+`a778deb1d90aa1679c4c611d24ef2`, which ends in `2`. `TrimRight` ate that `2`
+along with the suffix, and the bare-prefix row has therefore been testing a
+name that is not the bare prefix on EVERY run of the suite to date. Other keys
+lose more: `Cmd: "probe5"` -> leaf `9f2f39da3c6ab99effbb0b4a58d74`, trimmed
+`9f2f39da3c6ab99effbb0b4a58d`, three characters gone.
+
+## Red command, finding 1 against PR #578's name shape
+
+    <scratchpad>/p6_578 $ go test ./jobqueue/ -run 'TestProbe' -count=1 -v
+
+A copy of this tree with `mkHashedDir` minting `<leaf>-<v4 UUID>` and
+`isMkTempName` replaced by #578's `isJobCreatedWorkSpaceName` verbatim. The
+current derivation does not merely weaken a case there, it reddens the suite:
+a UUID rarely ends in a digit, so `TrimRight` returns the workspace name
+UNCHANGED and the "bare prefix" decoy is created AT the Job's own workspace,
+so cleanup legitimately deletes the fixture's own user file.
+
+```
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestProbeReportedDirectories.../project/jobqueue_cwd/1/a/a/
+             a778deb1d90aa1679c4c611d24ef2-73dcc73d-6f5e-4a69-8ade-b8780b8a719b/
+             cwd/MINE.txt: no such file or directory'
+--- FAIL: TestProbeReportedDirectories (0.04s)
+--- FAIL: TestProbeCleanupActionsAgree (0.01s)
+```
+
+## Gates
+
+    go test ./jobqueue/ -run 'TestProbe' -count=1 -v   # all 8 must pass
+    go build ./...
+    go vet ./cmd/ ./jobqueue/
+    gofmt -l jobqueue/
+
+`make test`, `make race` and `make lint` are run centrally, not here.
+
+## Red command, finding 3 (the flake)
+
+    for i in $(seq 1 20); do go test ./jobqueue/ -run 'TestProbe' -count=1; done
+
+Pristine `HEAD` (file unmodified, extracted with `git archive`): **2 of 20**
+runs FAIL. With finding 1's fix applied: **3 of 20**. Run alone the row does
+not fail, so the rate depends on how much directory churn the preceding tests
+have done.
+
+The failure, verbatim:
+
+```
+  * .../jobqueue/behaviours_test.go
+  Line 1740:
+  Expected: nil
+  Actual:   'stat /tmp/TestProbeWorkSpaceChangedInTheWindow331922314/001/
+             jobqueue_cwd/1/a/a/a778deb1d90aa1679c4c611d24ef21707029070/cwd/
+             live_output.txt: no such file or directory'
+--- FAIL: TestProbeWorkSpaceChangedInTheWindow (0.00s)
+```
+
+## The mechanism, measured
+
+The row's `inWindow` does `os.RemoveAll(workSpace)` then
+`os.MkdirAll(workSpace)`, and the row's comment claims the two are told apart
+because "the inode of the dir that was checked says so". `proveSameDir`
+(jobqueue/utils.go:1119) compares with `os.SameFile`, ie. dev+inode. **ext4
+hands the removed directory's inode straight back to the next `mkdir`**, and
+when it does, the proof legitimately holds and the sweep legitimately proceeds.
+
+Instrumented the row itself in a scratch copy of the tree to print the
+workspace inode either side of the window, then ran the full `TestProbe` set
+30 times. **7 of 30 runs lost the file, and in every one of the 7 the inode
+was the same and `Trigger` returned nil:**
+
+```
+ZZLOST live_output: wsIno 1616777 -> 1616777 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1616773 -> 1616773 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1092575 -> 1092575 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1615911 -> 1615911 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1616612 -> 1616612 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1616612 -> 1616612 (same=true) triggerErr=<nil>
+ZZLOST live_output: wsIno 1616777 -> 1616777 (same=true) triggerErr=<nil>
+instrumented failures: 7 / 30
+```
+
+So the row is not probing a guard that holds; it is probing one whose failure
+is already a recorded residual - `.docs/cwd_matters_cleanup/readme.md`,
+"Measured residuals": "`os.SameFile` is not an identity check across delete and
+recreate. ext4 reuses a freed directory inode immediately, so a per-level proof
+can be satisfied by a different directory."

--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -91,8 +91,44 @@ Branch `add-deletion-safety-probes` (PR #570), based on `origin/develop`, at
     30-of-30 measurement behind the claim only sampled the reuse direction.
     Carried forward as its own item below.
 
-- [ ] Retire `probeKeyBlindRows` / `TestProbeMountConfigsOneKeyCovers`, four
+- [x] Retire `probeKeyBlindRows` / `TestProbeMountConfigsOneKeyCovers`, four
       deliberately-RED rows, without dropping their residual on the floor.
+
+  - Nothing to retire: they are ALREADY out of this PR.
+    `git grep probeKeyBlindRows origin/add-deletion-safety-probes` finds
+    nothing, the file has exactly 8 `TestProbe*` functions and all 8 are green,
+    and no `KNOWN FAILING` marker survives. They were dropped in the rebase at
+    reflog `HEAD@{2026-09-03 21:52:59}` and are preserved on
+    `origin/probe-round8-cases` (`da946ebd`), where `probeKeyBlindRows` is at
+    line 1559 and `TestProbeMountConfigsOneKeyCovers` at 1621. The only
+    `SkipConvey`s in the file are pre-existing FUSE host-capability guards.
+  - The residual is recorded in two comments in
+    `jobqueue/deletion_probes_test.go` rather than in
+    `.docs/cwd_matters_cleanup/readme.md`, and this is a comment-only change:
+    filtering both HEAD's and the new file through
+    `grep -v '^[[:space:]]*//'` gives byte-identical output, so no expression,
+    row, assertion or `wantErr` moved. Per **testing-principles** § Cleanup and
+    Removal no supported behaviour changed, so no new test was invented.
+  - Why not the readme: #578 rewrites that exact section and its version already
+    carries this residual in full - `## Measured residuals` is line 312 in both
+    trees, and #578 adds `**What is left of it.**` at 355 with the fourth bullet
+    at 374-395 naming `probeKeyBlindRows`, `origin/probe-round8-cases`, row 1's
+    pass, rows 2-4's failure, and the mechanism. Editing our copy would
+    duplicate that and conflict on the rebase. Both comments therefore state
+    the mechanism themselves, so they are complete on this tree and
+    non-duplicative after the merge.
+  - The two comments fixed had each been asserting reasoning the four rows
+    refuted. The `"another run of the same job"` row claimed "Only one run of a
+    key is live at a time, so this is a documented residual rather than an
+    escape" - a premise this repo's own readme (325-332) contradicts, recording
+    that the residual bites when two live instances of one Job share a `Cwd`.
+    `TestProbeLiveFuseMounts`' reuse Convey claimed "the two are one job by key,
+    so they mount the same remote at the same place, and the stale run's own
+    keep set still names it" - key equality implies neither. That row IS safe,
+    but because it uses one `MountConfigs` on both sides, not because of the
+    key, and it now says so.
+  - Both comments describe the suffix by what it is FOR rather than what
+    characters it is made of, so they survive #578's `<leaf>-<uuid>` rename.
 
 ## Red command, finding 1
 

--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -50,7 +50,7 @@ Branch `add-deletion-safety-probes` (PR #570), based on `origin/develop`, at
     the "another run of the same job" row.
   - Reviewed: PASS.
 
-- [ ] `TestProbeWorkSpaceChangedInTheWindow`'s row "another run of the same key
+- [x] `TestProbeWorkSpaceChangedInTheWindow`'s row "another run of the same key
       is handed this workspace's name" is FLAKY, and when it fails it fails by
       losing the live run's output: the row asserts a survival production does
       not guarantee.
@@ -58,6 +58,36 @@ Branch `add-deletion-safety-probes` (PR #570), based on `origin/develop`, at
   - Found while verifying finding 1. PRE-EXISTING on this branch, not caused by
     that fix: 2 of 20 full `TestProbe` runs fail on pristine `HEAD` with the
     unmodified file, 3 of 20 with the fix.
+  - Fixed by ordering: the replacement run is now minted by production
+    (`mkHashedDir(job.Cwd, job.Key())`, a genuine second run of the same key)
+    WHILE the proven workspace still occupies its inode, then moved onto its
+    name with `os.Rename` - the pattern the row below it already used. The
+    original's inode is freed only afterwards, so it cannot be handed to the
+    replacement. Row name, position, `wantErr` and all four survivors unchanged;
+    one assertion ADDED, `So(os.SameFile(now, checked), ShouldBeFalse)`, so a
+    change that reintroduces the reuse fails on the first run rather than one
+    run in ten, and fails naming the premise instead of the lost file.
+  - The same-inode case is not dropped on the floor: the row's comment now says
+    the row guarantees a distinct inode and names the case it therefore does not
+    cover, pointing at this repo's
+    `.docs/cwd_matters_cleanup/readme.md` "Measured residuals" entry for
+    `os.SameFile`. No deliberately-red test was added.
+  - Determinism: 4 of 30 full `TestProbe` runs failed before, 0 of 30 after
+    (re-confirmed 0 of 30), and 0 of 60 iterations of
+    `-run 'TestProbeWorkSpaceChangedInTheWindow'` alone.
+  - Mutations, `go vet ./jobqueue/` clean before each verdict: reverting to
+    `RemoveAll` then `MkdirAll` on the same path brings the flake back, 2 of 30;
+    keeping the new identity assertion with that reverted ordering fails 9 of
+    30, every one at the `os.SameFile` assertion rather than at the lost file,
+    so the added assertion is both load-bearing and 2-3x more sensitive than the
+    survival check it backs up.
+  - Rows [2] and [3] of the same table recreate the HASHED level, and were
+    measured NOT to share the weakness: 30 of 30 runs recreated it on the same
+    inode and 30 of 30 still passed, because both expect `wantErr: nil` (a quiet
+    no-op, so an inode match flips no expected refusal), because the upward walk
+    removes only an EMPTY directory and the level is non-empty in both rows by
+    then, and because the freed workspace NAME was never handed back
+    (`wsNameReused=false` in all 30). Left alone deliberately.
 
 - [ ] Retire `probeKeyBlindRows` / `TestProbeMountConfigsOneKeyCovers`, four
       deliberately-RED rows, without dropping their residual on the floor.

--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -384,3 +384,39 @@ The fix is not "tolerate a changed inode". The check buys something real - row
 level's path, and a tolerant chain would let the upward walk unlink it. Any fix
 has to tell "another wr hashed level of the same key, freshly minted" apart from
 "something else now occupies this path".
+
+## Review finding: the FUSE probes failed where they should have skipped
+
+Copilot, on head `11645948`:
+
+> `probeMountRemote` treats a failed `gofuse.Mount` as an assertion failure, but
+> `probeCanMountFuse` only checks for /dev/fuse and a fusermount binary. On some
+> hosts those exist but unprivileged mounts are still denied, which would make
+> these tests fail instead of skipping (workspace_test.go already handles this
+> by treating mount refusal as a skip).
+
+Correct. `probeCanMountFuse` answers "is FUSE plausibly available", which is not
+the same question as "will this mount be permitted": a container without
+SYS_ADMIN, a restrictive `fusermount`, or an exhausted `/dev/fuse` all satisfy
+the first and refuse the second. `probeMountRemote` then asserted
+`So(err, ShouldBeNil)` and the whole probe suite went red on a host that had
+simply declined to mount - a CI failure saying nothing about wr.
+
+`jobqueue/workspace_test.go`'s `mountLoopback` already had the right shape,
+returning a bool and logging the refusal, so this follows it rather than
+inventing a second convention.
+
+**Fixed:** `probeMountRemote` returns `(string, bool)`, and its four call sites
+return from the Convey when the mount is refused.
+
+**Verified by simulating a refusing host**, which took two attempts and the first
+was wrong in an instructive way:
+
+- Forcing the error *after* `gofuse.Mount` had already succeeded made the suite
+  **fail** - but that was the simulation's own fault, not the fix's: the real
+  mount was up, the early return skipped registering `t.Cleanup`, and the leaked
+  mounts broke later rows. A simulation that changes more than the thing under
+  test proves nothing.
+- Making the mount **genuinely** fail (pointing it at a mount point that is not
+  there) gives `ok` - every affected probe skips cleanly and the suite stays
+  green, which is the behaviour the finding asked for.

--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -81,13 +81,15 @@ Branch `add-deletion-safety-probes` (PR #570), based on `origin/develop`, at
     30, every one at the `os.SameFile` assertion rather than at the lost file,
     so the added assertion is both load-bearing and 2-3x more sensitive than the
     survival check it backs up.
-  - Rows [2] and [3] of the same table recreate the HASHED level, and were
-    measured NOT to share the weakness: 30 of 30 runs recreated it on the same
-    inode and 30 of 30 still passed, because both expect `wantErr: nil` (a quiet
-    no-op, so an inode match flips no expected refusal), because the upward walk
-    removes only an EMPTY directory and the level is non-empty in both rows by
-    then, and because the freed workspace NAME was never handed back
-    (`wsNameReused=false` in all 30). Left alone deliberately.
+  - **RETRACTED.** This item originally recorded rows [2] and [3] of the same
+    table as measured NOT to share the weakness, on the grounds that both expect
+    `wantErr: nil` so an inode match flips no expected refusal, that the upward
+    walk removes only an EMPTY directory, and that the freed workspace NAME was
+    never handed back. The review refuted it: each of those grounds is true and
+    each guards the wrong direction. The risk to rows [2] and [3] is an inode
+    MISMATCH producing an UNEXPECTED refusal, which `wantErr: nil` fails on. The
+    30-of-30 measurement behind the claim only sampled the reuse direction.
+    Carried forward as its own item below.
 
 - [ ] Retire `probeKeyBlindRows` / `TestProbeMountConfigsOneKeyCovers`, four
       deliberately-RED rows, without dropping their residual on the floor.
@@ -205,3 +207,64 @@ is already a recorded residual - `.docs/cwd_matters_cleanup/readme.md`,
 "Measured residuals": "`os.SameFile` is not an identity check across delete and
 recreate. ext4 reuses a freed directory inode immediately, so a per-level proof
 can be satisfied by a different directory."
+
+- [ ] `probeWindowRows()` rows [2] and [3], the two that remove the deepest
+      HASHED level and recreate it, expect `wantErr: nil` - a quiet no-op - but
+      production refuses whenever the recreated level does not happen to get the
+      removed one's inode. The rows pass only because ext4 usually hands it
+      back. Same defect as the item above, mirrored: that row lost a file when
+      the inode WAS reused, these two error when it is NOT.
+
+  - Found by the review of `bb783cfd`, which measured 3 of 90 full `TestProbe`
+    runs failing this way. I could not reproduce it by sampling - **0 of 90** on
+    my own host at `bb783cfd` - so the rate is churn- and host-dependent and
+    sampling is the wrong instrument.
+
+## Red command, finding 4
+
+Forcing, not sampling. In a scratch copy of `bb783cfd`, row [3]'s `inWindow`
+builds the replacement level while the proven one still holds its inode, so
+ext4 cannot hand that inode back:
+
+```go
+spare := hashed + "_spare"
+So(os.MkdirAll(spare, os.ModePerm), ShouldBeNil)
+So(os.RemoveAll(hashed), ShouldBeNil)
+So(os.Rename(spare, hashed), ShouldBeNil)
+```
+
+    go vet ./jobqueue/            # clean
+    go test ./jobqueue/ -run 'TestProbeWorkSpaceChangedInTheWindow' -count=1
+
+```
+Failures:
+
+  * .../jobqueue/deletion_probes_test.go
+  Line 533:
+  Expected: nil
+  Actual:   '1 error occurred:
+  	* dir is not below the base dir: /tmp/TestProbeWorkSpaceChangedInTheWindow1202053240/
+  	  004/jobqueue_cwd/1/a/a is no longer the dir that was checked
+
+  '
+
+60 total assertions
+--- FAIL: TestProbeWorkSpaceChangedInTheWindow (0.00s)
+```
+
+Deterministic: the row fails every time the level's inode differs. The 60
+assertions show the survivors all survived - `soPathsExist` runs before
+`soProbeRefused` - so nothing is LOST here; what is wrong is the error class the
+row claims production guarantees.
+
+`provenDirs.openChain` (jobqueue/utils.go) verifies every level above the leaf
+with `openVerifiedDir` -> `proveSameDir`, and a level whose inode changed is not
+`IsNotExist`, so the error is returned and `cleanup` returns it before `empty`
+or `removeUpward` run. Production therefore has three branches here, and the
+rows assert the middle one as though it were the only one:
+
+- the level is removed and NOT recreated: `IsNotExist`, the chain is incomplete,
+  cleanup returns nil. This is the quiet case.
+- the level is recreated with a DIFFERENT inode: refusal, `errNotBelowBaseDir`.
+- the level is recreated with the SAME inode: cleanup proceeds as if nothing
+  changed. This is the recorded `os.SameFile` residual.

--- a/.docs/bugfixes/260904-4.md
+++ b/.docs/bugfixes/260904-4.md
@@ -208,7 +208,7 @@ is already a recorded residual - `.docs/cwd_matters_cleanup/readme.md`,
 recreate. ext4 reuses a freed directory inode immediately, so a per-level proof
 can be satisfied by a different directory."
 
-- [ ] `probeWindowRows()` rows [2] and [3], the two that remove the deepest
+- [x] `probeWindowRows()` rows [2] and [3], the two that remove the deepest
       HASHED level and recreate it, expect `wantErr: nil` - a quiet no-op - but
       production refuses whenever the recreated level does not happen to get the
       removed one's inode. The rows pass only because ext4 usually hands it
@@ -268,3 +268,83 @@ rows assert the middle one as though it were the only one:
 - the level is recreated with a DIFFERENT inode: refusal, `errNotBelowBaseDir`.
 - the level is recreated with the SAME inode: cleanup proceeds as if nothing
   changed. This is the recorded `os.SameFile` residual.
+
+## Finding 4: what was done
+
+Both rows now call one helper, `replaceWithADirOfItsOwn`, which makes the
+replacement level while the proven one still holds its inode, renames it on once
+the original has gone, and asserts with `os.SameFile` that the identity really
+changed. Both rows gained `wantErr: errNotBelowBaseDir`. Row names, positions
+and survivor lists are unchanged; the row's assertion count went 60 -> 70.
+
+Row [2]'s block comment now names which of production's three answers each row
+pins and names the other two, pointing at
+`.docs/cwd_matters_cleanup/readme.md`'s "Measured residuals" entry for
+`os.SameFile` for the same-inode one. No deliberately-red test was added.
+
+Determinism: 0 failures in 30 full `TestProbe` runs and 0 in 60 iterations of
+`-run 'TestProbeWorkSpaceChangedInTheWindow'`. All 8 pass on the #578-shape
+harness too, and the change names no workspace name, only the hashed level the
+table already passes in.
+
+Mutations, `go vet ./jobqueue/` clean before each verdict:
+
+- forcing reverted to a plain `RemoveAll` with the new `wantErr` kept: **10 of
+  10 RED**, both rows, `Expected '<nil>' to NOT be nil`.
+- row [2]'s `wantErr` back to nil with the forcing in place: **5 of 5 RED** at
+  the `is no longer the dir that was checked` error.
+- the helper's own ordering reversed, so the inode can be reused: **10 of 10
+  RED** at the `os.SameFile` assertion, ie. the premise fails before any row's
+  expectation can be turned over.
+
+## The quiet branch is pinned nowhere
+
+`provenDirs.openChain`'s `os.IsNotExist` arm - a proven intermediate level that
+vanished BETWEEN the proof and the reopen - has no test in the package. The near
+misses pin a different thing: `jobqueue/workspace_test.go:1094` and
+`jobqueue/behaviours_test.go:1212` exercise absence at PROOF time
+(`i >= len(dirs.infos)`), which is `openChain`'s other early return; the other
+`cleanupProvenHook` users (`jobqueue/behaviours_test.go:903-1010`) all swap a
+component for a symlink and so land on the refusal arm. Recorded as a gap, not
+filled: scope here was these two rows. Deliberately not written into a code
+comment, which would rot as soon as a row is added.
+
+## A production finding for a separate PR, NOT fixed here
+
+#570 is tests-only, so this is raised rather than fixed.
+
+The rows' old `wantErr: nil` was not merely optimistic. Measured on ext4 (`/`
+and `/tmp` are both `/dev/vda1`), 200 iterations per condition, removing a
+directory and recreating it at the same path, where churn=N means N other
+directories were created between the `rmdir` and the `mkdir`:
+
+```
+churn=0: inode differed in   0 / 200
+churn=1: inode differed in 200 / 200
+churn=8: inode differed in 200 / 200
+```
+
+ext4 hands the freed inode to the NEXT `mkdir` on the filesystem, whoever asks.
+So the inode returns only when nothing else on that filesystem creates a
+directory inside the window - true of a single-threaded test binary, false of a
+shared filesystem carrying many concurrent runs. This also settles the sampling
+puzzle: 3 of 90 versus 0 of 90 is not the frequency of the mechanism, it is the
+frequency of a concurrent `mkdir` landing in a microsecond-wide window in an
+otherwise quiet test process.
+
+The consequence is that for the ordinary two-runs-of-one-key window - one run's
+cleanup walks up removing the empty levels it shares with every other run, the
+next run's `mkHashedDir` creates them again - `errNotBelowBaseDir` is the NORMAL
+answer at scale, not a rare one. `cleanup` returns `openChain`'s error before
+`empty` and before `removeUpward`, so the cleanup Behaviour reports a failure
+and the empty hashed levels plus the `<AppName>_cwd` base are left untidied.
+
+It is not data loss: the refusal is fail-safe, and in that window the run's own
+workspace is already gone, another run's upward walk removing only EMPTY
+directories.
+
+The fix is not "tolerate a changed inode". The check buys something real - row
+[3] is the same window with an empty directory of the USER's renamed onto the
+level's path, and a tolerant chain would let the upward walk unlink it. Any fix
+has to tell "another wr hashed level of the same key, freshly minted" apart from
+"something else now occupies this path".

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1,0 +1,842 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+// This file is where adversarial probes of wr's deletion guards land. Each ROW
+// of the tables below names one route by which a Job's two directory fields,
+// its mount configuration, its own Cmd or a concurrent run of it could aim a
+// deletion at something wr did not create, and asks the production entry points
+// about it.
+//
+// A row asserts two things, in this order: that a file of the user's is still
+// there, and - where the guard gives a distinguishable error - that the refusal
+// carried that error's class, so a change which starts refusing for the wrong
+// reason is caught too. Survival is asserted first because Convey's FailureHalts
+// stops a leaf at its first failed So, and a deletion is the failure that
+// matters.
+//
+// New probe attempts belong here, as a row in whichever table fits, rather than
+// as a function of their own. A route already pinned by workspace_test.go or
+// behaviours_test.go belongs there, not here.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// fixture strings shared by the probe tables.
+const (
+	probeCmd = "probe"
+
+	// probeMineName is a file the user created, which no probe may lose, and
+	// probeRemoteName one behind a live mount or in an un-uploaded cache, which
+	// no probe may lose either.
+	probeMineName   = "MINE.txt"
+	probeRemoteName = "REMOTE_DATA"
+
+	// probeMuxfysDir is named the way muxfys names the cache dir it chooses for
+	// itself inside whatever CacheBase it was given.
+	probeMuxfysDir = muxfysCachePrefix + "_cache123"
+
+	// probeBareLeaf and probeOtherLeaf name the two decoy dirs of probeWorld,
+	// and probeDigits is what os.MkdirTemp appends to a name it chooses.
+	probeBareLeaf  = "bare prefix"
+	probeOtherLeaf = "user's own"
+	probeDigits    = "0123456789"
+
+	// probeSiblingDigits turns a workspace name into the name os.MkdirTemp would
+	// have given ANOTHER run of the same Job.
+	probeSiblingDigits = "999"
+)
+
+// probeWorld is the filesystem a (Cwd, ActualCwd) probe runs against: the
+// workspace mkHashedDir really built for a Job, a file of the user's own in
+// every directory a deletion aimed at the wrong place could land in, and another
+// run of the SAME Job beside it.
+type probeWorld struct {
+	// root is the parent of cwd, cwd is the Job's own Cwd, base is the
+	// <AppName>_cwd component below it, and hashed is the deepest hashed level,
+	// ie. the workspace's own parent.
+	root   string
+	cwd    string
+	base   string
+	hashed string
+
+	workSpace string
+	actualCwd string
+
+	// tmpDir is the dir wr made beside the working directory to be the Job's
+	// TMPDIR, which a licensed sweep takes with the rest of the workspace.
+	tmpDir string
+
+	// decoys are directories of the USER's, beside the Job's own workspace and
+	// named the two ways a name os.MkdirTemp chose can be mis-recognised: the
+	// bare prefix wr would have used had it not needed a unique dir, and a name
+	// of the user's own at the same depth. Whoever submits the Job picks the Cmd
+	// that Key() hashes, so they can put a directory at either.
+	decoys map[string]string
+
+	// output is this run's own file, which cleanup IS entitled to delete.
+	output string
+
+	// sibling is another run of the same Job, differing only in the digits
+	// os.MkdirTemp chose, and siblingFile its live output.
+	sibling     string
+	siblingFile string
+
+	// mine are the user's files, in every place a deletion could stray to.
+	mine []string
+}
+
+// decoy is the working directory a probe reports inside one of the world's decoy
+// dirs, which is a real dir of the user's at the depth wr creates at.
+func (w probeWorld) decoy(name string) string {
+	return filepath.Join(w.hashed, w.decoys[name], createdCwdName)
+}
+
+// seedProbeWorld gives job the workspace mkHashedDir really creates below a
+// fresh Cwd, and surrounds it with the user's own files.
+func seedProbeWorld(t *testing.T, job *Job) probeWorld {
+	t.Helper()
+
+	w := probeWorld{root: t.TempDir()}
+	w.cwd = filepath.Join(w.root, "project")
+	So(os.MkdirAll(w.cwd, os.ModePerm), ShouldBeNil)
+
+	job.Cwd = w.cwd
+	w.actualCwd, w.workSpace, w.tmpDir = realWorkSpace(job)
+	w.base = filepath.Join(w.cwd, AppName+createdCwdBaseSuffix)
+	w.hashed = filepath.Dir(w.workSpace)
+	w.decoys = map[string]string{
+		probeBareLeaf:  strings.TrimRight(filepath.Base(w.workSpace), probeDigits),
+		probeOtherLeaf: "zzzz1234",
+	}
+
+	for _, leaf := range w.decoys {
+		w.mine = append(w.mine, writeFileIn(filepath.Join(w.hashed, leaf, createdCwdName), probeMineName))
+	}
+
+	for _, dir := range []string{
+		w.root, w.cwd, filepath.Join(w.cwd, "my_scripts"),
+		w.base, filepath.Join(w.base, "not_a_hash"),
+		w.hashed, filepath.Join(w.hashed, "someone_elses"),
+	} {
+		w.mine = append(w.mine, writeFileIn(dir, probeMineName))
+	}
+
+	w.sibling = filepath.Join(w.workSpace+probeSiblingDigits, createdCwdName)
+	w.siblingFile = writeFileIn(w.sibling, "other_run.txt")
+	w.output = writeFileIn(w.actualCwd, "own_output.txt")
+
+	return w
+}
+
+// probeCwdRow is one (Cwd, ActualCwd) pair to ask the real cleanup about: the
+// path a run really produced, mutated the way a stale, hand-edited,
+// display-derived or maliciously-reported value could mutate it.
+type probeCwdRow struct {
+	name string
+
+	// cwd is the Cwd the Job carries, or nil for the world's own; actualCwd is
+	// the value the Job reports as its working directory.
+	cwd       func(w probeWorld) string
+	actualCwd func(w probeWorld) string
+
+	// wantErr is the error class the refusal must carry, or nil where the pair
+	// names something wr really created, or nothing at all.
+	wantErr error
+
+	// sweptOwn and sweptSibling say which of the two runs' working directories
+	// the pair licenses cleanup to delete. Both false means it licenses nothing.
+	sweptOwn     bool
+	sweptSibling bool
+}
+
+func probeCwdRows() []probeCwdRow {
+	own := func(w probeWorld) string { return w.actualCwd }
+
+	return []probeCwdRow{
+		// the same directory, spelled every way a value that reached wr through
+		// a display, a config file or a shell could spell it. Each is cleaned
+		// before anything is compared, so each must reach the same verdict as
+		// the control: sweep this Job's own workspace and nothing else.
+		{name: "the path the run really used (control)", actualCwd: own, sweptOwn: true},
+		{
+			name:      "that path with a trailing slash",
+			actualCwd: func(w probeWorld) string { return w.actualCwd + "/" },
+			sweptOwn:  true,
+		},
+		{
+			name:      "that path with a trailing /.",
+			actualCwd: func(w probeWorld) string { return w.actualCwd + "/." },
+			sweptOwn:  true,
+		},
+
+		// every level of wr's own tree except the working directory itself. Each
+		// is at the wrong depth for the path mkHashedDir builds, and treating one
+		// as a working directory would hand its parent to the sweep.
+		{
+			name:      "one level deeper, still called cwd",
+			actualCwd: func(w probeWorld) string { return filepath.Join(w.actualCwd, createdCwdName) },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "the workspace holding it",
+			actualCwd: func(w probeWorld) string { return w.workSpace },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "the deepest hashed level",
+			actualCwd: func(w probeWorld) string { return w.hashed },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "the _cwd base itself",
+			actualCwd: func(w probeWorld) string { return w.base },
+			wantErr:   errNotACreatedCwd,
+		},
+
+		// directories of the user's own, at each level of that tree.
+		{
+			name:      "a dir of the user's inside the _cwd base",
+			actualCwd: func(w probeWorld) string { return filepath.Join(w.base, "not_a_hash") },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "a dir of the user's inside the deepest hashed level",
+			actualCwd: func(w probeWorld) string { return filepath.Join(w.hashed, "someone_elses") },
+			wantErr:   errNotACreatedCwd,
+		},
+
+		// the unique leaf os.MkdirTemp named, mutated. Whoever submits the Job
+		// picks the Cmd that Key() hashes, so they can put a directory of their
+		// own beside the Job's at the prefix that name starts with.
+		{
+			name:      "a dir of the user's at the leaf's bare prefix",
+			actualCwd: func(w probeWorld) string { return w.decoy(probeBareLeaf) },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "a dir of the user's at a leaf name of their own",
+			actualCwd: func(w probeWorld) string { return w.decoy(probeOtherLeaf) },
+			wantErr:   errNotACreatedCwd,
+		},
+
+		// ANOTHER run of the same Job, which the path check accepts by design:
+		// the key is what it recognises, and two runs of one key differ only in
+		// the digits os.MkdirTemp chose. Only one run of a key is live at a time,
+		// so this is a documented residual rather than an escape - but it must
+		// still stop at the sibling, taking nothing of the user's with it.
+		{
+			name:         "another run of the same job",
+			actualCwd:    func(w probeWorld) string { return w.sibling },
+			sweptSibling: true,
+		},
+
+		// the Cwd half of the pair. Cwd is not part of a Job's key unless it is
+		// CwdMatters, so moving it leaves the reported working directory at the
+		// wrong depth below it rather than changing what the key builds.
+		{
+			name:      "Cwd raised to its own parent",
+			cwd:       func(w probeWorld) string { return w.root },
+			actualCwd: own,
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "Cwd lowered to the _cwd base",
+			cwd:       func(w probeWorld) string { return w.base },
+			actualCwd: own,
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			name:      "Cwd the filesystem root",
+			cwd:       func(_ probeWorld) string { return "/" },
+			actualCwd: own,
+			wantErr:   errNotACreatedCwd,
+		},
+
+		// a blank ActualCwd means wr never learned of a working directory for
+		// this Job, so there is nothing it may delete and nothing to say.
+		{name: "ActualCwd blank", actualCwd: func(_ probeWorld) string { return "" }},
+
+		// the same directory named through a path that leaves Cwd and comes back
+		// to it: /proc/self/cwd is the running process's own directory, so this
+		// is a spelling only the kernel can resolve.
+		{
+			name: "ActualCwd named through /proc/self/cwd",
+			actualCwd: func(w probeWorld) string {
+				rel, err := filepath.Rel(w.cwd, w.actualCwd)
+				So(err, ShouldBeNil)
+
+				return filepath.Join(procSelfCwd, rel)
+			},
+			wantErr: errNotBelowBaseDir,
+		},
+	}
+}
+
+// procSelfCwd is where Linux names a process's own working directory. A Job's
+// ActualCwd spelled through it names a directory only the kernel can resolve.
+const procSelfCwd = "/proc/self/cwd"
+
+func TestProbeReportedDirectories(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given the workspace wr really made and the user's files all around it", t, func() {
+		for _, row := range probeCwdRows() {
+			Convey(row.name, func() {
+				job := &Job{Cmd: probeCmd, Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}}}
+				w := seedProbeWorld(t, job)
+
+				if row.cwd != nil {
+					job.Cwd = row.cwd(w)
+				}
+
+				job.ActualCwd = row.actualCwd(w)
+
+				err := job.Behaviours.Trigger(false, job)
+
+				soPathsExist(w.mine...)
+				soPathsExist(w.cwd)
+				soProbeSwept(row.sweptOwn, w.output, w.actualCwd, w.tmpDir)
+				soProbeSwept(row.sweptSibling, w.siblingFile, w.sibling)
+
+				soProbeRefused(err, row.wantErr)
+			})
+		}
+	})
+
+	Convey("A Job whose Cwd is itself a symlink sweeps its own workspace and nothing else", t, func() {
+		// Job.Cwd is stored exactly as the user typed it, because it feeds
+		// Job.Key(), so a symlinked spelling is one wr is GIVEN. Everything below
+		// it is then spelled that way too, and a containment proof that resolved
+		// the symlink on one side only would refuse every such Job, silently
+		// leaking a workspace per run.
+		base := t.TempDir()
+		real := filepath.Join(base, "real")
+		So(os.MkdirAll(real, os.ModePerm), ShouldBeNil)
+
+		link := filepath.Join(base, "cwd_link")
+		So(os.Symlink(real, link), ShouldBeNil)
+
+		precious := writeFileIn(filepath.Join(base, "user_scripts"), probeMineName)
+
+		job := &Job{Cmd: probeCmd, Cwd: link}
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+		output := writeFileIn(actualCwd, "own_output.txt")
+
+		err := (&Behaviour{When: OnExit, Do: CleanupAll}).Trigger(OnExit, job)
+
+		soPathsExist(precious, real, link)
+		soPathsGone(output, actualCwd, tmpDir, workSpace)
+
+		So(err, ShouldBeNil)
+	})
+}
+
+// soProbeSwept asserts that a directory and the file in it either went or
+// stayed, according to whether the row licensed cleanup to delete it.
+func soProbeSwept(swept bool, paths ...string) {
+	if swept {
+		soPathsGone(paths...)
+
+		return
+	}
+
+	soPathsExist(paths...)
+}
+
+// soProbeRefused asserts the refusal a row expected: nothing at all, or an error
+// of the given class.
+func soProbeRefused(err error, wantErr error) {
+	if wantErr == nil {
+		So(err, ShouldBeNil)
+
+		return
+	}
+
+	So(err, ShouldNotBeNil)
+	So(errors.Is(err, wantErr), ShouldBeTrue)
+}
+
+// probeMountRow is one MountConfig shape, with the directories mounting it
+// really puts a live mount point or an un-uploaded cache in.
+//
+// Cleanup runs BEFORE Job.Unmount (client.go) and a cached writable mount only
+// uploads at Unmount, so a directory this table gets wrong is the user's remote
+// objects, or the job's own results, deleted before they ever left the machine.
+type probeMountRow struct {
+	name string
+	mc   MountConfig
+
+	// setUp arranges whatever the shape needs on disk beyond the planting
+	// below, such as the symlink a mount or a cache is spelled through. It is
+	// called once the workspace exists, so the Job's key is already settled.
+	setUp func(actualCwd, workSpace string)
+
+	// live, gone and kept are spelled relative to the WORKSPACE - "." being the
+	// workspace itself, "cwd" the working directory and "tmp" the job's TMPDIR -
+	// and are written out LITERALLY rather than derived with the resolvers the
+	// code under test uses, so a row cannot agree with a resolution bug.
+	//
+	// A file is planted in each of live, and must survive. gone are the paths
+	// cleanup and the TMPDIR removal must between them have deleted, and kept
+	// those they must have left.
+	live []string
+	gone []string
+	kept []string
+}
+
+// probeCachedTargets is a writable cached mount target, for which muxfys chooses
+// a cache dir of its own inside whatever CacheBase it was given.
+func probeCachedTargets() []MountTarget {
+	return []MountTarget{{Path: "bucket/sub", Cache: true, Write: true}}
+}
+
+// probeSymlink replaces link with a symlink to target.
+func probeSymlink(target, link string) {
+	So(os.Symlink(target, link), ShouldBeNil)
+}
+
+func probeMountRows() []probeMountRow {
+	const (
+		output  = createdCwdName + "/own_output.txt"
+		scratch = createdTmpName + "/scratch.txt"
+		mount   = "mnt"
+	)
+
+	return []probeMountRow{
+		// the job's TMPDIR is inside the workspace, so a mount or a cache put
+		// there has to survive not just the sweep but the SEPARATE removal
+		// Execute makes of the tmp dir on every exit, cleanup Behaviour or none.
+		{
+			name: "a mount point that IS the job's TMPDIR",
+			mc:   MountConfig{Mount: "../" + createdTmpName, Targets: probeCachedTargets()},
+			live: []string{createdTmpName, probeMuxfysDir},
+			kept: []string{".", createdTmpName, scratch},
+			gone: []string{createdCwdName, output},
+		},
+		{
+			name: "a mount point inside the job's TMPDIR",
+			mc:   MountConfig{Mount: "../" + createdTmpName + "/m", Targets: probeCachedTargets()},
+			live: []string{createdTmpName + "/m", probeMuxfysDir},
+			kept: []string{".", createdTmpName, scratch},
+			gone: []string{createdCwdName, output},
+		},
+		{
+			name: "a muxfys CacheBase inside the job's TMPDIR",
+			mc: MountConfig{
+				Mount: mount, CacheBase: "../" + createdTmpName, Targets: probeCachedTargets(),
+			},
+			live: []string{createdCwdName + "/" + mount, createdTmpName + "/" + probeMuxfysDir},
+			kept: []string{".", createdCwdName, createdTmpName, scratch},
+			gone: []string{output},
+		},
+		{
+			name: "an explicit CacheDir inside the job's TMPDIR",
+			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
+				Path: "bucket/sub", CacheDir: createdTmpName + "/c", Write: true,
+			}}},
+			live: []string{createdCwdName + "/" + mount, createdTmpName + "/c"},
+			kept: []string{".", createdCwdName, createdTmpName, scratch},
+			gone: []string{output},
+		},
+
+		// a mount point and a cache location ABOVE the workspace need protecting
+		// nowhere, since the sweep only goes inside it - but the upward walk of
+		// empty parents does go higher, and has to stop at the first directory
+		// that will not go, which is the one holding them.
+		{
+			name: "a mount point and a cache dir above the workspace",
+			mc: MountConfig{Mount: "../../up", Targets: []MountTarget{{
+				Path: "bucket/sub", CacheDir: "..", Write: true,
+			}}},
+			live: []string{"../up", "../bucket/sub"},
+			kept: []string{".."},
+			gone: []string{".", createdCwdName, createdTmpName, output, scratch},
+		},
+
+		// a mount point at the workspace makes everything wr created for the Job
+		// the inside of a live mount, TMPDIR included: reclaiming that dir is a
+		// separate deletion from the sweep, so it needs its own answer.
+		{
+			name: "a mount point that IS the workspace, which puts the TMPDIR inside a live mount",
+			mc:   MountConfig{Mount: "..", Targets: probeCachedTargets()},
+			live: []string{".", createdCwdName, createdTmpName},
+			kept: []string{".", createdCwdName, createdTmpName, output, scratch},
+		},
+
+		// a symlink INSIDE the tree being swept makes the two spellings of a
+		// mount or cache location agree LEXICALLY while naming different entries
+		// of it, so only the resolved spelling names the directory the data is
+		// physically in - the one a sweep would recurse into.
+		{
+			name: "a muxfys CacheBase spelled through a symlink inside the working dir",
+			mc:   MountConfig{Mount: mount, CacheBase: "clink", Targets: probeCachedTargets()},
+			setUp: func(actualCwd, _ string) {
+				So(os.MkdirAll(filepath.Join(actualCwd, "realcache"), os.ModePerm), ShouldBeNil)
+				probeSymlink("realcache", filepath.Join(actualCwd, "clink"))
+			},
+			live: []string{
+				createdCwdName + "/realcache/" + probeMuxfysDir, createdCwdName + "/" + mount,
+			},
+			kept: []string{".", createdCwdName, createdCwdName + "/realcache"},
+			// the symlink itself is not a dir, so the sweep unlinks it: what had
+			// to be recognised is the dir it led to, which is where the cache is.
+			gone: []string{output, createdCwdName + "/clink", createdTmpName, scratch},
+		},
+		{
+			name: "an explicit CacheDir spelled through a symlink inside the workspace",
+			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
+				Path: "bucket/sub", CacheDir: "clink", Write: true,
+			}}},
+			setUp: func(_, workSpace string) {
+				So(os.MkdirAll(filepath.Join(workSpace, "realcache"), os.ModePerm), ShouldBeNil)
+				probeSymlink("realcache", filepath.Join(workSpace, "clink"))
+			},
+			live: []string{"realcache/bucket/sub", createdCwdName + "/" + mount},
+			kept: []string{".", createdCwdName, "realcache", "clink"},
+			gone: []string{output, createdTmpName, scratch},
+		},
+	}
+}
+
+func TestProbeMountAndCacheShapes(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a Job whose mounts and caches land in the dirs wr reclaims", t, func() {
+		for _, row := range probeMountRows() {
+			Convey(row.name, func() {
+				cwd := t.TempDir()
+				precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+				job := &Job{Cwd: cwd, Cmd: probeCmd, MountConfigs: MountConfigs{row.mc}}
+				actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+				writeFileIn(actualCwd, "own_output.txt")
+				writeFileIn(tmpDir, "scratch.txt")
+
+				if row.setUp != nil {
+					row.setUp(actualCwd, workSpace)
+				}
+
+				planted := probePlant(workSpace, row.live)
+
+				snap := job.workSpaceSnapshot()
+				cleanErr := snap.cleanupWorkSpace()
+				tmpErr := snap.removeTmpDir()
+
+				soPathsExist(planted...)
+				soPathsExist(probePaths(workSpace, row.kept)...)
+				soPathsExist(precious, cwd)
+				soPathsGone(probePaths(workSpace, row.gone)...)
+
+				So(cleanErr, ShouldBeNil)
+				So(tmpErr, ShouldBeNil)
+			})
+		}
+	})
+}
+
+// probePlant creates each of the given dirs, spelled relative to base, with a
+// file in it that must survive, and returns those files' paths.
+func probePlant(base string, rels []string) []string {
+	planted := make([]string, 0, len(rels))
+
+	for _, rel := range rels {
+		planted = append(planted, writeFileIn(filepath.Join(base, rel), probeRemoteName))
+	}
+
+	return planted
+}
+
+// probePaths turns paths spelled relative to base into absolute ones.
+func probePaths(base string, rels []string) []string {
+	paths := make([]string, 0, len(rels))
+
+	for _, rel := range rels {
+		paths = append(paths, filepath.Join(base, rel))
+	}
+
+	return paths
+}
+
+// probe counts for the concurrency probes below. They are the smallest that
+// still fail when the upward walk's one-empty-dir-at-a-time removal, or the hold
+// file that stops it racing a directory being created, is taken away.
+const (
+	probeCleaners   = 8
+	probeRounds     = 5
+	probeChurners   = 4
+	probeChurnCycle = 40
+)
+
+// probeRun is one run of a Job: the working directory mkHashedDir made for it,
+// and the output file only that run may delete.
+type probeRun struct {
+	actualCwd string
+	tmpDir    string
+	output    string
+}
+
+// startProbeRun makes a run of the Job with the given key below cwd, exactly as
+// Client.Execute does, and puts a live output file in its working directory.
+func startProbeRun(cwd, key, owner string) (probeRun, error) {
+	actualCwd, tmpDir, err := mkHashedDir(cwd, key)
+	if err != nil {
+		return probeRun{}, err
+	}
+
+	output := filepath.Join(actualCwd, "output_"+owner+".txt")
+
+	return probeRun{actualCwd: actualCwd, tmpDir: tmpDir, output: output},
+		os.WriteFile(output, []byte("live output of "+owner), 0o600)
+}
+
+// cleanUp asks the real cleanup to sweep this run, the way a Job carrying the
+// same Cmd and Cwd would.
+func (r probeRun) cleanUp(cwd, cmd string) error {
+	job := &Job{Cmd: cmd, Cwd: cwd, ActualCwd: r.actualCwd}
+
+	return job.workSpaceSnapshot().cleanupWorkSpace()
+}
+
+func TestProbeConcurrentRunsOfOneCwd(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// every run of every Job of one Cwd works below the same <AppName>_cwd base,
+	// and the runs of one KEY share every hashed level above their own workspace,
+	// so a cleanup's upward walk of empty parents is aimed straight at the
+	// directories another live run is sitting in.
+	Convey("Given a Cwd two Jobs are running in", t, func() {
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		victim := &Job{Cwd: cwd, Cmd: probeCmd + " victim"}
+		victimCwd, victimWorkSpace, victimTmp := realWorkSpace(victim)
+		results := writeFileIn(victimCwd, "results.txt")
+
+		cleaner := &Job{Cwd: cwd, Cmd: probeCmd + " cleaner"}
+		realWorkSpace(cleaner)
+
+		Convey("many cleanups of one at once delete nothing of the other's", func() {
+			var wg sync.WaitGroup
+
+			for range probeCleaners {
+				wg.Go(func() {
+					//nolint:errcheck // one cleanup racing another may fail; what survived is the assertion
+					cleaner.workSpaceSnapshot().cleanupWorkSpace()
+				})
+			}
+
+			wg.Wait()
+
+			soPathsExist(results, victimCwd, victimTmp, victimWorkSpace, precious, cwd)
+		})
+	})
+
+	Convey("Given a live run of a Job, and further runs of the SAME key beside it", t, func() {
+		// two managers over one filesystem run what is the same Job by key - Cwd
+		// is not part of a non-cwd_matters key, and nothing else about a run is
+		// either - so their workspaces differ only in the digits os.MkdirTemp
+		// chose, below hashed levels they share.
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		cmd := probeCmd + " shared"
+		key := (&Job{Cmd: cmd, Cwd: cwd}).Key()
+
+		live, err := startProbeRun(cwd, key, "live")
+		So(err, ShouldBeNil)
+
+		Convey("the live run survives each of them being made and cleaned up", func() {
+			for range probeRounds {
+				short, serr := startProbeRun(cwd, key, "short")
+				So(serr, ShouldBeNil)
+				So(short.cleanUp(cwd, cmd), ShouldBeNil)
+			}
+
+			soPathsExist(live.output, live.actualCwd, live.tmpDir, precious, cwd)
+		})
+
+		Convey("and survives them being made and cleaned up concurrently", func() {
+			// the directory a run is being created in is the same one another
+			// run's cleanup is walking up through, so creating one has to be able
+			// to hold its ground: a run that cannot be created is a job that
+			// cannot start, and one whose live output goes is a job whose results
+			// are lost.
+			var (
+				wg        sync.WaitGroup
+				failed    atomic.Int64
+				lostLive  atomic.Int64
+				lostOwn   atomic.Int64
+				lastError atomic.Value
+			)
+
+			for i := range probeChurners {
+				owner := string(rune('A' + i))
+
+				wg.Go(func() {
+					for range probeChurnCycle {
+						run, serr := startProbeRun(cwd, key, owner)
+						if serr != nil {
+							failed.Add(1)
+							lastError.Store(serr.Error())
+
+							continue
+						}
+
+						if _, statErr := os.Lstat(run.output); statErr != nil {
+							lostOwn.Add(1)
+						}
+
+						if _, statErr := os.Lstat(live.output); statErr != nil {
+							lostLive.Add(1)
+						}
+
+						//nolint:errcheck // a cleanup racing another may fail; the counts are the assertions
+						run.cleanUp(cwd, cmd)
+					}
+				})
+			}
+
+			wg.Wait()
+
+			soPathsExist(live.output, live.actualCwd, live.tmpDir, precious, cwd)
+
+			So(lostLive.Load(), ShouldEqual, 0)
+			So(lostOwn.Load(), ShouldEqual, 0)
+			So(failed.Load(), ShouldEqual, 0)
+			So(lastError.Load(), ShouldBeNil)
+		})
+	})
+}
+
+// probeModRow is one `wr mod` shape applied to the Job wr v0.37.0|1 persisted:
+// CwdMatters with ActualCwd poisoned to Cwd, still carrying the cleanup
+// Behaviour that version stored.
+//
+// The modification is the one route by which such a Job can end up running in a
+// directory wr made while still reporting the user's own Cwd as its working
+// directory, which is the state the file loss came from.
+type probeModRow struct {
+	name string
+	mod  func(jm *JobModifier)
+
+	// wantPoison is whether the modification leaves the poisoned ActualCwd in
+	// place, and wantCleanup whether it leaves a cleanup Behaviour able to act
+	// on it.
+	wantPoison  bool
+	wantCleanup bool
+
+	// wantErr is what the cleanup the modification permits must refuse with, or
+	// nil where it leaves no cleanup to run.
+	wantErr error
+}
+
+func probeModRows() []probeModRow {
+	return []probeModRow{
+		{
+			// this is the one modification that would leave the Job running in a
+			// directory wr makes while still reporting the user's own Cwd as the
+			// one it ran in - the state the file loss came from - and it does not:
+			// Cwd is part of a CwdMatters Job's key and of no other's, so
+			// unsetting CwdMatters changes the key, and a stored working directory
+			// the current definition cannot build is discarded. The cleanup this
+			// modification does permit is then left with nothing to act on.
+			//
+			// (What refuses the state itself, should it be reached some other way,
+			// is pinned by behaviours_test.go's ActualCwd-equal-to-Cwd cases.)
+			name:        "--unset_cwd_matters, which clears the poison because the key changes",
+			mod:         func(jm *JobModifier) { jm.SetCwdMatters(false) },
+			wantCleanup: true,
+		},
+		{
+			// the Job stays cwd_matters, so it keeps the poison and loses the
+			// cleanup: a cleanup can only delete a directory wr made, and a
+			// cwd_matters Job has none.
+			name:       "--priority, which leaves the poison but drops the cleanup",
+			mod:        func(jm *JobModifier) { jm.SetPriority(5) },
+			wantPoison: true,
+		},
+	}
+}
+
+func TestProbeV037PoisonedJob(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given the job wr v0.37.0|1 persisted, in a Cwd of the user's own", t, func() {
+		// the Cwd is spelled the way a workspace of wr's is - a *_cwd base, the
+		// created depth, a leaf called cwd - so that nothing about its SHAPE is
+		// what refuses the deletion. This is the incident's own arrangement: the
+		// user's scripts sat above a directory named that way.
+		base := t.TempDir()
+		scripts := filepath.Join(base, "scripts_ciseqtl")
+		precious := writeFileIn(scripts, "05_RunCisEQTL.R")
+
+		cwd := filepath.Join(scripts, AppName+createdCwdBaseSuffix, "a", "b", "c", "abc123", createdCwdName)
+		So(os.MkdirAll(cwd, os.ModePerm), ShouldBeNil)
+
+		inputs := writeFileIn(filepath.Join(cwd, "inputs"), "counts.tsv")
+
+		for _, row := range probeModRows() {
+			Convey(row.name, func() {
+				job := &Job{
+					Cmd: probeCmd, Cwd: cwd, CwdMatters: true, ActualCwd: cwd,
+					Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}},
+				}
+
+				jm := NewJobModifer()
+				row.mod(jm)
+				jm.applyTo(job)
+
+				err := job.Behaviours.Trigger(false, job)
+
+				soPathsExist(precious, inputs, cwd, scripts)
+
+				So(job.ActualCwd == cwd, ShouldEqual, row.wantPoison)
+				So(strings.Contains(job.Behaviours.String(), "cleanup"), ShouldEqual, row.wantCleanup)
+
+				soProbeRefused(err, row.wantErr)
+			})
+		}
+	})
+}

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -316,11 +316,21 @@ func probeCwdRows() []probeCwdRow {
 			wantErr: errNotACreatedCwd,
 		},
 
-		// ANOTHER run of the same Job, which the path check accepts by design:
-		// the key is what it recognises, and two runs of one key differ only in
-		// the digits os.MkdirTemp chose. Only one run of a key is live at a time,
-		// so this is a documented residual rather than an escape - but it must
-		// still stop at the sibling, taking nothing of the user's with it.
+		// ANOTHER run of the same Job, which the path check accepts by design: the
+		// key is what it recognises, and the only thing that tells one run of a key
+		// from another is the per-run suffix wr appends, which no stored path can be
+		// shown to own. What this row pins is that the sweep stops at the sibling,
+		// taking nothing of the user's with it; it does not pin that a repeated name
+		// is harmless. If one ever arises, a live run's un-uploaded writable-mount
+		// output is deletable by a finished run of the same key: content awaiting
+		// upload is a plain directory rather than a mount, so no mount-boundary guard
+		// sees it, and the stale run's keep set need not name it. Written up in
+		// .docs/cwd_matters_cleanup/readme.md, "Measured residuals"; the four rows
+		// that measured it are preserved on origin/probe-round8-cases. #578's per-run
+		// mint, held by its TestWorkSpaceNameIsMintedPerRun, closes the issuing half:
+		// it leaves wr handing a finished run's name to a later one too unlikely to
+		// plan for, which is why the above is what a repeat would cost rather than a
+		// live hole.
 		{
 			name:         "another run of the same job",
 			actualCwd:    func(w probeWorld) string { return w.sibling },
@@ -1055,14 +1065,27 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 		})
 
 		Convey("a run handed a workspace name an earlier run finished with keeps its mount", func() {
-			// os.MkdirTemp's digits are not pinned to a run, so the name one
-			// manager's run finished with is free for another manager's run of the
-			// SAME key to be handed later, and a stale ActualCwd then names a live
-			// workspace byte for byte. Nothing about the path can tell the two
-			// apart - the residual the "another run of the same job" row records -
-			// but the two are one job by key, so they mount the same remote at the
-			// same place, and the stale run's own keep set still names it. The
-			// local workspace goes; the user's remote data does not.
+			// the per-run suffix that tells one run of a key from another is not pinned
+			// to a run by anything a stored path records, so the name one manager's run
+			// finished with could be handed to another manager's run of the SAME key
+			// later, and a stale ActualCwd then names a live workspace byte for byte.
+			// Nothing about the path can tell the two apart - the residual the "another
+			// run of the same job" row records. This row forces that collision with ONE
+			// MountConfigs on both sides, and that config is why it is safe: it mounts
+			// the same remote at the same place for both runs, so the stale run's keep
+			// set names the live mount. The local workspace goes; the user's remote data
+			// does not. Key equality alone does not buy that. Key() reads Mount, Profile
+			// and Path, and nothing that decides where a mount or a cache lands, so two
+			// runs of one key can put theirs in different places, and then the finished
+			// run can delete the live run's un-uploaded writable-mount output: content
+			// awaiting upload is a plain directory rather than a mount, so no
+			// mount-boundary guard sees it, and the stale keep set need not name it.
+			// Written up in .docs/cwd_matters_cleanup/readme.md, "Measured residuals";
+			// the four rows that measured it are preserved on origin/probe-round8-cases.
+			// #578's per-run mint, held by its TestWorkSpaceNameIsMintedPerRun, closes
+			// the issuing half: it leaves wr handing a finished run's name to a later
+			// one too unlikely to plan for, which is why the above is what a repeat
+			// would cost rather than a live hole.
 			cwd := t.TempDir()
 			precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
 

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -45,11 +45,13 @@ package jobqueue
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -73,10 +75,10 @@ const (
 	probeOtherLeaf = "user's own"
 	probeDigits    = "0123456789"
 
-	// probeCacheLink is the name of a symlink a mount config spells a cache
-	// location through, and probeRealCache the dir it leads to.
-	probeCacheLink = "clink"
-	probeRealCache = "realcache"
+	// probeLinkName is the name of a symlink a mount config spells a mount point
+	// or a cache location through, and probeRealDir the dir it leads to.
+	probeLinkName = "link"
+	probeRealDir  = "real"
 
 	// probeSiblingDigits turns a workspace name into the name os.MkdirTemp would
 	// have given ANOTHER run of the same Job.
@@ -508,30 +510,30 @@ func probeMountRows() []probeMountRow {
 		// physically in - the one a sweep would recurse into.
 		{
 			name: "a muxfys CacheBase spelled through a symlink inside the working dir",
-			mc:   MountConfig{Mount: mountDir, CacheBase: probeCacheLink, Targets: probeCachedTargets()},
+			mc:   MountConfig{Mount: mountDir, CacheBase: probeLinkName, Targets: probeCachedTargets()},
 			setUp: func(actualCwd, _ string) {
-				So(os.MkdirAll(filepath.Join(actualCwd, probeRealCache), os.ModePerm), ShouldBeNil)
-				probeSymlink(probeRealCache, filepath.Join(actualCwd, probeCacheLink))
+				So(os.MkdirAll(filepath.Join(actualCwd, probeRealDir), os.ModePerm), ShouldBeNil)
+				probeSymlink(probeRealDir, filepath.Join(actualCwd, probeLinkName))
 			},
 			live: []string{
-				createdCwdName + "/" + probeRealCache + "/" + probeMuxfysDir, createdCwdName + "/" + mountDir,
+				createdCwdName + "/" + probeRealDir + "/" + probeMuxfysDir, createdCwdName + "/" + mountDir,
 			},
-			kept: []string{".", createdCwdName, createdCwdName + "/" + probeRealCache},
+			kept: []string{".", createdCwdName, createdCwdName + "/" + probeRealDir},
 			// the symlink itself is not a dir, so the sweep unlinks it: what had
 			// to be recognised is the dir it led to, which is where the cache is.
-			gone: []string{output, createdCwdName + "/" + probeCacheLink, createdTmpName, scratch},
+			gone: []string{output, createdCwdName + "/" + probeLinkName, createdTmpName, scratch},
 		},
 		{
 			name: "an explicit CacheDir spelled through a symlink inside the workspace",
 			mc: MountConfig{Mount: mountDir, Targets: []MountTarget{{
-				Path: testWSTargetPath, CacheDir: probeCacheLink, Write: true,
+				Path: testWSTargetPath, CacheDir: probeLinkName, Write: true,
 			}}},
 			setUp: func(_, workSpace string) {
-				So(os.MkdirAll(filepath.Join(workSpace, probeRealCache), os.ModePerm), ShouldBeNil)
-				probeSymlink(probeRealCache, filepath.Join(workSpace, probeCacheLink))
+				So(os.MkdirAll(filepath.Join(workSpace, probeRealDir), os.ModePerm), ShouldBeNil)
+				probeSymlink(probeRealDir, filepath.Join(workSpace, probeLinkName))
 			},
-			live: []string{probeRealCache + "/" + testWSTargetPath, createdCwdName + "/" + mountDir},
-			kept: []string{".", createdCwdName, probeRealCache, probeCacheLink},
+			live: []string{probeRealDir + "/" + testWSTargetPath, createdCwdName + "/" + mountDir},
+			kept: []string{".", createdCwdName, probeRealDir, probeLinkName},
 			gone: []string{output, createdTmpName, scratch},
 		},
 	}
@@ -597,6 +599,208 @@ func probePaths(base string, rels []string) []string {
 	}
 
 	return paths
+}
+
+// probeFuseRow is one MountConfig shape whose mount point holds a REAL FUSE
+// mount of the user's remote data, rather than a plain directory standing in for
+// one.
+//
+// A plain directory cannot show what the keep set is FOR. Every deletion below
+// is made through an os.Root, which resolves each path beneath the directory it
+// holds - but RESOLVE_BENEATH does not imply RESOLVE_NO_XDEV, so an
+// os.Root.RemoveAll of an entry that happens to be a live mount crosses into it
+// and unlinks what is behind. For a muxfys mount that is the user's objects in
+// their object store, and for a writable one their job's own results before
+// Unmount ever uploaded them. Nothing about the workspace's shape stops it; the
+// keep set is the only thing that does.
+type probeFuseRow struct {
+	name string
+	mc   MountConfig
+
+	// setUp arranges whatever the shape needs on disk beyond the mount itself,
+	// as probeMountRow's does and for the same reason.
+	setUp func(actualCwd, workSpace string)
+
+	// mount is where the remote is really mounted, own are the files this run
+	// left OUTSIDE that mount, and kept and gone are the paths cleanup and the
+	// TMPDIR removal must between them have left and deleted. All of them are
+	// spelled relative to the WORKSPACE and written out literally, as
+	// probeMountRow spells its own.
+	//
+	// The own files are written after the mount is raised, and nothing wr made
+	// under a mount point is named at all, because a mount point has to be empty
+	// to mount over: in a real run the working directory and the TMPDIR are made
+	// empty and the mounts go up before the Job's Cmd writes anything, so what a
+	// run leaves inside one of its own mounts is remote data, not local.
+	mount string
+	own   []string
+	kept  []string
+	gone  []string
+}
+
+func probeFuseRows() []probeFuseRow {
+	const (
+		output   = createdCwdName + "/own_output.txt"
+		scratch  = createdTmpName + "/scratch.txt"
+		cwdMount = createdCwdName + "/" + testWSMount
+		realDir  = createdCwdName + "/" + probeRealDir
+	)
+
+	return []probeFuseRow{
+		// one row per rule of the keep set that can be the only thing between
+		// the sweep and a live mount, each over a directory wr itself made.
+		{
+			// keptDirs.inActualCwd, honoured by removeAllExcept.
+			name:  "a live mount inside the working directory",
+			mc:    MountConfig{Mount: testWSMount, Targets: probeCachedTargets()},
+			mount: cwdMount,
+			own:   []string{output, scratch},
+			kept:  []string{".", createdCwdName, cwdMount},
+			gone:  []string{output, createdTmpName, scratch},
+		},
+		{
+			// keptDirs.wholeActualCwd: the working directory IS the mount, so
+			// everything in it is the user's remote data and none of it may go.
+			name:  "a live mount that IS the working directory",
+			mc:    MountConfig{Mount: ".", Targets: probeCachedTargets()},
+			mount: createdCwdName,
+			own:   []string{scratch},
+			kept:  []string{".", createdCwdName},
+			gone:  []string{createdTmpName, scratch},
+		},
+		{
+			// keptDirs.workSpaceEntries, honoured by BOTH sweeps: the tmp dir is
+			// reclaimed on every exit, cleanup Behaviour or none, so a mount put
+			// there must survive a deletion the workspace sweep does not make.
+			name:  "a live mount that IS the job's TMPDIR",
+			mc:    MountConfig{Mount: "../" + createdTmpName, Targets: probeCachedTargets()},
+			mount: createdTmpName,
+			own:   []string{output},
+			kept:  []string{".", createdTmpName},
+			gone:  []string{createdCwdName, output},
+		},
+		{
+			// relsBelowDirResolved: only the RESOLVED spelling names the
+			// directory the mount is physically in, and a keep set given the
+			// lexical one alone would protect the symlink and delete the mount.
+			name: "a live mount spelled through a symlink inside the working directory",
+			mc:   MountConfig{Mount: probeLinkName + "/" + testWSMount, Targets: probeCachedTargets()},
+			setUp: func(actualCwd, _ string) {
+				So(os.MkdirAll(filepath.Join(actualCwd, probeRealDir), os.ModePerm), ShouldBeNil)
+				probeSymlink(probeRealDir, filepath.Join(actualCwd, probeLinkName))
+			},
+			mount: realDir + "/" + testWSMount,
+			own:   []string{output, scratch},
+			kept:  []string{".", createdCwdName, realDir, realDir + "/" + testWSMount},
+			// the symlink itself is not a dir, so the sweep unlinks it: what had
+			// to be recognised is the dir it led to, which is where the mount is.
+			gone: []string{output, createdCwdName + "/" + probeLinkName, createdTmpName, scratch},
+		},
+	}
+}
+
+func TestProbeLiveFuseMounts(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a Job whose mount point holds a live mount of the user's remote data", t, func() {
+		if !probeCanMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		for _, row := range probeFuseRows() {
+			Convey(row.name, func() {
+				cwd := t.TempDir()
+				precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+				job := &Job{Cwd: cwd, Cmd: probeCmd, MountConfigs: MountConfigs{row.mc}}
+				actualCwd, workSpace, _ := realWorkSpace(job)
+
+				if row.setUp != nil {
+					row.setUp(actualCwd, workSpace)
+				}
+
+				remote := probeMountRemote(t, filepath.Join(workSpace, row.mount))
+				probeOwnFiles(workSpace, row.own)
+
+				snap := job.workSpaceSnapshot()
+				cleanErr := snap.cleanupWorkSpace()
+				tmpErr := snap.removeTmpDir()
+
+				soPathsExist(remote)
+				soPathsExist(filepath.Join(workSpace, row.mount, probeRemoteName))
+				soPathsExist(probePaths(workSpace, row.kept)...)
+				soPathsExist(precious, cwd)
+				soPathsGone(probePaths(workSpace, row.gone)...)
+
+				So(cleanErr, ShouldBeNil)
+				So(tmpErr, ShouldBeNil)
+			})
+		}
+	})
+}
+
+// probeOwnFiles writes the files a run left outside its own mounts, each spelled
+// relative to base, as probeFuseRow.own spells them.
+func probeOwnFiles(base string, rels []string) {
+	for _, rel := range rels {
+		path := filepath.Join(base, rel)
+		writeFileIn(filepath.Dir(path), filepath.Base(path))
+	}
+}
+
+// probeCanMountFuse reports whether this host lets an unprivileged process raise
+// a FUSE mount, which the rows above need and a host with no /dev/fuse or no
+// setuid fusermount cannot give them.
+func probeCanMountFuse() bool {
+	dev, err := os.OpenFile("/dev/fuse", os.O_RDWR, 0)
+	if err != nil {
+		return false
+	}
+
+	defer dev.Close()
+
+	for _, bin := range []string{"fusermount3", "fusermount"} {
+		if _, err = exec.LookPath(bin); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// probeMountRemote plants a file of the user's remote data in a directory
+// OUTSIDE the Job's Cwd and really FUSE mounts that directory over mountPoint,
+// returning the planted file's path. The mount is taken down when the test ends.
+//
+// go-fuse's loopback filesystem is what makes the mount real, and it is the
+// cheapest one an unprivileged process can raise. What is behind it is an
+// ordinary directory, so what survived can be asserted about directly; muxfys
+// would need an object store to talk to, and the deletion under test does not
+// care which filesystem is mounted, only that a mount gets crossed.
+func probeMountRemote(t *testing.T, mountPoint string) string {
+	t.Helper()
+
+	backing := t.TempDir()
+	remote := writeFileIn(backing, probeRemoteName)
+
+	root, err := gofuse.NewLoopbackRoot(backing)
+	So(err, ShouldBeNil)
+	So(os.MkdirAll(mountPoint, os.ModePerm), ShouldBeNil)
+
+	server, err := gofuse.Mount(mountPoint, root, &gofuse.Options{})
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() {
+		if uerr := server.Unmount(); uerr != nil {
+			t.Logf("could not unmount the probe's remote at %s: %s", mountPoint, uerr)
+		}
+	})
+
+	return remote
 }
 
 // probe counts for the concurrency probes below. They are the smallest that

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -48,7 +48,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -596,13 +595,10 @@ func probePaths(base string, rels []string) []string {
 }
 
 // probe counts for the concurrency probes below. They are the smallest that
-// still fail when the upward walk's one-empty-dir-at-a-time removal, or the hold
-// file that stops it racing a directory being created, is taken away.
+// still fail when the upward walk stops removing one empty dir at a time.
 const (
-	probeCleaners   = 8
-	probeRounds     = 5
-	probeChurners   = 4
-	probeChurnCycle = 40
+	probeCleaners = 8
+	probeRounds   = 5
 )
 
 // probeRun is one run of a Job: the working directory mkHashedDir made for it,
@@ -693,57 +689,6 @@ func TestProbeConcurrentRunsOfOneCwd(t *testing.T) {
 			}
 
 			soPathsExist(live.output, live.actualCwd, live.tmpDir, precious, cwd)
-		})
-
-		Convey("and survives them being made and cleaned up concurrently", func() {
-			// the directory a run is being created in is the same one another
-			// run's cleanup is walking up through, so creating one has to be able
-			// to hold its ground: a run that cannot be created is a job that
-			// cannot start, and one whose live output goes is a job whose results
-			// are lost.
-			var (
-				wg        sync.WaitGroup
-				failed    atomic.Int64
-				lostLive  atomic.Int64
-				lostOwn   atomic.Int64
-				lastError atomic.Value
-			)
-
-			for i := range probeChurners {
-				owner := string(rune('A' + i))
-
-				wg.Go(func() {
-					for range probeChurnCycle {
-						run, serr := startProbeRun(cwd, key, owner)
-						if serr != nil {
-							failed.Add(1)
-							lastError.Store(serr.Error())
-
-							continue
-						}
-
-						if _, statErr := os.Lstat(run.output); statErr != nil {
-							lostOwn.Add(1)
-						}
-
-						if _, statErr := os.Lstat(live.output); statErr != nil {
-							lostLive.Add(1)
-						}
-
-						//nolint:errcheck // a cleanup racing another may fail; the counts are the assertions
-						run.cleanUp(cwd, cmd)
-					}
-				})
-			}
-
-			wg.Wait()
-
-			soPathsExist(live.output, live.actualCwd, live.tmpDir, precious, cwd)
-
-			So(lostLive.Load(), ShouldEqual, 0)
-			So(lostOwn.Load(), ShouldEqual, 0)
-			So(failed.Load(), ShouldEqual, 0)
-			So(lastError.Load(), ShouldBeNil)
 		})
 	})
 }

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1017,6 +1017,144 @@ func (r probeRun) cleanUp(cwd, cmd string) error {
 	return job.workSpaceSnapshot().cleanupWorkSpace()
 }
 
+// probeWindowRow is one thing that can happen to the directories a cleanup has
+// already proven, in the window between the proof and the sweep, when ANOTHER of
+// the user's own jobs is working below the same Cwd - the normal condition at
+// scale.
+//
+// Every level above the workspace is shared with every other run of the same
+// key, and the workspace's own name is unique only among the workspaces that
+// EXIST: os.MkdirTemp hands the name of a workspace that has gone to the next
+// run that asks. So each row leaves a path that still names something, just not
+// the thing that was proven, and only the inodes the descent lstat'ed - or the
+// upward walk's refusal to remove anything but an empty directory - tell the two
+// apart.
+type probeWindowRow struct {
+	name string
+
+	// inWindow is called between the proof and the sweep, with the Job whose
+	// cleanup is running, its own workspace and the deepest hashed level above
+	// it, and returns the paths that must ALL still be there afterwards.
+	inWindow func(job *Job, workSpace, hashed string) []string
+
+	// wantErr is the error class the refusal must carry, or nil where the row
+	// leaves the cleanup something it may legitimately finish.
+	wantErr error
+}
+
+func probeWindowRows() []probeWindowRow {
+	return []probeWindowRow{
+		// the workspace itself, replaced. What was proven is gone, and the
+		// deletion is aimed at whatever holds its name now.
+		{
+			// this is the name-reuse residual, arriving one moment too late to
+			// be one: a stale ActualCwd naming a workspace since handed out
+			// again is indistinguishable by path (the "another run of the same
+			// job" row), but a workspace this cleanup PROVED and then lost is
+			// not - the inode of the dir that was checked says so.
+			name: "another run of the same key is handed this workspace's name",
+			inWindow: func(_ *Job, workSpace, _ string) []string {
+				So(os.RemoveAll(workSpace), ShouldBeNil)
+				So(os.MkdirAll(workSpace, os.ModePerm), ShouldBeNil)
+
+				reusedCwd, reusedTmp, err := mkCwdAndTmp(workSpace)
+				So(err, ShouldBeNil)
+
+				return []string{
+					writeFileIn(reusedCwd, "live_output.txt"), reusedCwd, reusedTmp, workSpace,
+				}
+			},
+			wantErr: errNotBelowBaseDir,
+		},
+		{
+			// the same window with a directory of the user's in it instead,
+			// which the hashed levels being inside their own Cwd puts within
+			// reach of anything running as them. Nothing about its SHAPE is
+			// what refuses it: it sits at the path mkHashedDir built for this
+			// very Job, so the sweep would empty it entirely, keeping nothing.
+			name: "a directory of the user's is renamed onto the workspace's name",
+			inWindow: func(job *Job, workSpace, _ string) []string {
+				userTree := filepath.Join(job.Cwd, "scripts")
+				writeFileIn(userTree, "analyse.sh")
+				writeFileIn(filepath.Join(userTree, "lib"), "helpers.sh")
+
+				So(os.RemoveAll(workSpace), ShouldBeNil)
+				So(os.Rename(userTree, workSpace), ShouldBeNil)
+
+				return []string{
+					filepath.Join(workSpace, "analyse.sh"),
+					filepath.Join(workSpace, "lib", "helpers.sh"), workSpace,
+				}
+			},
+			wantErr: errNotBelowBaseDir,
+		},
+
+		// the hashed level ABOVE the workspace, taken and put back. This is the
+		// ordering two runs of one key really produce: one run's cleanup walks
+		// up removing the empty levels it shares with every other run, and the
+		// next run's mkHashedDir creates them again. The cleanup has nothing
+		// left to delete and must say so quietly, since a workspace that has
+		// gone is the ordinary state of a second cleanup - but the handles it
+		// still holds are on the levels it descended through, not on the ones
+		// that replaced them, and the only thing its upward walk may remove is
+		// an empty directory.
+		{
+			name: "the hashed level above the workspace is recreated by another run of the same key",
+			inWindow: func(job *Job, _, hashed string) []string {
+				So(os.RemoveAll(hashed), ShouldBeNil)
+
+				other, err := startProbeRun(job.Cwd, job.Key(), "other")
+				So(err, ShouldBeNil)
+
+				return []string{other.output, other.actualCwd, other.tmpDir, hashed}
+			},
+		},
+		{
+			name: "the hashed level above the workspace is recreated holding a tree of the user's",
+			inWindow: func(_ *Job, _, hashed string) []string {
+				So(os.RemoveAll(hashed), ShouldBeNil)
+
+				return []string{writeFileIn(filepath.Join(hashed, "someone_elses"), probeMineName), hashed}
+			},
+		},
+	}
+}
+
+func TestProbeWorkSpaceChangedInTheWindow(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a cleanup that has proven its workspace, and another run of the same key below the Cwd", t, func() {
+		for _, row := range probeWindowRows() {
+			Convey(row.name, func() {
+				cwd := t.TempDir()
+				precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+				job := &Job{Cmd: probeCmd, Cwd: cwd, Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}}}
+				_, workSpace, _ := realWorkSpace(job)
+
+				var survivors []string
+
+				cleanupProvenHook = func() {
+					cleanupProvenHook = nil
+
+					survivors = row.inWindow(job, workSpace, filepath.Dir(workSpace))
+				}
+
+				Reset(func() { cleanupProvenHook = nil })
+
+				err := job.Behaviours.Trigger(false, job)
+
+				soPathsExist(survivors...)
+				soPathsExist(precious, cwd)
+
+				soProbeRefused(err, row.wantErr)
+			})
+		}
+	})
+}
+
 func TestProbeConcurrentRunsOfOneCwd(t *testing.T) {
 	if runnermode || servermode {
 		return
@@ -1075,6 +1213,47 @@ func TestProbeConcurrentRunsOfOneCwd(t *testing.T) {
 			}
 
 			soPathsExist(live.output, live.actualCwd, live.tmpDir, precious, cwd)
+		})
+	})
+
+	Convey("Given a workspace name the next run of the same key was handed", t, func() {
+		// os.MkdirTemp's digits are unique only among the workspaces that
+		// EXIST, so once a run's workspace has gone its name is free for the
+		// next run of the same key to be given - and the finished run's OWN
+		// ActualCwd, which nobody reported and which its own mkHashedDir
+		// returned, then names a LIVE run's working directory byte for byte.
+		//
+		// Nothing about the path can tell the two apart, since they are one job
+		// by key and the key is the whole of what the check recognises. For
+		// cleanup that residual is recorded by the "another run of the same
+		// job" row. `run` shares the same resolution, so it inherits the same
+		// residual - and what it does with the directory is the user's own
+		// command, which can do anything they can.
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		job := &Job{Cmd: probeCmd, Cwd: cwd}
+		finished, workSpace, _ := realWorkSpace(job)
+
+		So(os.RemoveAll(workSpace), ShouldBeNil)
+		So(os.MkdirAll(workSpace, os.ModePerm), ShouldBeNil)
+
+		reusedCwd, reusedTmp, err := mkCwdAndTmp(workSpace)
+		So(err, ShouldBeNil)
+		So(reusedCwd, ShouldEqual, finished)
+
+		live := writeFileIn(reusedCwd, "live_output.txt")
+
+		Convey("a run behaviour of the finished run executes in the live run's working directory", func() {
+			err = (&Behaviour{When: OnExit, Do: Run, Arg: "rm -rf ./*"}).Trigger(OnExit, job)
+
+			// nothing of the USER's goes, and the deletion stops at the working
+			// directory the command was pointed at: it is the live run's own
+			// output that this residual costs.
+			soPathsExist(precious, cwd, workSpace, reusedCwd, reusedTmp)
+			soPathsGone(live)
+
+			So(err, ShouldBeNil)
 		})
 	})
 }

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -47,6 +47,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -83,6 +84,13 @@ const (
 	// probeSiblingDigits turns a workspace name into the name os.MkdirTemp would
 	// have given ANOTHER run of the same Job.
 	probeSiblingDigits = "999"
+
+	// probeArabicDigit is the digit three written in Arabic-Indic numerals: a
+	// character unicode calls a digit and os.MkdirTemp never writes.
+	probeArabicDigit = "\u0663"
+
+	// probeRelativeDir is a relative path, which a Job's directories may not be.
+	probeRelativeDir = "relative/cwd"
 )
 
 // probeWorld is the filesystem a (Cwd, ActualCwd) probe runs against: the
@@ -207,6 +215,18 @@ func probeCwdRows() []probeCwdRow {
 			actualCwd: func(w probeWorld) string { return w.actualCwd + "/." },
 			sweptOwn:  true,
 		},
+		{
+			name:      "that path with a doubled separator in it",
+			actualCwd: func(w probeWorld) string { return w.workSpace + "//" + createdCwdName },
+			sweptOwn:  true,
+		},
+		{
+			name: "that path spelled through a component of its own and ..",
+			actualCwd: func(w probeWorld) string {
+				return filepath.Join(w.workSpace, "x", "..", createdCwdName)
+			},
+			sweptOwn: true,
+		},
 
 		// every level of wr's own tree except the working directory itself. Each
 		// is at the wrong depth for the path mkHashedDir builds, and treating one
@@ -219,6 +239,15 @@ func probeCwdRows() []probeCwdRow {
 		{
 			name:      "the workspace holding it",
 			actualCwd: func(w probeWorld) string { return w.workSpace },
+			wantErr:   errNotACreatedCwd,
+		},
+		{
+			// the tmp dir wr made beside the working directory sits at the right
+			// depth below the same workspace, so only its NAME tells the two
+			// apart - and treating it as a working directory would hand the
+			// workspace to the sweep from a Job that reported the wrong sister.
+			name:      "the tmp dir wr made beside it",
+			actualCwd: func(w probeWorld) string { return filepath.Join(w.workSpace, createdTmpName) },
 			wantErr:   errNotACreatedCwd,
 		},
 		{
@@ -257,6 +286,16 @@ func probeCwdRows() []probeCwdRow {
 			actualCwd: func(w probeWorld) string { return w.decoy(probeOtherLeaf) },
 			wantErr:   errNotACreatedCwd,
 		},
+		{
+			// the digits os.MkdirTemp appends are ASCII, and the check spells
+			// that out as a range rather than asking unicode: a name whose
+			// suffix is a digit in another script is a name the user chose.
+			name: "the same leaf with a digit of another script appended",
+			actualCwd: func(w probeWorld) string {
+				return filepath.Join(w.hashed, filepath.Base(w.workSpace)+probeArabicDigit, createdCwdName)
+			},
+			wantErr: errNotACreatedCwd,
+		},
 
 		// ANOTHER run of the same Job, which the path check accepts by design:
 		// the key is what it recognises, and two runs of one key differ only in
@@ -289,6 +328,34 @@ func probeCwdRows() []probeCwdRow {
 			cwd:       func(_ probeWorld) string { return "/" },
 			actualCwd: own,
 			wantErr:   errNotACreatedCwd,
+		},
+		{
+			// Cwd is stored exactly as it was typed, because it feeds Job.Key(),
+			// so an unclean spelling of the right directory is one wr is GIVEN
+			// and must reach the control's verdict.
+			name:      "Cwd with a trailing separator",
+			cwd:       func(w probeWorld) string { return w.cwd + "/" },
+			actualCwd: own,
+			sweptOwn:  true,
+		},
+		{
+			// this code runs in the runner AND in the manager, which have
+			// different working directories, so a relative Cwd names a
+			// different tree in each. Refusing it costs a leaked workspace.
+			name:      "Cwd given as a relative path",
+			cwd:       func(_ probeWorld) string { return probeRelativeDir },
+			actualCwd: own,
+			wantErr:   errNotBelowBaseDir,
+		},
+		{
+			name: "ActualCwd given as a relative path",
+			actualCwd: func(w probeWorld) string {
+				rel, err := filepath.Rel(w.cwd, w.actualCwd)
+				So(err, ShouldBeNil)
+
+				return rel
+			},
+			wantErr: errNotBelowBaseDir,
 		},
 
 		// a blank ActualCwd means wr never learned of a working directory for
@@ -370,6 +437,62 @@ func TestProbeReportedDirectories(t *testing.T) {
 
 		So(err, ShouldBeNil)
 	})
+
+	Convey("A Job refuses the live workspace of another whose key shares its hashed levels", t, func() {
+		// the hashed levels are the first three characters of the key, so two
+		// Jobs whose keys agree there share EVERY directory above their own
+		// workspace: the *_cwd base and all mkHashedLevels-1 of them. Only the
+		// MkdirTemp leaf differs, and that leaf is named for the REST of the
+		// key - so this is the closest two different Jobs of one Cwd can get,
+		// and the one place the leaf check is the only thing left standing.
+		//
+		// Three characters is a 4096-way space that whoever submits a Job can
+		// grind a Cmd through, which is why the check does not stop there.
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		victim := &Job{Cwd: cwd, Cmd: probeCmd + " victim"}
+
+		cleaner := probeJobSharingHashedLevels(cwd, victim)
+		So(cleaner, ShouldNotBeNil)
+
+		victimCwd, victimWorkSpace, victimTmp := realWorkSpace(victim)
+		results := writeFileIn(victimCwd, "results.txt")
+
+		cleanerCwd, _, _ := realWorkSpace(cleaner)
+		So(filepath.Dir(filepath.Dir(cleanerCwd)), ShouldEqual, filepath.Dir(victimWorkSpace))
+
+		cleaner.ActualCwd = victimCwd
+
+		err := (&Behaviour{When: OnExit, Do: CleanupAll}).Trigger(OnExit, cleaner)
+
+		soPathsExist(precious, cwd)
+		soPathsExist(results, victimCwd, victimTmp, victimWorkSpace)
+
+		soProbeRefused(err, errNotACreatedCwd)
+	})
+}
+
+// probeJobSharingHashedLevels finds a Job of the given Cwd whose key starts with
+// the same characters as other's - so mkHashedDir puts its workspace below the
+// very same hashed levels - but which is not the same Job.
+//
+// The Cmd is ground out rather than written down because the key is a hash of
+// it: a literal would stop sharing the levels the moment anything else about
+// what Key() reads changed.
+func probeJobSharingHashedLevels(cwd string, other *Job) *Job {
+	const probeGrindLimit = 1 << 20
+
+	prefix := other.Key()[:mkHashedLevels-1]
+
+	for i := range probeGrindLimit {
+		job := &Job{Cwd: cwd, Cmd: probeCmd + " sharer " + strconv.Itoa(i)}
+		if job.Key()[:mkHashedLevels-1] == prefix && job.Key() != other.Key() {
+			return job
+		}
+	}
+
+	return nil
 }
 
 // soProbeSwept asserts that a directory and the file in it either went or
@@ -452,6 +575,30 @@ func TestProbeCleanupActionsAgree(t *testing.T) {
 				})
 			})
 		}
+	})
+
+	Convey("A hard link into the workspace costs the user a name, not their file", t, func() {
+		// every deletion in the sweep is an unlinkat of one name, so a second
+		// name for a file of the user's - which their own Cmd can make, and
+		// which no check here could tell from an ordinary output file - loses
+		// that name and leaves the file. There is no route by which the sweep
+		// truncates or empties what it unlinks.
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		job := &Job{Cwd: cwd, Cmd: probeCmd, Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}}}
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+		for _, dir := range []string{actualCwd, workSpace, tmpDir} {
+			So(os.Link(precious, filepath.Join(dir, "another_name.txt")), ShouldBeNil)
+		}
+
+		err := job.Behaviours.Trigger(false, job)
+
+		soPathsExist(precious, cwd)
+		soPathsGone(workSpace)
+
+		So(err, ShouldBeNil)
 	})
 }
 
@@ -558,6 +705,17 @@ func probeMountRows() []probeMountRow {
 		{
 			name: "a mount point that IS the workspace, which puts the TMPDIR inside a live mount",
 			mc:   MountConfig{Mount: "..", Targets: probeCachedTargets()},
+			live: []string{".", createdCwdName, createdTmpName},
+			kept: []string{".", createdCwdName, createdTmpName, output, scratch},
+		},
+		{
+			// a mount point ABOVE the workspace puts the workspace inside the
+			// live mount just as surely, and the rule is about being at or above
+			// rather than about being the workspace itself: everything wr made
+			// for the Job is then the user's remote data, read through a mount
+			// Unmount has not got to yet.
+			name: "a mount point at the hashed level above the workspace",
+			mc:   MountConfig{Mount: "../..", Targets: probeCachedTargets()},
 			live: []string{".", createdCwdName, createdTmpName},
 			kept: []string{".", createdCwdName, createdTmpName, output, scratch},
 		},

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1219,6 +1219,29 @@ type probeWindowRow struct {
 	wantErr error
 }
 
+// replaceWithADirOfItsOwn removes dir and leaves an empty directory of its own
+// in its place, one that CANNOT be the directory that was there: the replacement
+// is made while dir still holds its inode, so the freed inode cannot be handed
+// back to it, and it takes dir's name only once dir has gone. A plain remove and
+// recreate guarantees nothing, since ext4 hands the freed inode straight back.
+//
+// It asserts the identity really did change, so an ordering that lets the inode
+// be reused fails here, naming the premise, rather than turning over the
+// expectation of whichever row relied on it.
+func replaceWithADirOfItsOwn(dir string) {
+	checked, err := os.Lstat(dir)
+	So(err, ShouldBeNil)
+
+	spare := dir + "_spare"
+	So(os.MkdirAll(spare, os.ModePerm), ShouldBeNil)
+	So(os.RemoveAll(dir), ShouldBeNil)
+	So(os.Rename(spare, dir), ShouldBeNil)
+
+	now, err := os.Lstat(dir)
+	So(err, ShouldBeNil)
+	So(os.SameFile(now, checked), ShouldBeFalse)
+}
+
 func probeWindowRows() []probeWindowRow {
 	return []probeWindowRow{
 		// the workspace itself, replaced. What was proven is gone, and the
@@ -1289,30 +1312,50 @@ func probeWindowRows() []probeWindowRow {
 		// the hashed level ABOVE the workspace, taken and put back. This is the
 		// ordering two runs of one key really produce: one run's cleanup walks
 		// up removing the empty levels it shares with every other run, and the
-		// next run's mkHashedDir creates them again. The cleanup has nothing
-		// left to delete and must say so quietly, since a workspace that has
-		// gone is the ordinary state of a second cleanup - but the handles it
+		// next run's mkHashedDir creates them again. The handles this cleanup
 		// still holds are on the levels it descended through, not on the ones
-		// that replaced them, and the only thing its upward walk may remove is
-		// an empty directory.
+		// that replaced them, and openChain proves every level it reopens by
+		// inode (proveSameDir), so a level that is there but is not the one
+		// that was checked is not absence: cleanup returns before it empties
+		// anything or walks up anything.
+		//
+		// Both rows below therefore give the replacement level an inode of its
+		// own, and pin that refusal, which is the one of production's three
+		// answers here they can hold it to:
+		//   - the level removed and NOT recreated is absence, so the chain is
+		//     incomplete and cleanup returns nil. That is the quiet case, and
+		//     it is a different window from the one these rows arrange.
+		//   - the level recreated with a DIFFERENT inode is refused, with
+		//     errNotBelowBaseDir. That is what these rows arrange, and the
+		//     survivors are asserted first, so a refusal costs nothing.
+		//   - the level recreated with the SAME inode satisfies the proof, and
+		//     the sweep proceeds as though nothing had changed. ext4 hands a
+		//     freed directory inode straight back to the next mkdir, so that
+		//     is the ordinary outcome of a plain remove-and-recreate, and it is
+		//     a recorded residual rather than something a row can hold
+		//     production to - see "Measured residuals" in
+		//     .docs/cwd_matters_cleanup/readme.md, "os.SameFile is not an
+		//     identity check across delete and recreate".
 		{
 			name: "the hashed level above the workspace is recreated by another run of the same key",
 			inWindow: func(job *Job, _, hashed string) []string {
-				So(os.RemoveAll(hashed), ShouldBeNil)
+				replaceWithADirOfItsOwn(hashed)
 
 				other, err := startProbeRun(job.Cwd, job.Key(), "other")
 				So(err, ShouldBeNil)
 
 				return []string{other.output, other.actualCwd, other.tmpDir, hashed}
 			},
+			wantErr: errNotBelowBaseDir,
 		},
 		{
 			name: "the hashed level above the workspace is recreated holding a tree of the user's",
 			inWindow: func(_ *Job, _, hashed string) []string {
-				So(os.RemoveAll(hashed), ShouldBeNil)
+				replaceWithADirOfItsOwn(hashed)
 
 				return []string{writeFileIn(filepath.Join(hashed, "someone_elses"), probeMineName), hashed}
 			},
+			wantErr: errNotBelowBaseDir,
 		},
 	}
 }

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1004,7 +1004,11 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 					row.setUp(actualCwd, workSpace)
 				}
 
-				remote := probeMountRemote(t, filepath.Join(workSpace, row.mount))
+				remote, mounted := probeMountRemote(t, filepath.Join(workSpace, row.mount))
+				if !mounted {
+					return
+				}
+
 				probeOwnFiles(workSpace, row.own)
 
 				snap := job.workSpaceSnapshot()
@@ -1040,7 +1044,10 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 			}
 			lostCwd, _, lostTmp := realWorkSpace(job)
 
-			remote := probeMountRemote(t, filepath.Join(lostCwd, testWSMount))
+			remote, mounted := probeMountRemote(t, filepath.Join(lostCwd, testWSMount))
+			if !mounted {
+				return
+			}
 
 			pin := job.pinBehaviours()
 
@@ -1102,7 +1109,11 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(reusedCwd, ShouldEqual, finished)
 
-			remote := probeMountRemote(t, filepath.Join(reusedCwd, testWSMount))
+			remote, mounted := probeMountRemote(t, filepath.Join(reusedCwd, testWSMount))
+			if !mounted {
+				return
+			}
+
 			live := writeFileIn(reusedCwd, "live_output.txt")
 
 			snap := job.workSpaceSnapshot()
@@ -1158,7 +1169,7 @@ func probeCanMountFuse() bool {
 // ordinary directory, so what survived can be asserted about directly; muxfys
 // would need an object store to talk to, and the deletion under test does not
 // care which filesystem is mounted, only that a mount gets crossed.
-func probeMountRemote(t *testing.T, mountPoint string) string {
+func probeMountRemote(t *testing.T, mountPoint string) (string, bool) {
 	t.Helper()
 
 	backing := t.TempDir()
@@ -1169,7 +1180,17 @@ func probeMountRemote(t *testing.T, mountPoint string) string {
 	So(os.MkdirAll(mountPoint, os.ModePerm), ShouldBeNil)
 
 	server, err := gofuse.Mount(mountPoint, root, &gofuse.Options{})
-	So(err, ShouldBeNil)
+	if err != nil {
+		// probeCanMountFuse only asks whether /dev/fuse and a fusermount
+		// binary are there. A host can have both and still refuse the mount -
+		// a container without SYS_ADMIN, a restrictive fusermount, a full
+		// /dev/fuse - and a probe that cannot raise its remote proves nothing
+		// either way, so it skips rather than reporting a deletion wr did not
+		// make. workspace_test.go's mountLoopback does the same.
+		t.Logf("this host refused a loopback FUSE mount at %s: %s", mountPoint, err)
+
+		return "", false
+	}
 
 	t.Cleanup(func() {
 		if uerr := server.Unmount(); uerr != nil {
@@ -1177,7 +1198,7 @@ func probeMountRemote(t *testing.T, mountPoint string) string {
 		}
 	})
 
-	return remote
+	return remote, true
 }
 
 // probe counts for the concurrency probes below. They are the smallest that
@@ -1642,7 +1663,11 @@ func TestProbeWorkSpaceOnAnotherFilesystem(t *testing.T) {
 		// workspace, so mounting there puts the whole workspace across the
 		// boundary before the workspace exists.
 		hashed, _ := calculateHashedDir(filepath.Join(cwd, AppName+createdCwdBaseSuffix), job.Key())
-		scratch := probeMountRemote(t, hashed)
+
+		scratch, mounted := probeMountRemote(t, hashed)
+		if !mounted {
+			return
+		}
 
 		actualCwd, workSpace, tmpDir := realWorkSpace(job)
 		output := writeFileIn(actualCwd, "own_output.txt")

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1508,3 +1508,48 @@ func TestProbeV037PoisonedJob(t *testing.T) {
 		}
 	})
 }
+
+func TestProbeWorkSpaceOnAnotherFilesystem(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a workspace wr built on a filesystem mounted inside the Job's Cwd", t, func() {
+		// every deletion is made through an os.Root, and RESOLVE_BENEATH does
+		// not imply RESOLVE_NO_XDEV, so nothing in wr asks whether a path
+		// crosses a mount boundary. A Cwd with fast scratch mounted somewhere
+		// below it is ordinary on the shared filesystems jobs run on, and the
+		// hashed levels are exactly where such a mount would be: the sweep then
+		// works entirely on the other filesystem, and the upward walk arrives at
+		// the mount point itself.
+		if !probeCanMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		cwd := t.TempDir()
+		precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+		job := &Job{Cwd: cwd, Cmd: probeCmd, Behaviours: Behaviours{{When: OnExit, Do: CleanupAll}}}
+
+		// the deepest hashed level is where mkHashedDir will put this Job's
+		// workspace, so mounting there puts the whole workspace across the
+		// boundary before the workspace exists.
+		hashed, _ := calculateHashedDir(filepath.Join(cwd, AppName+createdCwdBaseSuffix), job.Key())
+		scratch := probeMountRemote(t, hashed)
+
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+		output := writeFileIn(actualCwd, "own_output.txt")
+
+		err := job.Behaviours.Trigger(false, job)
+
+		// the file of the user's on the OTHER filesystem is beside the
+		// workspace, so only the upward walk could reach it - and that walk
+		// removes empty directories, which the mount point is not.
+		soPathsExist(scratch, precious, cwd, hashed)
+		soPathsGone(output, actualCwd, tmpDir, workSpace)
+
+		So(err, ShouldBeNil)
+	})
+}

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1228,14 +1228,34 @@ func probeWindowRows() []probeWindowRow {
 			// be one: a stale ActualCwd naming a workspace since handed out
 			// again is indistinguishable by path (the "another run of the same
 			// job" row), but a workspace this cleanup PROVED and then lost is
-			// not - the inode of the dir that was checked says so.
+			// told apart by the inode of the dir that was checked - PROVIDED
+			// the replacement got an inode of its own, which is why the other
+			// run is minted while this workspace still holds its own, and moved
+			// onto its name only afterwards. Freeing the name first would not
+			// guarantee it: ext4 hands a freed directory inode straight back to
+			// the next mkdir, and a replacement given the proven inode
+			// satisfies proveSameDir, so the sweep proceeds and takes the live
+			// run's output with it. That case is a recorded residual, not
+			// something this row can hold production to - see "Measured
+			// residuals" in .docs/cwd_matters_cleanup/readme.md, "os.SameFile
+			// is not an identity check across delete and recreate".
 			name: "another run of the same key is handed this workspace's name",
-			inWindow: func(_ *Job, workSpace, _ string) []string {
-				So(os.RemoveAll(workSpace), ShouldBeNil)
-				So(os.MkdirAll(workSpace, os.ModePerm), ShouldBeNil)
-
-				reusedCwd, reusedTmp, err := mkCwdAndTmp(workSpace)
+			inWindow: func(job *Job, workSpace, _ string) []string {
+				checked, err := os.Lstat(workSpace)
 				So(err, ShouldBeNil)
+
+				otherCwd, otherTmp, err := mkHashedDir(job.Cwd, job.Key())
+				So(err, ShouldBeNil)
+
+				So(os.RemoveAll(workSpace), ShouldBeNil)
+				So(os.Rename(filepath.Dir(otherCwd), workSpace), ShouldBeNil)
+
+				now, err := os.Lstat(workSpace)
+				So(err, ShouldBeNil)
+				So(os.SameFile(now, checked), ShouldBeFalse)
+
+				reusedCwd := filepath.Join(workSpace, filepath.Base(otherCwd))
+				reusedTmp := filepath.Join(workSpace, filepath.Base(otherTmp))
 
 				return []string{
 					writeFileIn(reusedCwd, "live_output.txt"), reusedCwd, reusedTmp, workSpace,

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -73,6 +73,11 @@ const (
 	probeOtherLeaf = "user's own"
 	probeDigits    = "0123456789"
 
+	// probeCacheLink is the name of a symlink a mount config spells a cache
+	// location through, and probeRealCache the dir it leads to.
+	probeCacheLink = "clink"
+	probeRealCache = "realcache"
+
 	// probeSiblingDigits turns a workspace name into the name os.MkdirTemp would
 	// have given ANOTHER run of the same Job.
 	probeSiblingDigits = "999"
@@ -344,11 +349,11 @@ func TestProbeReportedDirectories(t *testing.T) {
 		// the symlink on one side only would refuse every such Job, silently
 		// leaking a workspace per run.
 		base := t.TempDir()
-		real := filepath.Join(base, "real")
-		So(os.MkdirAll(real, os.ModePerm), ShouldBeNil)
+		realCwd := filepath.Join(base, "real")
+		So(os.MkdirAll(realCwd, os.ModePerm), ShouldBeNil)
 
 		link := filepath.Join(base, "cwd_link")
-		So(os.Symlink(real, link), ShouldBeNil)
+		So(os.Symlink(realCwd, link), ShouldBeNil)
 
 		precious := writeFileIn(filepath.Join(base, "user_scripts"), probeMineName)
 
@@ -358,7 +363,7 @@ func TestProbeReportedDirectories(t *testing.T) {
 
 		err := (&Behaviour{When: OnExit, Do: CleanupAll}).Trigger(OnExit, job)
 
-		soPathsExist(precious, real, link)
+		soPathsExist(precious, realCwd, link)
 		soPathsGone(output, actualCwd, tmpDir, workSpace)
 
 		So(err, ShouldBeNil)
@@ -421,7 +426,7 @@ type probeMountRow struct {
 // probeCachedTargets is a writable cached mount target, for which muxfys chooses
 // a cache dir of its own inside whatever CacheBase it was given.
 func probeCachedTargets() []MountTarget {
-	return []MountTarget{{Path: "bucket/sub", Cache: true, Write: true}}
+	return []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}}
 }
 
 // probeSymlink replaces link with a symlink to target.
@@ -433,7 +438,7 @@ func probeMountRows() []probeMountRow {
 	const (
 		output  = createdCwdName + "/own_output.txt"
 		scratch = createdTmpName + "/scratch.txt"
-		mount   = "mnt"
+		mount   = testWSMount
 	)
 
 	return []probeMountRow{
@@ -466,7 +471,7 @@ func probeMountRows() []probeMountRow {
 		{
 			name: "an explicit CacheDir inside the job's TMPDIR",
 			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
-				Path: "bucket/sub", CacheDir: createdTmpName + "/c", Write: true,
+				Path: testWSTargetPath, CacheDir: createdTmpName + "/c", Write: true,
 			}}},
 			live: []string{createdCwdName + "/" + mount, createdTmpName + "/c"},
 			kept: []string{".", createdCwdName, createdTmpName, scratch},
@@ -480,9 +485,9 @@ func probeMountRows() []probeMountRow {
 		{
 			name: "a mount point and a cache dir above the workspace",
 			mc: MountConfig{Mount: "../../up", Targets: []MountTarget{{
-				Path: "bucket/sub", CacheDir: "..", Write: true,
+				Path: testWSTargetPath, CacheDir: "..", Write: true,
 			}}},
-			live: []string{"../up", "../bucket/sub"},
+			live: []string{"../up", "../" + testWSTargetPath},
 			kept: []string{".."},
 			gone: []string{".", createdCwdName, createdTmpName, output, scratch},
 		},
@@ -503,30 +508,30 @@ func probeMountRows() []probeMountRow {
 		// physically in - the one a sweep would recurse into.
 		{
 			name: "a muxfys CacheBase spelled through a symlink inside the working dir",
-			mc:   MountConfig{Mount: mount, CacheBase: "clink", Targets: probeCachedTargets()},
+			mc:   MountConfig{Mount: mount, CacheBase: probeCacheLink, Targets: probeCachedTargets()},
 			setUp: func(actualCwd, _ string) {
-				So(os.MkdirAll(filepath.Join(actualCwd, "realcache"), os.ModePerm), ShouldBeNil)
-				probeSymlink("realcache", filepath.Join(actualCwd, "clink"))
+				So(os.MkdirAll(filepath.Join(actualCwd, probeRealCache), os.ModePerm), ShouldBeNil)
+				probeSymlink(probeRealCache, filepath.Join(actualCwd, probeCacheLink))
 			},
 			live: []string{
-				createdCwdName + "/realcache/" + probeMuxfysDir, createdCwdName + "/" + mount,
+				createdCwdName + "/" + probeRealCache + "/" + probeMuxfysDir, createdCwdName + "/" + mount,
 			},
-			kept: []string{".", createdCwdName, createdCwdName + "/realcache"},
+			kept: []string{".", createdCwdName, createdCwdName + "/" + probeRealCache},
 			// the symlink itself is not a dir, so the sweep unlinks it: what had
 			// to be recognised is the dir it led to, which is where the cache is.
-			gone: []string{output, createdCwdName + "/clink", createdTmpName, scratch},
+			gone: []string{output, createdCwdName + "/" + probeCacheLink, createdTmpName, scratch},
 		},
 		{
 			name: "an explicit CacheDir spelled through a symlink inside the workspace",
 			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
-				Path: "bucket/sub", CacheDir: "clink", Write: true,
+				Path: testWSTargetPath, CacheDir: probeCacheLink, Write: true,
 			}}},
 			setUp: func(_, workSpace string) {
-				So(os.MkdirAll(filepath.Join(workSpace, "realcache"), os.ModePerm), ShouldBeNil)
-				probeSymlink("realcache", filepath.Join(workSpace, "clink"))
+				So(os.MkdirAll(filepath.Join(workSpace, probeRealCache), os.ModePerm), ShouldBeNil)
+				probeSymlink(probeRealCache, filepath.Join(workSpace, probeCacheLink))
 			},
-			live: []string{"realcache/bucket/sub", createdCwdName + "/" + mount},
-			kept: []string{".", createdCwdName, "realcache", "clink"},
+			live: []string{probeRealCache + "/" + testWSTargetPath, createdCwdName + "/" + mount},
+			kept: []string{".", createdCwdName, probeRealCache, probeCacheLink},
 			gone: []string{output, createdTmpName, scratch},
 		},
 	}

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -866,7 +866,7 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 			job.ActualCwd = retry.actualCwd
 			job.Unlock()
 
-			err = pin.trigger(false)
+			err = pin.trigger()
 
 			soPathsExist(remote)
 			soPathsExist(filepath.Join(lostCwd, testWSMount, probeRemoteName))

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -70,20 +70,14 @@ const (
 	// itself inside whatever CacheBase it was given.
 	probeMuxfysDir = muxfysCachePrefix + "_cache123"
 
-	// probeBareLeaf and probeOtherLeaf name the two decoy dirs of probeWorld,
-	// and probeDigits is what os.MkdirTemp appends to a name it chooses.
+	// probeBareLeaf and probeOtherLeaf name the two decoy dirs of probeWorld.
 	probeBareLeaf  = "bare prefix"
 	probeOtherLeaf = "user's own"
-	probeDigits    = "0123456789"
 
 	// probeLinkName is the name of a symlink a mount config spells a mount point
 	// or a cache location through, and probeRealDir the dir it leads to.
 	probeLinkName = "link"
 	probeRealDir  = "real"
-
-	// probeSiblingDigits turns a workspace name into the name os.MkdirTemp would
-	// have given ANOTHER run of the same Job.
-	probeSiblingDigits = "999"
 
 	// probeArabicDigit is the digit three written in Arabic-Indic numerals: a
 	// character unicode calls a digit and os.MkdirTemp never writes.
@@ -114,17 +108,19 @@ type probeWorld struct {
 	tmpDir string
 
 	// decoys are directories of the USER's, beside the Job's own workspace and
-	// named the two ways a name os.MkdirTemp chose can be mis-recognised: the
-	// bare prefix wr would have used had it not needed a unique dir, and a name
-	// of the user's own at the same depth. Whoever submits the Job picks the Cmd
-	// that Key() hashes, so they can put a directory at either.
+	// named the two ways the unique name wr minted can be mis-recognised: the
+	// bare prefix wr would have used had it not needed a unique dir, ie. that
+	// prefix with an EMPTY suffix, and a name of the user's own at the same
+	// depth. Whoever submits the Job picks the Cmd that Key() hashes, so they
+	// can put a directory at either.
 	decoys map[string]string
 
 	// output is this run's own file, which cleanup IS entitled to delete.
 	output string
 
-	// sibling is another run of the same Job, differing only in the digits
-	// os.MkdirTemp chose, and siblingFile its live output.
+	// sibling is the working directory mkHashedDir made for ANOTHER run of the
+	// same Job, so it differs from this run's only in the unique suffix wr chose
+	// for it, and siblingFile is its live output.
 	sibling     string
 	siblingFile string
 
@@ -151,13 +147,29 @@ func seedProbeWorld(t *testing.T, job *Job) probeWorld {
 	w.actualCwd, w.workSpace, w.tmpDir = realWorkSpace(job)
 	w.base = filepath.Join(w.cwd, AppName+createdCwdBaseSuffix)
 	w.hashed = filepath.Dir(w.workSpace)
+
+	// the prefix comes from calculateHashedDir, the helper both mkHashedDir and
+	// the guard ask, so the bare-prefix decoy is the prefix with an EMPTY suffix
+	// however wr spells the suffix it adds. Deriving it from the workspace name
+	// instead cannot: the prefix is hex, so trimming the suffix off by character
+	// class eats into it.
+	hashed, bare := calculateHashedDir(w.base, job.Key())
+	So(hashed, ShouldEqual, w.hashed)
+
 	w.decoys = map[string]string{
-		probeBareLeaf:  strings.TrimRight(filepath.Base(w.workSpace), probeDigits),
+		probeBareLeaf:  bare,
 		probeOtherLeaf: "zzzz1234",
 	}
 
-	for _, leaf := range w.decoys {
-		w.mine = append(w.mine, writeFileIn(filepath.Join(w.hashed, leaf, createdCwdName), probeMineName))
+	// the real workspace is that same prefix plus the unique suffix wr chose, so
+	// the two names differ in the suffix ALONE - which is what makes the row
+	// fed by this decoy a test of the empty suffix rather than of a name that
+	// merely resembles the prefix.
+	So(filepath.Base(w.workSpace), ShouldStartWith, w.decoys[probeBareLeaf])
+	So(filepath.Base(w.workSpace), ShouldNotEqual, w.decoys[probeBareLeaf])
+
+	for _, name := range w.decoys {
+		w.mine = append(w.mine, writeFileIn(filepath.Join(w.hashed, name, createdCwdName), probeMineName))
 	}
 
 	for _, dir := range []string{
@@ -168,7 +180,14 @@ func seedProbeWorld(t *testing.T, job *Job) probeWorld {
 		w.mine = append(w.mine, writeFileIn(dir, probeMineName))
 	}
 
-	w.sibling = filepath.Join(w.workSpace+probeSiblingDigits, createdCwdName)
+	// the sibling is minted by asking production for a second workspace of the
+	// SAME key, which is exactly what a second run does, rather than by building
+	// a name of the shape one is expected to have.
+	sibling, _, err := mkHashedDir(job.Cwd, job.Key())
+	So(err, ShouldBeNil)
+	So(sibling, ShouldNotEqual, w.actualCwd)
+
+	w.sibling = sibling
 	w.siblingFile = writeFileIn(w.sibling, "other_run.txt")
 	w.output = writeFileIn(w.actualCwd, "own_output.txt")
 

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -436,9 +436,9 @@ func probeSymlink(target, link string) {
 
 func probeMountRows() []probeMountRow {
 	const (
-		output  = createdCwdName + "/own_output.txt"
-		scratch = createdTmpName + "/scratch.txt"
-		mount   = testWSMount
+		output   = createdCwdName + "/own_output.txt"
+		scratch  = createdTmpName + "/scratch.txt"
+		mountDir = testWSMount
 	)
 
 	return []probeMountRow{
@@ -462,18 +462,18 @@ func probeMountRows() []probeMountRow {
 		{
 			name: "a muxfys CacheBase inside the job's TMPDIR",
 			mc: MountConfig{
-				Mount: mount, CacheBase: "../" + createdTmpName, Targets: probeCachedTargets(),
+				Mount: mountDir, CacheBase: "../" + createdTmpName, Targets: probeCachedTargets(),
 			},
-			live: []string{createdCwdName + "/" + mount, createdTmpName + "/" + probeMuxfysDir},
+			live: []string{createdCwdName + "/" + mountDir, createdTmpName + "/" + probeMuxfysDir},
 			kept: []string{".", createdCwdName, createdTmpName, scratch},
 			gone: []string{output},
 		},
 		{
 			name: "an explicit CacheDir inside the job's TMPDIR",
-			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
+			mc: MountConfig{Mount: mountDir, Targets: []MountTarget{{
 				Path: testWSTargetPath, CacheDir: createdTmpName + "/c", Write: true,
 			}}},
-			live: []string{createdCwdName + "/" + mount, createdTmpName + "/c"},
+			live: []string{createdCwdName + "/" + mountDir, createdTmpName + "/c"},
 			kept: []string{".", createdCwdName, createdTmpName, scratch},
 			gone: []string{output},
 		},
@@ -508,13 +508,13 @@ func probeMountRows() []probeMountRow {
 		// physically in - the one a sweep would recurse into.
 		{
 			name: "a muxfys CacheBase spelled through a symlink inside the working dir",
-			mc:   MountConfig{Mount: mount, CacheBase: probeCacheLink, Targets: probeCachedTargets()},
+			mc:   MountConfig{Mount: mountDir, CacheBase: probeCacheLink, Targets: probeCachedTargets()},
 			setUp: func(actualCwd, _ string) {
 				So(os.MkdirAll(filepath.Join(actualCwd, probeRealCache), os.ModePerm), ShouldBeNil)
 				probeSymlink(probeRealCache, filepath.Join(actualCwd, probeCacheLink))
 			},
 			live: []string{
-				createdCwdName + "/" + probeRealCache + "/" + probeMuxfysDir, createdCwdName + "/" + mount,
+				createdCwdName + "/" + probeRealCache + "/" + probeMuxfysDir, createdCwdName + "/" + mountDir,
 			},
 			kept: []string{".", createdCwdName, createdCwdName + "/" + probeRealCache},
 			// the symlink itself is not a dir, so the sweep unlinks it: what had
@@ -523,14 +523,14 @@ func probeMountRows() []probeMountRow {
 		},
 		{
 			name: "an explicit CacheDir spelled through a symlink inside the workspace",
-			mc: MountConfig{Mount: mount, Targets: []MountTarget{{
+			mc: MountConfig{Mount: mountDir, Targets: []MountTarget{{
 				Path: testWSTargetPath, CacheDir: probeCacheLink, Write: true,
 			}}},
 			setUp: func(_, workSpace string) {
 				So(os.MkdirAll(filepath.Join(workSpace, probeRealCache), os.ModePerm), ShouldBeNil)
 				probeSymlink(probeRealCache, filepath.Join(workSpace, probeCacheLink))
 			},
-			live: []string{probeRealCache + "/" + testWSTargetPath, createdCwdName + "/" + mount},
+			live: []string{probeRealCache + "/" + testWSTargetPath, createdCwdName + "/" + mountDir},
 			kept: []string{".", createdCwdName, probeRealCache, probeCacheLink},
 			gone: []string{output, createdTmpName, scratch},
 		},

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -397,6 +397,64 @@ func soProbeRefused(err error, wantErr error) {
 	So(errors.Is(err, wantErr), ShouldBeTrue)
 }
 
+// probeCleanupActionRow is one of the two BehaviourActions that sweep a Job's
+// workspace. Behaviour.trigger has an arm of its own for each, and the doc on
+// CleanupAll reserves it the reach Cleanup gives up once output files can be
+// designated - so the two arms are one place a future divergence would land,
+// and the poisoned database records of the original file loss carried
+// cleanup_all.
+//
+// Each row asks the same two questions of one action, so an arm that stopped
+// going through the workspace licence shows up as the answer changing for one
+// action and not the other.
+type probeCleanupActionRow struct {
+	name string
+	do   BehaviourAction
+}
+
+func probeCleanupActionRows() []probeCleanupActionRow {
+	return []probeCleanupActionRow{
+		{name: "cleanup", do: Cleanup},
+		{name: "cleanup_all", do: CleanupAll},
+	}
+}
+
+func TestProbeCleanupActionsAgree(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given the workspace wr really made and the user's files all around it", t, func() {
+		for _, row := range probeCleanupActionRows() {
+			Convey("an on_exit "+row.name, func() {
+				job := &Job{Cmd: probeCmd, Behaviours: Behaviours{{When: OnExit, Do: row.do}}}
+				w := seedProbeWorld(t, job)
+
+				Convey("sweeps this run's own workspace and nothing else", func() {
+					err := job.Behaviours.Trigger(false, job)
+
+					soPathsExist(w.mine...)
+					soPathsExist(w.cwd, w.siblingFile, w.sibling)
+					soPathsGone(w.output, w.actualCwd, w.tmpDir)
+
+					So(err, ShouldBeNil)
+				})
+
+				Convey("refuses a dir of the user's at the workspace leaf's bare prefix", func() {
+					job.ActualCwd = w.decoy(probeBareLeaf)
+
+					err := job.Behaviours.Trigger(false, job)
+
+					soPathsExist(w.mine...)
+					soPathsExist(w.cwd, w.output, w.actualCwd, w.tmpDir)
+
+					soProbeRefused(err, errNotACreatedCwd)
+				})
+			})
+		}
+	})
+}
+
 // probeMountRow is one MountConfig shape, with the directories mounting it
 // really puts a live mount point or an un-uploaded cache in.
 //
@@ -696,6 +754,42 @@ func probeFuseRows() []probeFuseRow {
 			// to be recognised is the dir it led to, which is where the mount is.
 			gone: []string{output, createdCwdName + "/" + probeLinkName, createdTmpName, scratch},
 		},
+		{
+			// removeAllExcept's keep-before-check ordering. A dir that must
+			// survive AND is on the way to a deeper dir that must survive is both
+			// an exception and a dir to recurse into, and only keeping it whole is
+			// safe: recursing into a live mount to reach something deeper reads it
+			// through the mount and deletes every entry of the user's remote data
+			// that is not the deeper thing itself.
+			name: "a live mount inside the working directory with a cache dir configured inside it",
+			mc: MountConfig{Mount: testWSMount, Targets: []MountTarget{{
+				Path: testWSTargetPath, CacheDir: createdCwdName + "/" + testWSMount + "/c", Write: true,
+			}}},
+			mount: cwdMount,
+			own:   []string{output, scratch},
+			kept:  []string{".", createdCwdName, cwdMount},
+			gone:  []string{output, createdTmpName, scratch},
+		},
+		{
+			// keptDirs.wholeWorkSpace, honoured by BOTH sweeps. A CacheDir that IS
+			// the workspace makes the workspace root where the live mount's output
+			// waits for Unmount to upload it, under names only the remote knows, so
+			// nothing wr made there is wr's to delete: not the job's own results,
+			// and not the TMPDIR the runner reclaims on every exit.
+			//
+			// A mount point at the workspace cannot reach this rule the same way: a
+			// real mount needs an empty mount point, and mkCwdAndTmp has already
+			// filled the workspace by the time a run mounts.
+			name: "a live mount whose cache dir IS the workspace, so nothing there may go",
+			mc: MountConfig{Mount: testWSMount, Targets: []MountTarget{{
+				Path: testWSTargetPath, CacheDir: ".", Write: true,
+			}}},
+			mount: cwdMount,
+			own:   []string{output, scratch},
+			kept: []string{
+				".", createdCwdName, createdTmpName, cwdMount, output, scratch,
+			},
+		},
 	}
 }
 
@@ -740,6 +834,89 @@ func TestProbeLiveFuseMounts(t *testing.T) {
 				So(tmpErr, ShouldBeNil)
 			})
 		}
+
+		Convey("the manager's own route keeps the mount of the run it pinned", func() {
+			// the manager reaches the same deletion code as the runner, but
+			// through a PIN taken when it declared the job lost, and by the time
+			// that pin triggers the very same *Job can be a live retry, with the
+			// retry's own working directory written onto it by a Touch. So both
+			// halves of what the sweep may do are named by the pin: the workspace
+			// it deletes, and the live mount of the user's remote data inside that
+			// workspace which it must not delete through.
+			cwd := t.TempDir()
+			precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+			job := &Job{
+				Cwd: cwd, Cmd: probeCmd,
+				MountConfigs: MountConfigs{{Mount: testWSMount, Targets: probeCachedTargets()}},
+				Behaviours:   Behaviours{{When: OnExit, Do: CleanupAll}},
+			}
+			lostCwd, _, lostTmp := realWorkSpace(job)
+
+			remote := probeMountRemote(t, filepath.Join(lostCwd, testWSMount))
+
+			pin := job.pinBehaviours()
+
+			abandoned := writeFileIn(lostCwd, "abandoned.txt")
+
+			retry, err := startProbeRun(cwd, job.Key(), "retry")
+			So(err, ShouldBeNil)
+
+			job.Lock()
+			job.ActualCwd = retry.actualCwd
+			job.Unlock()
+
+			err = pin.trigger(false)
+
+			soPathsExist(remote)
+			soPathsExist(filepath.Join(lostCwd, testWSMount, probeRemoteName))
+			soPathsExist(retry.output, retry.actualCwd, retry.tmpDir)
+			soPathsExist(precious, cwd)
+			soPathsGone(abandoned, lostTmp)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("a run handed a workspace name an earlier run finished with keeps its mount", func() {
+			// os.MkdirTemp's digits are not pinned to a run, so the name one
+			// manager's run finished with is free for another manager's run of the
+			// SAME key to be handed later, and a stale ActualCwd then names a live
+			// workspace byte for byte. Nothing about the path can tell the two
+			// apart - the residual the "another run of the same job" row records -
+			// but the two are one job by key, so they mount the same remote at the
+			// same place, and the stale run's own keep set still names it. The
+			// local workspace goes; the user's remote data does not.
+			cwd := t.TempDir()
+			precious := writeFileIn(filepath.Join(cwd, "user_scripts"), probeMineName)
+
+			job := &Job{
+				Cwd: cwd, Cmd: probeCmd,
+				MountConfigs: MountConfigs{{Mount: testWSMount, Targets: probeCachedTargets()}},
+			}
+			finished, workSpace, _ := realWorkSpace(job)
+
+			So(os.RemoveAll(workSpace), ShouldBeNil)
+			So(os.MkdirAll(workSpace, os.ModePerm), ShouldBeNil)
+
+			reusedCwd, reusedTmp, err := mkCwdAndTmp(workSpace)
+			So(err, ShouldBeNil)
+			So(reusedCwd, ShouldEqual, finished)
+
+			remote := probeMountRemote(t, filepath.Join(reusedCwd, testWSMount))
+			live := writeFileIn(reusedCwd, "live_output.txt")
+
+			snap := job.workSpaceSnapshot()
+			cleanErr := snap.cleanupWorkSpace()
+			tmpErr := snap.removeTmpDir()
+
+			soPathsExist(remote)
+			soPathsExist(filepath.Join(reusedCwd, testWSMount, probeRemoteName))
+			soPathsExist(precious, cwd, workSpace, reusedCwd)
+			soPathsGone(live, reusedTmp)
+
+			So(cleanErr, ShouldBeNil)
+			So(tmpErr, ShouldBeNil)
+		})
 	})
 }
 


### PR DESCRIPTION
Several rounds of adversarial probing have attacked wr's deletion guards and recorded, in prose, which routes were refused and by which guard. Prose cannot fail. This turns those refusals into tests, so they are both the proof and a regression guard, and so future probing does not re-derive the same ground.

One new file, `jobqueue/deletion_probes_test.go`. Tests only — no production code changes. Four table-driven tests, 29 cases, built on the package's existing fixtures and helpers rather than new copies. A comment at the top says what the file is for and that new probe attempts belong there as a row.

**Every case is provably able to fail.** 15 mutations were applied to production code, each confirmed to still compile with `go vet` (a build failure reports zero failing assertions and looks exactly like a dead guard), and each run to see which cases went red:

| Guard mutated | Cases that went red |
| --- | --- |
| `relIsJobCreatedCwd` depth check loosened | one level deeper, still called cwd |
| whole identity check bypassed | 11 rows, including the workspace, the hashed level, the `_cwd` base and both decoy leaves |
| `isMkTempName` always true / always false | the bare-prefix and own-leaf-name rows / 14 rows including all 8 mount shapes |
| `relIsBelow` in `createdCwdRel` removed | `ActualCwd` named through `/proc/self/cwd` |
| blank-`ActualCwd` early return removed | blank `ActualCwd`, and one `wr mod` route |
| `openBaseRoot` made to resolve Cwd | the symlinked-Cwd case |
| `removeTmp`'s keep-set checks removed | all four TMPDIR mount/cache rows |
| upward walk changed to `RemoveAll` | 7 cases including both concurrency probes |
| resolved spelling dropped from `relsBelowDirResolved` | both symlink-spelled cache rows |
| `applyTo`'s key-change clear, `dropImpossibleCleanups`, `absJobDir`'s `Clean` | the corresponding `wr mod` and trailing-slash rows |

Cases that could not be made to fail were dropped rather than kept for appearance — doubled separators and `/./` mid-path (Go normalises them identically with or without wr's `Clean`), a tilde in `Mount` (no code expands it), and a final symlink before deletion (neither `os.Root.RemoveAll` nor `os.RemoveAll` follows one, so nothing can be neutered).

Roughly two thirds of the corpus was already pinned by existing tests and is not duplicated here — the report on the branch lists which attack maps to which existing test. What is newly pinned includes: every level of wr's own tree reported as the working directory; user directories at the leaf's bare `MkdirTemp` prefix and at a leaf name of their own; another run of the same key; a Cwd that is itself a symlink; mount points and caches in or at the job's TMPDIR (`removeTmpDir`'s keep set had no coverage at all); a mount at the workspace putting TMPDIR inside a live mount; caches spelled through a symlink inside the swept tree; concurrent and same-key cleanups beside a live sibling run; and the v0.37.0/1 poisoned job through two `wr mod` routes, in the original incident's own path shape.

Cost: 0.056s added, 1.12s under `-race`. No `internal/testsuite/planner.go` change needed — the tests run in the default lane.

`make test` and `make race` both 424 passed / 9 skipped (develop's 420 plus these four test functions); `make lint` 0 issues.
