### PR TITLE
Fix a job archiving as a success when its output failed to upload

### DIFF
--- a/.docs/bugfixes/260902-6.md
+++ b/.docs/bugfixes/260902-6.md
@@ -1,0 +1,270 @@
+# Bugfixes 260902-6
+
+Branch `fix-silent-upload-failure`: a job whose command exited 0 but whose
+output failed to upload at unmount was archived as a clean success. The output
+was gone - muxfys deletes the write cache at unmount whether or not the upload
+worked - and `wr status` reported `state=complete exitcode=0 failreason=""`.
+This is the worst class of bug in wr: data lost, reported as success.
+
+## Where this came from
+
+A read of `Client.Execute`'s ending, following the `FailReasonUpload` constant
+(jobqueue/client.go:88), which was declared and referenced nowhere else in the
+repository. A constant that is only declared is either dead or a dropped
+assignment; this one was a dropped assignment.
+
+## The mechanism
+
+Measured at the branch point, `e8c3e55a`:
+
+1. `job.Unmount()` (jobqueue/client.go:2171) uploads a writable muxfys mount's
+   created files. On failure the handling at 2173-2177 set `dorelease = true`,
+   so the job would be released and tried again.
+2. `classifyExecOutcome` was called at 2210 and its result assigned field by
+   field at 2227-2230:
+
+   ```go
+   dobury = outcome.dobury
+   dorelease = outcome.dorelease
+   failreason = outcome.failreason
+   myerr = outcome.myerr
+   ```
+
+   For a command that exited 0, `classifyExecOutcome` returns a bare
+   `execOutcome{doarchive: true}`. So `dorelease` went back to false,
+   `failreason` back to `""`, and `myerr` - which had the unmount error and any
+   behaviour error folded into it at 2165/2179 - was thrown away. `doarchive`
+   won the `switch` in `applyFinalState`, and the job archived.
+3. Nothing else was holding the data. muxfys `Unmount` deletes every temporary
+   cache dir after attempting the upload, regardless of the result
+   (muxfys.go:484-495 -> `remote.deleteCache` -> `os.RemoveAll(r.cacheDir)`,
+   remote.go:474-478).
+
+So a network blip, an expired credential or a full bucket at unmount lost the
+whole job's output and the job archived clean.
+
+## It is a regression, in two steps
+
+`git show 69ab3075^:jobqueue/client.go` (pre-#534) at the same place:
+
+```go
+	if strings.Contains(unmountErr.Error(), "failed to upload") {
+		if !dobury {
+			dorelease = true
+		}
+		if failreason == "" {
+			failreason = FailReasonUpload
+		}
+		if exitcode == 0 {
+			exitcode = -2
+		}
+	}
+```
+
+and the `err == nil` branch of the classification only set `exitcode`,
+`doarchive` and `myerr` - it did not touch `dorelease` or `failreason`. The
+final `switch` tried `dobury`, then `dorelease`, then `doarchive`, so
+`dorelease` beat `doarchive` and the job was released with
+`FailReasonUpload`. #534 (69ab3075, "Modernise") replaced those per-field
+assignments with a whole-struct overwrite, which is what loses the data.
+
+Two dead branches in the same code have an older cause. At b640230a (2017,
+"Fix upload failures never getting buried: now get exit code -2") the
+classification ran BEFORE the unmount, so `addMountLogs := dobury || dorelease`
+and `if (dobury || dorelease) && berr != nil` both saw the command's verdict,
+and `if exitcode == 0 { exitcode = -2 }` was reachable. #461 (24b53ea7,
+2024-08-28, "Add option to have runners log to files") moved the classification
+to AFTER the unmount. From then on:
+
+- `addMountLogs` was computed while `dobury`/`dorelease` were still false from
+  their declarations, so it was ALWAYS false and mount logs never reached any
+  job's stderr.
+- `(dobury || dorelease) && berr != nil` was false unless an upload failure and
+  a behaviour error coincided, which is why a failing `cleanup` or `run`
+  behaviour on an otherwise successful job was reported nowhere.
+- `exitcode = -2` was dead, because the `err == nil` branch reassigned
+  `exitcode` from the wait status straight afterwards.
+
+The bisect over `jobqueue/client.go`'s history (comparing the line of
+`addMountLogs :=` with the line of `// the command worked fine`) puts the
+flip between 35fe245a (2022-07-28, classification first) and 24b53ea7
+(2024-08-28, unmount first).
+
+## The end-to-end demonstration
+
+Real minio in docker on port 9112, a real writable FUSE mount, a real spawned
+runner, from the parked harness `TestProbeWritableMountUploadFailure` (not
+committed). The job writes `precious-output` to `mnt/out.txt`, then stops the
+minio container so the upload at unmount cannot work, then exits 0.
+
+Before, at `e8c3e55a`:
+
+```
+probe upload: cmd exit tail " && exit 0"
+probe upload: state=complete exitcode=0 failreason=""
+probe upload: stderr=""
+probe upload: objects in the bucket: []
+probe upload: cache dirs left: []
+probe upload: files left in the mount point: []
+PROBE FINDING: out.txt is gone from the bucket, the cache and the mount point
+```
+
+A/B control, the same job with a trailing `exit 1` instead of `exit 0`:
+
+```
+probe upload: state=buried exitcode=1 failreason="command exited non-zero"
+```
+
+so the only thing standing between the user and a silent loss was the
+command's own exit code.
+
+After the fix:
+
+```
+probe upload: cmd exit tail " && exit 0"
+probe upload: state=buried exitcode=-2 failreason="failed to upload files to remote file system"
+probe upload: stderr="\n\nMount logs:\nt=... lvl=eror msg=\"Remote call failed\" pkg=muxfys
+  mount=.../cwd/mnt target=http://127.0.0.1:9112/wrprobe call=UploadFile path=out.txt
+  retries=1 err=\"Put \\\"http://127.0.0.1:9112/wrprobe/out.txt\\\": dial tcp
+  127.0.0.1:9112: connect: connection refused\""
+```
+
+`buried` rather than `delayed` because the harness's job has `Retries: 0`, so
+the release buries immediately. The mount logs, dead since #461, now name the
+object and the reason.
+
+## The fix
+
+Shape (a), stop discarding, in `jobqueue/client.go`:
+
+- [x] The pre-classification state is now one `execOutcome` value,
+  `unmountOutcome`, instead of loose `dobury`/`dorelease`/`failreason`
+  variables. It reuses the existing type, so no new type was added.
+- [x] An upload failure fills it in completely -
+  `dorelease`, `failreason: FailReasonUpload`, `exitcode:
+  exitCodeUploadFailure` (-2, restored as a named constant) - and the
+  accumulated `myerr` is attached to it.
+- [x] `combineExecOutcomes(unmount, cmd)` folds the two: the command's own
+  failure keeps its fail reason and exit code, but a command that worked
+  cannot archive over an upload failure.
+
+  ```go
+  func combineExecOutcomes(unmount, cmd execOutcome) execOutcome {
+      if !unmount.dorelease || cmd.dobury || cmd.dorelease {
+          return cmd
+      }
+
+      return unmount
+  }
+  ```
+
+- [x] `outcome` is then the single authority for the final action, so the four
+  copy-out assignments and the `dobury`/`dorelease`/`failreason`/`doarchive`
+  locals are gone; `execAction` is built from `outcome` directly.
+
+Shape (b), reordering so the classification precedes the unmount, was rejected.
+Behaviours currently run BEFORE the unmount and #567 depends on the keep set
+protecting an un-uploaded cache precisely because `cleanup` can run while the
+mount is live; moving the unmount earlier would also change what a `run`
+behaviour sees, breaking any `run` that post-processes files on the mount. (a)
+is a 4-line function plus a struct fill.
+
+What a job does now when an upload fails: it is released with
+`FailReasonUpload` and exit code -2, so it is retried up to its `Retries`
+count and then buried - never archived. The mount logs and the unmount error
+reach the job's stderr and `Execute`'s returned error.
+
+### The two dead branches
+
+Both are fixed as part of the same correction, in a small pure helper
+`appendExecProblems`, which is where the three stderr-appending blocks moved:
+
+- [x] The mount logs are now gated on `jobFailed := err != nil ||
+  unmountOutcome.dorelease`, computed after the unmount rather than before it.
+  That is exactly "the classification will not archive this job": every
+  `err != nil` path of `classifyExecOutcome` buries or releases.
+- [x] The behaviour-problems section is no longer gated at all. A `cleanup` or
+  `run` behaviour that fails now names itself in the job's stderr whatever the
+  command did.
+
+A failing behaviour still does not release or bury an otherwise successful job.
+Doing that would re-run a command that already worked, every time a `cleanup`
+hit a transient problem; the report belongs in the job's stderr, and that is
+where it now is.
+
+## Mutation results
+
+`go vet ./jobqueue/` passed for every mutation, so each verdict is a real
+failing assertion and not a build failure.
+
+- [x] M1: restore the plain overwrite (`return cmd`): RED, "its job is not
+  archived when its output failed to upload", `final.doarchive`
+  `Expected: false / Actual: true`.
+- [x] M2: always prefer the pre-classification state (`return unmount`): RED,
+  three cases - "its job is archived when its mounts unmounted cleanly"
+  (`Expected: true / Actual: false`), and both "an upload failure does not
+  replace its bury/release reason" (`failreason` `Expected: "command exited
+  non-zero" / Actual: "failed to upload files to remote file system"`).
+- [x] M3: re-gate the behaviour section behind `jobFailed`: RED, "a behaviour
+  problem is reported even when the job succeeded",
+  `Expected 'cmd output' to contain substring 'Behaviour problems:'`.
+- [x] All three reverted; `go build ./...`, `go vet ./jobqueue/` and both tests
+  green.
+
+## Regression test
+
+`jobqueue/exec_outcome_test.go`, port-free, no docker, no FUSE:
+
+```
+CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+  -v -run 'TestExecOutcomeCombination|TestExecProblemReporting'
+```
+
+`TestExecOutcomeCombination` pins the archive-vs-release decision: a clean
+success archives with exit 0 and no fail reason; a zero-exit command whose
+unmount failed to upload does not archive, releases with `FailReasonUpload`,
+exit -2, and keeps the accumulated error; a command that buried or released on
+its own keeps its own reason and exit code even when the upload also failed.
+`TestExecProblemReporting` pins the two revived stderr sections.
+
+Red before the fix, with the combination as the plain overwrite the old code
+performed:
+
+```
+  Given a command that exited zero
+    its job is archived when its mounts unmounted cleanly OK
+    its job is not archived when its output failed to upload FAILED
+  * jobqueue/exec_outcome_test.go
+  Line 83:
+  Expected: false
+  Actual:   true
+--- FAIL: TestExecOutcomeCombination (0.00s)
+```
+
+## Not changed
+
+- muxfys deleting a temporary cache whose upload failed. The un-uploaded bytes
+  are still lost when the upload fails; the fix makes wr retry the job and tell
+  the user, rather than pretending it succeeded. Keeping the cache would have
+  to happen in muxfys, and wr has no way to hand a stale cache to the next
+  attempt.
+- The behaviours-before-unmount ordering.
+- `myerr` being discarded when a failing command's classification wins. That
+  has been true since 2017 (`myerr = nil` in the old `err == nil` branch, a
+  fresh `myerr` in each failing branch); the behaviour error now reaches the
+  user through the job's stderr instead.
+- `Client.finishRelease` (jobqueue/client.go) only decrements the LOCAL job
+  copy's `UntilBuried` when `Exitcode != 0`, while the server
+  (`finalizeReleasedJob`) decrements whenever the job was started. Exit code -2
+  keeps the two in step for this failure, but the divergence itself is
+  pre-existing and out of scope.
+
+## Gates
+
+`unset $(compgen -v | grep '^OS_')`, then:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: 422 passed - 9 skipped - 29 packages - 3m51s, PASSED (develop's
+  420 plus the two new tests).
+- `make race`: 422 passed - 9 skipped - 29 packages - 5m4s, PASSED.
+- `make lint`: 0 issues.

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -137,6 +137,10 @@ const (
 	exitCodeCommandNotFound   = 127
 	exitCodeCommandInvalid    = 128
 	exitCodeAbnormal          = 255
+
+	// exitCodeUploadFailure is recorded for a job whose command exited zero but
+	// whose output could not be uploaded to its writable mount.
+	exitCodeUploadFailure = -2
 )
 
 const (
@@ -353,6 +357,21 @@ func (state *executeLiveState) snapshot() *JobEndState {
 		Stdout:   stdout,
 		Stderr:   stderr,
 	}
+}
+
+// combineExecOutcomes folds the verdict that unmounting the job's mounts
+// reached into the outcome of the command itself.
+//
+// A command that failed decides its own fate: its fail reason and exit code are
+// the more useful ones to report. But a command that worked must not archive as
+// a clean success if its output could not be uploaded, since that output is
+// gone: the unmount's verdict has to survive to get the job run again.
+func combineExecOutcomes(unmount, cmd execOutcome) execOutcome {
+	if !unmount.dorelease || cmd.dobury || cmd.dorelease {
+		return cmd
+	}
+
+	return unmount
 }
 
 // GetRecent gets archived Jobs across all rep groups that finished running
@@ -637,6 +656,29 @@ func newClientForSocket(sock mangos.Socket, addr, caFile, certDomain string,
 		port:     addrParts[1],
 		args:     []string{addr, caFile, certDomain},
 	}, nil
+}
+
+// appendExecProblems appends to a finished job's stderr the problems that its
+// own stderr cannot carry: the logs of its mounts (only worth reporting for a
+// job that failed), any problem running its behaviours, and any problem
+// handling the command's stderr.
+func appendExecProblems(stderr []byte, jobFailed bool, mountLogs string, berr, errsew error) []byte {
+	if jobFailed && mountLogs != "" {
+		stderr = append(stderr, "\n\nMount logs:\n"...)
+		stderr = append(stderr, mountLogs...)
+	}
+
+	if berr != nil {
+		stderr = append(stderr, "\n\nBehaviour problems:\n"...)
+		stderr = append(stderr, berr.Error()...)
+	}
+
+	if errsew != nil {
+		stderr = append(stderr, "\n\nSTDERR handling problems:\n"...)
+		stderr = append(stderr, errsew.Error()...)
+	}
+
+	return stderr
 }
 
 // dialClientSocket creates a req socket configured with TLS for the given
@@ -2138,13 +2180,10 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	exceededMemEstimate = commandExceededMemoryEstimate(peakmem, job.Requirements.RAM)
 
-	// get the exit code and figure out what to do with the Job; dobury,
-	// dorelease and failreason are consulted by the unmount/behaviour reporting
-	// below before being finalised by the outcome classification.
-	var (
-		dobury, dorelease bool
-		failreason        string
-	)
+	// the unmount below can decide the job must be redone even when the
+	// command itself worked, so its verdict is kept here and folded into the
+	// command's own outcome after classification.
+	var unmountOutcome execOutcome
 
 	var mayBeTemp string
 	if job.UntilBuried > 1 {
@@ -2166,33 +2205,31 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	// try and unmount now, because if we fail to upload files, we'll have to
 	// start over
-	addMountLogs := dobury || dorelease
-
 	logs, unmountErr := job.Unmount()
 	if unmountErr != nil {
-		if strings.Contains(unmountErr.Error(), "failed to upload") && !dobury {
-			// dorelease feeds the behaviour-problem reporting below; the fail
-			// reason and exit code are then set by the outcome classification.
-			dorelease = true
+		if strings.Contains(unmountErr.Error(), "failed to upload") {
+			// the files that did not upload only existed in the mount's cache,
+			// which is deleted at unmount regardless, so the job must be redone
+			unmountOutcome = execOutcome{
+				dorelease:  true,
+				failreason: FailReasonUpload,
+				exitcode:   exitCodeUploadFailure,
+			}
 		}
 
 		myerr = appendExecErr(myerr, unmountErr, "unmounting also caused problem(s)")
 	}
 
-	if addMountLogs && logs != "" {
-		finalStdErr = append(finalStdErr, "\n\nMount logs:\n"...)
-		finalStdErr = append(finalStdErr, logs...)
-	}
+	// the accumulated problems are what we report if the unmount's verdict is
+	// the one that survives the combination below.
+	unmountOutcome.myerr = myerr
 
-	if (dobury || dorelease) && berr != nil {
-		finalStdErr = append(finalStdErr, "\n\nBehaviour problems:\n"...)
-		finalStdErr = append(finalStdErr, berr.Error()...)
-	}
+	// the mount logs are only worth adding to the job's stderr if the job did
+	// not simply succeed: either the command failed (classifyExecOutcome then
+	// always buries or releases it) or its output failed to upload.
+	jobFailed := err != nil || unmountOutcome.dorelease
 
-	if errsew != nil {
-		finalStdErr = append(finalStdErr, "\n\nSTDERR handling problems:\n"...)
-		finalStdErr = append(finalStdErr, errsew.Error()...)
-	}
+	finalStdErr = appendExecProblems(finalStdErr, jobFailed, logs, berr, errsew)
 
 	// *** following is useful when debugging; need a better way to see these
 	// errors from runner clients...
@@ -2224,13 +2261,9 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		},
 	})
 
-	dobury = outcome.dobury
-	dorelease = outcome.dorelease
-	failreason = outcome.failreason
+	outcome = combineExecOutcomes(unmountOutcome, outcome)
 	myerr = outcome.myerr
-
 	exitcode := outcome.exitcode
-	doarchive := outcome.doarchive
 
 	// now we've done everything time-consuming so can stop touching the job
 	stopTouching <- true
@@ -2248,7 +2281,8 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 	}
 
 	worked, hadProblems := c.reportFinalState(ctx, job, jes, execAction{
-		bury: dobury, release: dorelease, archive: doarchive, failreason: failreason,
+		bury: outcome.dobury, release: outcome.dorelease, archive: outcome.doarchive,
+		failreason: outcome.failreason,
 	})
 	if !worked {
 		//nolint:contextcheck // behaviours run detached from the cancellable job context

--- a/jobqueue/exec_outcome_test.go
+++ b/jobqueue/exec_outcome_test.go
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestExecProblemReporting(t *testing.T) {
+	Convey("Given a job's stderr", t, func() {
+		stderr := []byte("cmd output")
+
+		Convey("a behaviour problem is reported even when the job succeeded", func() {
+			final := appendExecProblems(stderr, false, "", errTestBehaviour, nil)
+
+			So(string(final), ShouldContainSubstring, "Behaviour problems:\ncleanup failed")
+		})
+
+		Convey("mount logs are reported when the job failed", func() {
+			final := appendExecProblems(stderr, true, "could not upload out.txt", nil, nil)
+
+			So(string(final), ShouldContainSubstring, "Mount logs:\ncould not upload out.txt")
+		})
+
+		Convey("mount logs are not reported when the job succeeded", func() {
+			final := appendExecProblems(stderr, false, "uploaded out.txt", nil, nil)
+
+			So(string(final), ShouldEqual, "cmd output")
+		})
+
+		Convey("a stderr handling problem is always reported", func() {
+			final := appendExecProblems(stderr, false, "", nil, errTestStderrHandling)
+
+			So(string(final), ShouldContainSubstring, "STDERR handling problems:\ndisk full")
+		})
+	})
+}
+
+func TestExecOutcomeCombination(t *testing.T) {
+	Convey("Given a command that exited zero", t, func() {
+		cmdWorked := execOutcome{doarchive: true}
+
+		Convey("its job is archived when its mounts unmounted cleanly", func() {
+			final := combineExecOutcomes(execOutcome{}, cmdWorked)
+
+			So(final.doarchive, ShouldBeTrue)
+			So(final.dorelease, ShouldBeFalse)
+			So(final.dobury, ShouldBeFalse)
+			So(final.failreason, ShouldBeBlank)
+			So(final.exitcode, ShouldEqual, 0)
+			So(final.myerr, ShouldBeNil)
+		})
+
+		Convey("its job is not archived when its output failed to upload", func() {
+			final := combineExecOutcomes(uploadFailedOutcome(errTestUploadFailed), cmdWorked)
+
+			So(final.doarchive, ShouldBeFalse)
+			So(final.dorelease, ShouldBeTrue)
+			So(final.failreason, ShouldEqual, FailReasonUpload)
+			So(final.exitcode, ShouldEqual, exitCodeUploadFailure)
+			So(final.myerr, ShouldEqual, errTestUploadFailed)
+		})
+	})
+
+	Convey("Given a command that failed", t, func() {
+		Convey("an upload failure does not replace its bury reason", func() {
+			cmdBuried := execOutcome{
+				myerr: errTestCmdNotFound, failreason: FailReasonCFound,
+				exitcode: exitCodeCommandNotFound, dobury: true,
+			}
+
+			final := combineExecOutcomes(uploadFailedOutcome(errTestUploadFailed), cmdBuried)
+
+			So(final.dobury, ShouldBeTrue)
+			So(final.dorelease, ShouldBeFalse)
+			So(final.doarchive, ShouldBeFalse)
+			So(final.failreason, ShouldEqual, FailReasonCFound)
+			So(final.exitcode, ShouldEqual, exitCodeCommandNotFound)
+		})
+
+		Convey("an upload failure does not replace its release reason", func() {
+			cmdReleased := execOutcome{
+				myerr: errTestCmdExited, failreason: FailReasonExit,
+				exitcode: 1, dorelease: true,
+			}
+
+			final := combineExecOutcomes(uploadFailedOutcome(errTestUploadFailed), cmdReleased)
+
+			So(final.dorelease, ShouldBeTrue)
+			So(final.doarchive, ShouldBeFalse)
+			So(final.failreason, ShouldEqual, FailReasonExit)
+			So(final.exitcode, ShouldEqual, 1)
+		})
+	})
+}
+
+// static errors standing in for the problems Execute accumulates.
+var (
+	errTestUploadFailed   = errors.New("unmounting also caused problem(s): failed to upload 1 files")
+	errTestBehaviour      = errors.New("cleanup failed")
+	errTestStderrHandling = errors.New("disk full")
+	errTestCmdNotFound    = errors.New("command not found")
+	errTestCmdExited      = errors.New("command exited with code 1")
+)
+
+// uploadFailedOutcome is the verdict Execute reaches when unmounting a job's
+// writable mount could not upload the job's output.
+func uploadFailedOutcome(myerr error) execOutcome {
+	return execOutcome{
+		myerr:      myerr,
+		failreason: FailReasonUpload,
+		exitcode:   exitCodeUploadFailure,
+		dorelease:  true,
+	}
+}


### PR DESCRIPTION
A job whose output could not be uploaded to its writable mount was archived as a clean success, with the output already deleted. `wr status` said complete, exit 0.

`Client.Execute` unmounts before it classifies the command's outcome. A failed upload at unmount sets `dorelease = true` so the job is released and retried — but the classification result was then assigned straight over it:

```go
dobury = outcome.dobury
dorelease = outcome.dorelease
failreason = outcome.failreason
myerr = outcome.myerr
```

and `classifyExecOutcome` returns a bare `execOutcome{doarchive: true}` whenever the command itself exited 0. So `dorelease` became false, `failreason` became empty, and `myerr` — which also carried the behaviour errors — was discarded. Meanwhile muxfys deletes the cache holding the un-uploaded data regardless of whether the upload succeeded, so the output is gone.

A network blip, an expired credential or a full bucket at unmount time therefore lost a whole job's output silently.

This is a regression. #534 removed the `failreason = FailReasonUpload` / `exitcode = -2` lines, and `FailReasonUpload` has been declared and referenced nowhere else since. Before that, the `err == nil` path left `dorelease` intact, so it beat `doarchive` and the job was released for a retry.

`combineExecOutcomes` now folds the unmount's verdict into the command's: a command that failed still decides its own fate, since its own reason is the more useful one to report, but a command that worked can no longer archive clean when its output could not be uploaded. `FailReasonUpload` and exit code -2 are restored.

Two dead reporting branches shared the root cause and are fixed with it:

* `addMountLogs := dobury || dorelease` was evaluated while both were still false from their declarations, so it was **always** false and mount logs never reached a job's stderr. This one predates #534.
* `if (dobury || dorelease) && berr != nil` was false for the same reason, which is why a failing `cleanup` or `run` behaviour on an otherwise successful job was reported nowhere at all — reachable ordinarily via `--with_docker`, where the container runs as root and its root-owned directories defeat the cleanup running as the user.

`appendExecProblems` now puts mount logs (for a failed job), behaviour problems and stderr-handling problems into the job's stderr.

Found by an adversarial probe, demonstrated end to end with real minio, a real FUSE mount and a real spawned runner, with an A/B control differing only in the command's exit code.

`make test` and `make race` both 422 passed / 9 skipped; `make lint` 0 issues. Guard mutation verified: reducing `combineExecOutcomes` to the old overwrite turns the test red with `go vet` clean.

`.docs/bugfixes/260902-6.md` records the mechanism, the archaeology and the end-to-end demonstration.
