### PR TITLE
Give a run behaviour the job's environment, not the caller's

### DIFF
--- a/.docs/bugfixes/260902-7.md
+++ b/.docs/bugfixes/260902-7.md
@@ -493,3 +493,130 @@ confirming with `ps -eo pid,cmd | grep -E "make (test|race)|jobqueue.test"` and
 concurrent runs on this box have produced false failures. Neither
 `TestReliable2FastStartupNoHistoryScan` nor `TestRESTJobModificationEndpoint`
 failed in any of the four runs.
+
+## Review finding: a missing env record reintroduced the same leak
+
+`fillEnvFromDB` above treated "the database has no record under this key" as
+"the job's environment is empty". `retrieveEnv` answers a missing key with nil
+(`db.retrieve` copies only when bolt found a value), and the function then set
+`stored.retrieved = true` alongside that nil `envC`, which is exactly the state
+`jobEnv.decode` reads as "the job stored no environment, and one was asked for":
+
+```go
+	if len(e.envC) == 0 {
+		if !e.retrieved {
+			return nil, nil
+		}
+
+		return applyEnvOverrides(os.Environ(), overrideEs), nil
+	}
+```
+
+`os.Environ()` there is the MANAGER's, so a lost job's `run` behaviour executed
+with the manager process's environment - silently, since nothing errored. That
+is the failure this whole PR exists to stop, back again in the one case where
+the manager cannot produce the environment at all.
+
+Confirmed against the real database rather than by reading: `storeEnv([]byte{})`
+(what `restJobsAdd` does for a job added with no environment) comes back from
+`retrieveEnv` non-nil and length 0, both from `db.envcache` and from bolt after
+a close and reopen, while an absent key comes back nil. So nil is precisely "no
+record", and the two cases really are distinguishable at that call.
+
+### The fix
+
+`jobRunEnv` gains one field, `unread error`, holding why the environment could
+not be read; `runEnv` returns it before decoding anything, and
+`fillEnvFromDB` sets it instead of filling in a nil `envC`:
+
+```go
+	envC := jobsDB.retrieveEnv(ctx, env.envKey)
+	if envC == nil {
+		env.unread = fmt.Errorf("%w: %s", errEnvNotInDB, env.envKey)
+
+		return
+	}
+
+	env.stored.envC = envC
+	env.stored.retrieved = true
+```
+
+An error on the snapshot, rather than a third value of `jobEnv.retrieved` or a
+returned error from `fillEnvFromDB`:
+
+- `jobEnv` is also what `Job.Env()` decodes on the runner, where nil `EnvC` with
+  `retrieved` set legitimately means `os.Environ()` for a job added with no
+  environment at all (checklist point 1 above). Adding a state there would put
+  the manager's problem into the runner's path; a field on `jobRunEnv`, which
+  only the behaviour path has, does not.
+- `fillEnvFromDB` returning an error would make its caller choose between
+  running the behaviours and reporting, and `triggerLostRunBehaviours` has only
+  one pin to trigger: the CLEANUP behaviours of a lost job must still run, since
+  they need no environment. Carrying the reason on the pin lets exactly the
+  `run` behaviour refuse while the rest proceed, and `Behaviours.trigger`'s
+  multierror already collects that refusal.
+
+So a lost job whose environment the manager cannot read now gets
+`run behaviour refused: the job's environment could not be read: no environment
+is stored in the database under the job's env key: <key>` from `Behaviour.run`,
+which `triggerLostRunBehaviours` `clog.Warn`s, and its cleanup behaviours still
+run. This is the only path that can produce it: `fillEnvFromDB` is the only
+thing that sets `unread`, and only the manager calls it. On the runner, a `run`
+behaviour whose environment fails to DECODE still refuses through `runEnv`'s
+existing error, and `Execute` still folds that into the job's outcome.
+
+Nothing on the runner side changed: `fillEnvFromDB` is manager-only, `unread` is
+nil everywhere else, and `runEnv`'s `os.Environ()` fallback for a job that
+stored no environment is untouched.
+
+### Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestBehaviourRunEnv
+
+An eighth case in `jobqueue/behaviours_env_test.go`, "the manager refuses a
+lost Job's run behaviour when the environment is missing from its database",
+does what `triggerLostRunBehaviours` does - pin, `fillEnvFromDB`, `trigger` -
+against a real `initDB` database and an `EnvKey` naming an environment that was
+never stored. It asserts on what the behaviour's command REPORTED first, so the
+failure names the environment that leaked, and on the refusal second:
+
+```
+    the manager refuses a lost Job's run behaviour when the environment is missing from its database ✔✔✔✔✘✔✔✔
+
+Failures:
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 250:
+  Expected '/home/ubuntu' to be blank (but it wasn't)!
+
+
+83 total assertions
+
+--- FAIL: TestBehaviourRunEnv (0.07s)
+```
+
+`/home/ubuntu` is this process's `HOME` - the manager's, on that path - arriving
+in the user's command. Green afterwards, all eight cases, `84 total assertions`.
+The existing seven needed no adjustment.
+
+The case uses `ChangeHome: false` deliberately: with `--change_home` set, the
+derived `HOME` would be the job's working directory on both sides of the fix,
+and the leak would show only in the variables the job stored. Without it, the
+process's `HOME` reaches the command unaltered and the failure says so.
+
+### Mutation checks
+
+`go vet ./jobqueue/` was run after each edit and reported clean, so neither
+verdict is a build failure masquerading as a dead guard.
+
+- [x] M5: `fillEnvFromDB` stops distinguishing (the `envC == nil` branch's
+  assignment discarded, `env.stored.envC = envC` and `retrieved = true`
+  unconditional again - the reviewed code exactly). Vet OK. **RED** on the new
+  case, line 250, `Expected '/home/ubuntu' to be blank`, `83 total assertions`.
+- [x] M6: `runEnv` ignores the distinction (`return nil, s.env.unread` ->
+  `_ = s.env.unread`). Vet OK. **RED** identically: line 250, `83 total
+  assertions`.
+
+Both reverted; `go vet` clean and all eight cases green again.

--- a/.docs/bugfixes/260902-7.md
+++ b/.docs/bugfixes/260902-7.md
@@ -1,0 +1,495 @@
+# Bugfixes 260902-7
+
+Branch `fix-run-behaviour-env`: a `run` behaviour executed with the CALLING
+PROCESS's environment instead of the job's, so `--change_home` did not move its
+`$HOME`, its `$TMPDIR` was not the job's, and the environment captured when the
+job was added - `--env` overrides and loaded environment modules with it - was
+discarded.
+
+## Where this came from
+
+`Behaviour.run` (jobqueue/behaviours.go) built the user's command with
+
+```go
+cmd := exec.CommandContext(context.Background(), "/bin/bash", "-c", bc)
+cmd.Dir = dir.execDir()
+```
+
+and never assigned `cmd.Env`. A nil `exec.Cmd.Env` means "inherit this
+process's", so everything `Client.Execute` puts in the environment of the job's
+own `Cmd` (client.go:1767-1786) was absent from the behaviour's:
+
+- `job.Env()` - the environment captured at `wr add`, plus `--env` overrides
+  (client.go:1767)
+- `TMPDIR` pointing at the job's own tmp dir (client.go:1779)
+- `HOME` pointing at the job's working directory when `--change_home` is set
+  (client.go:1781-1782)
+
+## Verification, before changing anything
+
+A throwaway probe drove the production entry point - `Behaviour.Trigger(OnExit,
+job)` for a Job with `ChangeHome: true`, a real workspace from `mkHashedDir`,
+and a stored `EnvC` carrying `WR_PROBE_VAR=probe_value` - with a command that
+reported its own environment:
+
+```
+actualCwd=/tmp/.../001/jobqueue_cwd/b/b/8/b183b8f37bb788728fb863897c67d4259033115/cwd
+tmpDir   =/tmp/.../001/jobqueue_cwd/b/b/8/b183b8f37bb788728fb863897c67d4259033115/tmp
+process HOME=/home/ubuntu
+run behaviour observed:
+    HOME=/home/ubuntu
+    TMPDIR=
+    WR_PROBE_VAR=
+```
+
+All three claims hold: the real `$HOME`, no `TMPDIR` at all, and nothing from
+the job's stored environment.
+
+The other half - that the job's own `Cmd` DOES see the job's directories - is
+already pinned by `TestJobqueueBasics` ("The stdout/err of archived jobs is
+retained, and cwd&TMPDIR&HOME get set appropriately", jobqueue_test.go:4551).
+It runs a perl one-liner printing `getcwd()` and `$ENV{HOME}` and warning
+`File::Spec->tmpdir`, and asserts, for a `ChangeHome: true` job with
+`CwdMatters: false`:
+
+```go
+So(stdout, ShouldEqual, actualCwd+"-"+actualCwd)   // cwd and HOME both actualCwd
+So(stderr, ShouldEqual, tmpDir)                    // TMPDIR is <workSpace>/tmp
+```
+
+and for the `CwdMatters: true` job, `tmpDir+"-"+home` with `home` from
+`os.UserHomeDir()` and `stderr == os.TempDir()`: wr creates no workspace for
+such a job, so its `Cmd` gets neither override, whatever `--change_home` says.
+
+### Consequence 1: `--change_home` did not apply to the behaviour
+
+The measured pair is `Cmd saw HOME=<actualCwd>` (the assertion above) against
+`run behaviour saw HOME="/home/ubuntu"` (the probe). So
+
+    wr add --change_home --on_exit '{"run":"rm -rf $HOME/scratch"}' ...
+
+deleted under the user's REAL home - the one directory `--change_home` exists to
+keep the job out of - while the job's `Cmd`, running the same string, would have
+deleted inside its own working directory.
+
+### Consequence 2: the manager's lost-job path ran it with the MANAGER's environment
+
+`Behaviour.run` is also reached from the manager: `markJobLost` /
+`lostJobRetryCheck` pin the job's behaviours (server.go:3856, server.go:2358)
+and `triggerLostRunBehaviours` (server.go:4665) runs them in the manager
+process. With no `cmd.Env`, that command inherited the MANAGER's environment - a
+different machine's under a cloud deployment - so one behaviour string acted on
+a different `$HOME` depending on whether the job failed normally or was declared
+lost.
+
+Worse, the manager could not have supplied the job's environment even if it had
+tried: it deliberately does not hold one on the job. `Job.EnvKey`'s own comment
+says so ("on the server we don't store EnvC with the job, but look it up in db
+via this key"), `resetJobStatusFields` nils `EnvC` on rerun (serverWebI.go:814),
+and `jobPopulateStdEnv` fills `EnvC` only into the COPY sent to a client
+(serverCLI.go:1881, reached for `Reserve` via `itemToJob(ctx, item, false,
+true)`). So on the manager `job.Env()` returns `nil, nil`.
+
+### Also fixed by the same change
+
+`--on_exit '{"run":"module load x; ..."}'` could not work at all, because a
+job's loaded environment modules live in the captured environment that was being
+discarded. It now works on the runner (the manager's host is a different
+machine's module tree; see "What the manager can and cannot reproduce").
+
+## The fix
+
+The environment is captured INTO the workspace snapshot, at the one moment the
+snapshot is taken under the job's lock, and used from there.
+
+`jobWorkSpaceSnapshot` (jobqueue/workspace.go) gains one field:
+
+```go
+type jobWorkSpaceSnapshot struct {
+	cwdMatters bool
+	cwd        string
+	actualCwd  string
+	key        string
+	mounts     MountConfigs
+	env        jobRunEnv
+}
+
+type jobRunEnv struct {
+	stored     jobEnv
+	changeHome bool
+	envKey     string
+}
+```
+
+`workSpaceSnapshotLocked` fills it with `j.storedEnvLocked()`, `j.ChangeHome`
+and `j.EnvKey`. `Behaviour.run` then asks the snapshot for the environment and
+assigns it:
+
+```go
+	env, err := snap.runEnv(dir)
+	if err != nil {
+		return fmt.Errorf("run behaviour refused: the job's environment could not be read: %w", err)
+	}
+	...
+	cmd.Env = env
+```
+
+### Why the snapshot, and why nothing is fetched later
+
+Behaviours act on a snapshot deliberately: a `--on_failure cleanup --on_exit
+run` pair is one decision about one directory, and re-reading the live `*Job`
+between them lets the two act on different ones. An environment fetched later
+has the same defect in a milder form (a `--env` modification landing between the
+cleanup and the run), and, on the manager, `ActualCwd` and `ChangeHome` must
+describe the SAME run. So the environment is pinned in the same breath as the
+directory, and `pinnedBehaviours` gets it for free, because
+`pinBehavioursLocked` already builds its snapshot with
+`workSpaceSnapshotLocked`.
+
+### Why `HOME` and `TMPDIR` are derived, not carried
+
+Both are already implied by what the snapshot knows, so carrying them would be a
+second copy of the same fact that could disagree with the first. They are
+derived from the directory that was PROVEN, not from the raw `ActualCwd` string:
+`runDir` gains a `tmp` field, set by `openRunDir` from `ws.paths.workSpace`, and
+
+```go
+func (r *runDir) dirEnv(changeHome bool) []string {
+	if r.tmp == "" {
+		return nil
+	}
+
+	dirEnv := []string{"TMPDIR=" + r.tmp}
+	if changeHome {
+		dirEnv = append(dirEnv, "HOME="+r.path)
+	}
+
+	return dirEnv
+}
+```
+
+`r.tmp == ""` is exactly the `CwdMatters` case, where `resolveRunDir` answers
+through `cwdRunDir` and holds nothing open. That reproduces `Execute`'s own
+condition - it applies both overrides only `if tmpDir != ""`, and
+`resolveWorkingDir` returns a blank `tmpDir` precisely for a `CwdMatters` job -
+so a `CwdMatters` job's behaviour gets neither override, as its `Cmd` does not.
+`envOverride` is the same helper `Execute` uses, in the same order.
+
+### The cost decision: capture compressed, decode only for a `run`
+
+`Behaviours.Trigger` answers "are there any behaviours at all?" BEFORE taking a
+snapshot, because most jobs have none and the snapshot costs the job's lock and
+`Key()`'s hash. That early-out is untouched, and the new capture does not undo
+it:
+
+- The capture copies three slice headers and two scalars. `EnvC` and
+  `EnvOverride` are only ever replaced wholesale (the retrieval that fills the
+  former, `EnvAddOverride` the latter), so copying headers pins the values the
+  same way `mounts` is pinned.
+- Decoding - a decompress plus a binc decode of every variable the job was added
+  with - happens inside `runEnv`, so ONLY when a `run` behaviour actually fires.
+  A job with no behaviours, and a job whose only behaviour is a cleanup, decode
+  nothing.
+
+That is observable, and pinned. `Job.Env()`'s body moved to `jobEnv.decode()`
+(jobqueue/job.go) - `Job.Env` is now a one-line delegation with its locking
+unchanged - and `decode` calls a new `envDecodeHook`, nil in production,
+alongside the existing `workSpaceResolveHook` that counts workspace resolutions
+for the same reason. The test's last case counts: `0` decodes for a job with no
+behaviours, `0` more for one with only `CleanupAll`, and `1` once a `run` is
+there.
+
+Two duplicated decode bodies collapsed into `decodeCompressedEnv` on the way
+(`envCurrentOverrides` is now one line), which is why job.go's diff is larger
+than the behaviour change.
+
+### The manager fetches what it is missing, after the lock
+
+`triggerLostRunBehaviours` fills the pin from the database before triggering:
+
+```go
+	d.pin.fillEnvFromDB(ctx, s.db)
+```
+
+```go
+func (p *pinnedBehaviours) fillEnvFromDB(ctx context.Context, jobsDB *db) {
+	env := &p.workSpace.env
+	if env.stored.retrieved || env.envKey == "" || !p.behaviours.includesRun() {
+		return
+	}
+
+	env.stored.envC = jobsDB.retrieveEnv(ctx, env.envKey)
+	env.stored.retrieved = true
+}
+```
+
+Three things make that safe and cheap:
+
+- It runs with NO lock held. The pin is taken under `queue.mutex` plus the job's
+  lock; this is called from the goroutine that already holds neither, which is
+  the rule from DEVELOPERS.md §2 rule 1 (snapshot under the lock, do the external
+  call after releasing it).
+- Fetching later is not a re-read of live state. `db.storeEnv` keys the value by
+  `byteKey(env)`, so the key is content-addressed: the bytes it names cannot
+  change under us, and the pin carries the key.
+- It reads nothing unless a `run` behaviour is present (`includesRun`), so the
+  lost-job path of a cleanup-only job - the common one - makes no database call
+  it did not make before. `retrieveEnv` is served from `db.envcache` in any
+  case.
+
+A `run` behaviour whose environment cannot be decoded refuses to run rather than
+running with the wrong one, matching `Execute`, which buries the job with
+`FailReasonEnv` when `job.Env()` fails. That is a new way for the behaviour to
+fail, and it needs no reporting path of its own: `Execute` already folds the
+behaviour error into its own with `myerr = appendExecErr(myerr, berr,
+"behaviour(s) also had problem(s)")` (client.go:2165), and the manager already
+logs it (`triggerLostRunBehaviours`). A sibling fix on another branch
+(`fix-silent-upload-failure`, `887d33fd`, `combineExecOutcomes` /
+`appendExecProblems`) makes that reach the user on a successful job too; nothing
+here duplicates it.
+
+## What the manager-side path can and cannot reproduce
+
+It can now reproduce, faithfully and identically to the runner:
+
+- the environment stored for the job at `wr add`, and any `--env` /
+  `SetEnvOverride` overrides on top of it
+- `TMPDIR`, from the proven workspace
+- `HOME`, when `--change_home` is set
+
+Three things still differ, all recorded rather than fixed:
+
+1. **A job added with NO environment.** `cmd/add.go`'s `addEnvVars` returns
+   `nil` when the deployment is not local and `remoteSameAsLocal` is not
+   enabled - the cloud case. `Job.Env()` then falls back to `os.Environ()` of
+   whichever process decodes (its documented behaviour: "If no environment was
+   stored for the job, returns current environment variables instead"). For such
+   a job, a `run` behaviour still sees the runner's environment on the runner and
+   the manager's on the manager. The job's own `Cmd` has exactly the same
+   property, so the behaviour and the `Cmd` still agree wherever they run
+   together; it is the two triggering PROCESSES that cannot be made to agree,
+   because the job never said what its environment was. `HOME` and `TMPDIR` are
+   still applied over that fallback, so `--change_home` holds even here.
+2. **The bsub-emulation additions.** `Execute` adds `PATH` (prepended with the
+   LSF emulation dir), `WR_BSUB_CONFIG`, `WR_MANAGER_HOST`, `WR_MANAGER_PORT`,
+   `LSF_*` and `SHELL` for a `BsubMode` job (`addBsubEnv`, client.go:1219).
+   Those are computed at execution time around a temp dir `Execute` deletes on
+   exit and are never stored, so no behaviour gets them - on either path. Not a
+   regression: the runner's behaviour never had them either, since they only ever
+   went into the `Cmd`'s `cmd.Env`, not into the runner's own environment.
+3. **The host.** The manager's command runs on the manager's machine with the
+   job's environment, so a `PATH`, a `MODULEPATH` or a mounted path from an exec
+   node may not exist there. Nothing in wr can fix that; it is inherent to
+   cleaning up after a job whose own host is confirmed dead.
+
+## Deliberate change of behaviour worth knowing
+
+On the runner, a `run` behaviour previously inherited the RUNNER's environment,
+which under LSF includes the scheduler's own variables (`LSB_JOBID`,
+`LSB_JOBINDEX`, ...). It now gets the job's, which does not have them - the same
+environment the job's `Cmd` had, and never had them either. Parity with the `Cmd`
+is the point of the fix, so this is intended, not an oversight.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestBehaviourRunEnv
+
+Port-free. `TestBehaviourRunEnv` in the new `jobqueue/behaviours_env_test.go`
+drives the production paths - `Behaviour.Trigger(OnExit, job)`,
+`job.TriggerBehaviours(false)`, and `job.pinBehaviours()` +
+`pinnedBehaviours.trigger()` - with a `run` behaviour whose command reports
+`$HOME`, `$TMPDIR` and `$WR_TEST_BEHAVIOUR_ENV` to a file outside the workspace
+that the test reads back. The job's stored environment has this process's with
+its `HOME` replaced by `/nonexistent/stored-home` and
+`WR_TEST_BEHAVIOUR_ENV=from_job_env` added, so the process's environment, the
+job's, and the working directory are three distinct values for `HOME` and no
+assertion can pass by accident.
+
+Failing output on the branch point. Two of the seven cases were removed to
+measure it, because they cannot compile against the branch point at all (they
+need `fillEnvFromDB` and `envDecodeHook`, which this change adds), and the two
+`pin.trigger()` calls were written `pin.trigger(false)`, that method's signature
+there. Nothing else was touched, and the assertion line numbers below are the
+committed file's:
+
+```
+.......x.......x........x......x.......x
+Failures:
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 118:
+  Expected: "from_job_env"
+  Actual:   ""
+  (Should equal)!
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 134:
+  Expected: "/tmp/TestBehaviourRunEnv250782619/003/jobqueue_cwd/b/b/8/b183b8f37bb788728fb863897c67d2924971196/cwd"
+  Actual:   "/home/ubuntu"
+  (Should equal)!
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 146:
+  Expected: "from_override"
+  Actual:   ""
+  (Should equal)!
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 158:
+  Expected: "from_job_env"
+  Actual:   ""
+  (Should equal)!
+
+  * /home/ubuntu/wr_fix_env/jobqueue/behaviours_env_test.go
+  Line 172:
+  Expected: "from_job_env"
+  Actual:   ""
+  (Should equal)!
+
+
+40 total assertions
+
+--- FAIL: TestBehaviourRunEnv (0.02s)
+```
+
+Line 134 is the `--change_home` case: the working directory expected, the user's
+real home delivered.
+
+Green afterwards, all seven cases:
+
+```
+  Given a Job whose stored environment differs from this process's ✔✔
+    a run behaviour executes with the Job's environment, not this process's ✔✔✔✔✔✔✔✔✔✔✔✔
+    --change_home points a run behaviour's HOME at the Job's working directory ✔✔✔✔✔✔✔✔✔
+    an env override reaches a run behaviour ✔✔✔✔✔✔✔✔✔
+    a CwdMatters Job's run behaviour gets its environment untouched ✔✔✔✔✔✔✔✔✔
+    the behaviours the manager pins carry the Job's environment ✔✔✔✔✔✔✔✔✔
+    the manager gives a lost Job's run behaviour the environment from its database ✔✔✔✔✔✔✔✔✔✔✔✔✔
+    only a run behaviour makes the Job's environment be decoded ✔✔✔✔✔✔✔✔✔✔✔✔
+
+75 total assertions
+
+--- PASS: TestBehaviourRunEnv (0.12s)
+```
+
+The `CwdMatters` case is the guard against a fix that just sets `HOME` and
+`TMPDIR` unconditionally: it must get the job's environment with NEITHER
+override applied, even with `ChangeHome: true`, and it passes before and after.
+
+## Mutation checks
+
+`go vet ./jobqueue/` was run after every edit and reported clean each time, so
+no verdict below is a build failure masquerading as a dead guard.
+
+- [x] M1: the `cmd.Env` assignment removed (`cmd.Env = env` -> `_ = env`, which
+  keeps it compiling). Vet OK. **RED** on all seven assertions that read the
+  job's environment - lines 120, 136, 148, 160, 174, 207, 237, `66 total
+  assertions` - including the `--change_home` one, `Actual: "/home/ubuntu"`.
+- [x] M2: the job's stored environment dropped from what is captured
+  (`stored: j.storedEnvLocked()` -> `stored: jobEnv{}`). Vet OK. **RED on
+  exactly the stored-variable assertions**: 120, 148, 160, 174, 237, `68 total
+  assertions`. The `--change_home` assertion (136) stays GREEN, and correctly
+  so - `HOME` comes from the derived `dirEnv`, not from the stored
+  environment - so the two guards are independent rather than one covering for
+  the other.
+- [x] M3: `changeHome` dropped from what is captured (`changeHome:
+  j.ChangeHome` -> `changeHome: false`). Vet OK. **RED on exactly the three
+  `HOME == actualCwd` assertions**: 136, 175, 208, `74 total assertions`, each
+  `Actual: "/nonexistent/stored-home"` - the stored `HOME` arriving intact,
+  which makes the failure `--change_home` not applying rather than the
+  environment going missing.
+- [x] M4: `fillEnvFromDB` fetches nothing (its two assignments replaced by
+  discards). Vet OK. **RED on exactly one assertion**, line 207, the manager's
+  database fill, `74 total assertions` - so that case is not passing for the
+  same reason the others are.
+
+All four reverted; `go vet` clean and `TestBehaviourRunEnv` green again.
+
+Not covered by a port-free test: the single wiring line
+`d.pin.fillEnvFromDB(ctx, s.db)` in `triggerLostRunBehaviours`. The test performs
+the same sequence that function performs (pin, fill, trigger) but calls it
+directly, since constructing a `Server` needs ports. The line itself is executed
+by the existing server-backed lost-job tests
+(`TestLostJobBehavioursActOnTheLostRun` and its siblings in
+`jobqueue/lost_job_behaviours_test.go`, which trigger real `Do: Run` behaviours
+from the manager), so a break in it shows up in `make test`.
+
+## One incidental change the lint gate forced
+
+`make lint` reported one new issue against this change:
+
+```
+jobqueue/behaviours.go:455:35: (pinnedBehaviours).trigger - success always receives false (unparam)
+```
+
+The baseline is `0 issues.` (measured on this branch point with the four
+modified files stashed and the two new files moved aside), so it is genuinely
+attributed here, and it is correct: `pinnedBehaviours.trigger` was only ever
+handed `false` - by `triggerLostRunBehaviours` and by every test. Adding the new
+test's two calls, also `false`, is what pushed unparam over its threshold
+(whole-repo `golangci-lint run --new-from-rev=` flags it with the new test file
+present and not without it, while the pre-existing
+`waitForScheduledGroupCount` finding is reported in both).
+
+Rather than suppress a correct finding, the parameter is gone:
+
+```go
+// trigger runs the pinned Behaviours against the pinned state, as the FAILURE it
+// always is: a pin is only ever triggered after the lost run it names was
+// confirmed dead and killed (see triggerLostRunBehaviours), so that run did not
+// succeed and OnFailure is the trigger it gets.
+func (p pinnedBehaviours) trigger() error {
+	return p.behaviours.trigger(false, p.workSpace)
+}
+```
+
+Behaviourally identical - `false` was the only value that ever reached it - and
+it updates three call sites (server.go, `lost_job_behaviours_test.go:1409`, and
+the new test). `Behaviours.trigger(success, ws)` keeps its parameter, since that
+one really does receive both values.
+
+## Files touched
+
+- `jobqueue/workspace.go`: `jobRunEnv` and the snapshot field, `runEnv`,
+  `runDir.tmp` and `runDir.dirEnv`, `openRunDir` filling `tmp`.
+- `jobqueue/behaviours.go`: `Behaviour.run` assigns `cmd.Env`;
+  `pinnedBehaviours.fillEnvFromDB`; `Behaviours.includesRun`;
+  `pinnedBehaviours.trigger` loses its always-false parameter.
+- `jobqueue/job.go`: `jobEnv` + `Job.storedEnvLocked` + `jobEnv.decode`
+  (`Job.Env`'s body, unchanged in behaviour and locking), `decodeCompressedEnv`
+  replacing two duplicated decode bodies, `envDecodeHook`.
+- `jobqueue/server.go`: one line in `triggerLostRunBehaviours`, plus its
+  `d.pin.trigger()` call losing its argument.
+- `jobqueue/lost_job_behaviours_test.go`: one `pin.trigger()` call site.
+- `jobqueue/behaviours_env_test.go`: new, `TestBehaviourRunEnv`.
+
+Nothing about the job's own `Cmd` changed: `Execute` computes its environment
+exactly as before.
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./jobqueue/`: clean.
+- `make test`: `421 passed · 9 skipped · 29 packages · 4m2s`, PASSED.
+- `make race`: `421 passed · 9 skipped · 29 packages · 4m46s`, PASSED.
+- `make lint`: `0 issues.`
+
+Baseline, measured in this clone on the branch point (`e8c3e55a`) with the five
+modified files stashed and the two new files moved aside: `make lint` gave
+`0 issues.` `make test`/`make race` on develop are `420 passed · 9 skipped`; the
+one extra test is `TestBehaviourRunEnv`, which is the whole of the difference.
+
+An earlier run of the same gates, before the unparam resolution above, gave
+`421 passed · 9 skipped · 3m47s` (test) and `421 passed · 9 skipped · 4m53s`
+(race) with `1 issues:` from lint; the numbers above are the re-run after that
+one line changed.
+
+Both `make test` runs and both `make race` runs were started only after
+confirming with `ps -eo pid,cmd | grep -E "make (test|race)|jobqueue.test"` and
+`uptime` that no other clone's run was active and load was below 2, since
+concurrent runs on this box have produced false failures. Neither
+`TestReliable2FastStartupNoHistoryScan` nor `TestRESTJobModificationEndpoint`
+failed in any of the four runs.

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -304,6 +304,10 @@ func (b *Behaviour) cleanup(snap jobWorkSpaceSnapshot, _ bool) error {
 // The directory comes back held open, and cmd.Dir names that handle where the
 // platform allows it to be named, so the command starts in the directory that was
 // proven rather than in whatever its path resolves to by then; see runDir.
+//
+// The environment comes from the same snapshot, so the command runs in the one
+// the Job's own Cmd ran in - including the HOME --change_home gave it; see
+// runEnv.
 func (b *Behaviour) run(snap jobWorkSpaceSnapshot) error {
 	bc, wasStr := b.Arg.(string)
 	if !wasStr {
@@ -323,12 +327,23 @@ func (b *Behaviour) run(snap jobWorkSpaceSnapshot) error {
 	if strings.Contains(bc, " | ") {
 		bc = "set -o pipefail; " + bc
 	}
+
+	// the command is part of the same job as the Cmd, so it runs in the same
+	// environment; an environment that cannot be read refuses the behaviour, the
+	// way Execute buries a Job whose environment it cannot read, rather than
+	// running the user's command in the wrong one. See runEnv.
+	env, err := snap.runEnv(dir)
+	if err != nil {
+		return fmt.Errorf("run behaviour refused: the job's environment could not be read: %w", err)
+	}
+
 	// *** hardcoding bash here, when we could in theory have client.Execute()
 	// pass shell in? And yes, we're allowing user to run absolutely any command
 	// they like, but that is the very nature of this app. This runs as them,
 	// so can do whatever they can do...
 	cmd := exec.CommandContext(context.Background(), "/bin/bash", "-c", bc)
 	cmd.Dir = dir.execDir()
+	cmd.Env = env
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -436,9 +451,43 @@ func (j *Job) pinBehavioursLocked() pinnedBehaviours {
 	return pinnedBehaviours{behaviours: j.Behaviours, workSpace: j.workSpaceSnapshotLocked(), run: j.runID}
 }
 
-// trigger runs the pinned Behaviours against the pinned state.
-func (p pinnedBehaviours) trigger(success bool) error {
-	return p.behaviours.trigger(success, p.workSpace)
+// trigger runs the pinned Behaviours against the pinned state, as the FAILURE it
+// always is: a pin is only ever triggered after the lost run it names was
+// confirmed dead and killed (see triggerLostRunBehaviours), so that run did not
+// succeed and OnFailure is the trigger it gets.
+func (p pinnedBehaviours) trigger() error {
+	return p.behaviours.trigger(false, p.workSpace)
+}
+
+// fillEnvFromDB gives the pinned state the environment the Job's Cmd ran under,
+// which the MANAGER does not hold on the Job: it keeps one copy per distinct
+// environment in its database and only the key naming it on each Job (see
+// Job.EnvKey). The pin carries that key, and the stored value is content-
+// addressed by it, so fetching it here gets the same value the pin named.
+//
+// Without this, a `run` behaviour the manager triggers for a lost job would
+// execute with the MANAGER's environment - a different machine's under a cloud
+// deployment - so the same behaviour string would act on a different HOME
+// depending on whether the job failed normally or was declared lost.
+//
+// It must be called with no lock held, since it reads the database, and it reads
+// nothing unless a `run` behaviour is there to need it.
+func (p *pinnedBehaviours) fillEnvFromDB(ctx context.Context, jobsDB *db) {
+	env := &p.workSpace.env
+	if env.stored.retrieved || env.envKey == "" || !p.behaviours.includesRun() {
+		return
+	}
+
+	env.stored.envC = jobsDB.retrieveEnv(ctx, env.envKey)
+	env.stored.retrieved = true
+}
+
+// includesRun tells you if one of the behaviours is Run, ie. if any of them
+// needs the Job's environment.
+func (bs Behaviours) includesRun() bool {
+	return slices.ContainsFunc(bs, func(b *Behaviour) bool {
+		return b.Do == Run
+	})
 }
 
 // RemovalRequested tells you if one of the behaviours is Remove.

--- a/jobqueue/behaviours.go
+++ b/jobqueue/behaviours.go
@@ -47,6 +47,7 @@ var (
 	errBehaviourInvalidStatus = errors.New("invalid status")
 	errBehaviourArgNotStr     = errors.New("arg is not a string")
 	errBehaviourArgNotStrSl   = errors.New("arg is not a []string")
+	errEnvNotInDB             = errors.New("no environment is stored in the database under the job's env key")
 )
 
 // cleanupProvenHook, when set, is called between the cleanup path proving which
@@ -470,6 +471,16 @@ func (p pinnedBehaviours) trigger() error {
 // deployment - so the same behaviour string would act on a different HOME
 // depending on whether the job failed normally or was declared lost.
 //
+// A key with no record behind it is recorded as unread rather than filled in as
+// an empty environment: an empty one is decoded as "the Job stored none", which
+// falls back to the current process's, and that is this triggering process - the
+// manager - all over again. The pin then refuses the `run` behaviour instead of
+// running the user's command with the wrong environment; see jobRunEnv.unread.
+//
+// db.retrieve draws that distinction for us, copying only a value bolt found, so
+// an environment stored as empty comes back non-nil and empty while an absent
+// key comes back nil.
+//
 // It must be called with no lock held, since it reads the database, and it reads
 // nothing unless a `run` behaviour is there to need it.
 func (p *pinnedBehaviours) fillEnvFromDB(ctx context.Context, jobsDB *db) {
@@ -478,7 +489,14 @@ func (p *pinnedBehaviours) fillEnvFromDB(ctx context.Context, jobsDB *db) {
 		return
 	}
 
-	env.stored.envC = jobsDB.retrieveEnv(ctx, env.envKey)
+	envC := jobsDB.retrieveEnv(ctx, env.envKey)
+	if envC == nil {
+		env.unread = fmt.Errorf("%w: %s", errEnvNotInDB, env.envKey)
+
+		return
+	}
+
+	env.stored.envC = envC
 	env.stored.retrieved = true
 }
 

--- a/jobqueue/behaviours_env_test.go
+++ b/jobqueue/behaviours_env_test.go
@@ -76,6 +76,18 @@ func readProbedEnv(out string) probedEnv {
 	return probedEnv{home: lines[0], tmpDir: lines[1], testVar: lines[2]}
 }
 
+// probedEnvIfRun is what a `run` Behaviour's command reported, or the zero
+// probedEnv when the behaviour refused to run the command at all: a refused
+// behaviour writes nothing, so any value here names an environment some process
+// handed the command.
+func probedEnvIfRun(out string) probedEnv {
+	if _, err := os.Stat(filepath.Clean(out)); os.IsNotExist(err) {
+		return probedEnv{}
+	}
+
+	return readProbedEnv(out)
+}
+
 // storeTestEnv gives job the environment it was added with: the calling process's
 // (so the command has a PATH) with its HOME replaced and a variable of the test's
 // own added, the way wr's own --env override does it.
@@ -206,6 +218,41 @@ func TestBehaviourRunEnv(t *testing.T) {
 			got := readProbedEnv(out)
 			So(got.testVar, ShouldEqual, "from_job_env")
 			So(got.home, ShouldEqual, actualCwd)
+		})
+
+		Convey("the manager refuses a lost Job's run behaviour when the environment is missing from its database", func() {
+			// an environment the database cannot produce is NOT an empty one:
+			// falling back to the current environment here would run the user's
+			// command with the MANAGER's, which is the exact leak the cases
+			// above pin. It must refuse, and say so.
+			ctx := context.Background()
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, Behaviours: Behaviours{probe}}
+			realWorkSpace(job)
+
+			testDB, _, err := initDB(ctx, filepath.Join(t.TempDir(), "queue.db"), "",
+				internal.Development, false, false)
+			So(err, ShouldBeNil)
+
+			defer func() { So(testDB.close(ctx), ShouldBeNil) }()
+
+			// the key of an environment that was never stored, as a Job whose
+			// env record has gone from the database has
+			job.EnvKey = byteKey([]byte("an environment that was never stored"))
+
+			pin := job.pinBehaviours()
+			pin.fillEnvFromDB(ctx, testDB)
+
+			err = pin.trigger()
+
+			// nothing reported means the command never ran; a HOME or a TMPDIR
+			// here is one the triggering process handed it
+			got := probedEnvIfRun(out)
+			So(got.home, ShouldBeBlank)
+			So(got.tmpDir, ShouldBeBlank)
+
+			// and the refusal is reported rather than silent
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "the job's environment could not be read")
 		})
 
 		Convey("only a run behaviour makes the Job's environment be decoded", func() {

--- a/jobqueue/behaviours_env_test.go
+++ b/jobqueue/behaviours_env_test.go
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/internal"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// testEnvVar is a variable the tests put in a Job's stored environment and
+// nowhere else, so a `run` Behaviour that reports a value for it can only have
+// got it from the Job.
+const testEnvVar = "WR_TEST_BEHAVIOUR_ENV"
+
+// testStoredHome is the HOME in a Job's stored environment: neither the calling
+// process's nor any directory wr creates, so each of the three is told apart by
+// the value the behaviour reports.
+const testStoredHome = "/nonexistent/stored-home"
+
+// probedEnv is what a `run` Behaviour's command found in its OWN environment. The
+// behaviour runs in a process of its own, so it writes these to a file and the
+// test reads them back; see envProbeBehaviour.
+type probedEnv struct {
+	home    string
+	tmpDir  string
+	testVar string
+}
+
+// envProbeBehaviour is a `run` Behaviour whose command reports the environment it
+// was given to the named file.
+func envProbeBehaviour(out string) *Behaviour {
+	return &Behaviour{
+		When: OnExit,
+		Do:   Run,
+		Arg:  `printf '%s\n%s\n%s\n' "$HOME" "$TMPDIR" "$` + testEnvVar + `" > ` + out,
+	}
+}
+
+// readProbedEnv reads back what envProbeBehaviour's command reported.
+func readProbedEnv(out string) probedEnv {
+	reported, err := os.ReadFile(filepath.Clean(out))
+	So(err, ShouldBeNil)
+
+	lines := strings.Split(strings.TrimSuffix(string(reported), "\n"), "\n")
+	So(len(lines), ShouldEqual, 3)
+
+	return probedEnv{home: lines[0], tmpDir: lines[1], testVar: lines[2]}
+}
+
+// storeTestEnv gives job the environment it was added with: the calling process's
+// (so the command has a PATH) with its HOME replaced and a variable of the test's
+// own added, the way wr's own --env override does it.
+func storeTestEnv(job *Job) {
+	env, err := compressEnv(envOverride(os.Environ(),
+		[]string{"HOME=" + testStoredHome, testEnvVar + "=from_job_env"}))
+	So(err, ShouldBeNil)
+
+	job.EnvC = env
+	job.EnvCRetrieved = true
+}
+
+func TestBehaviourRunEnv(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// a `run` behaviour is part of the same job as the Cmd, so it has to run in
+	// the same environment: the one captured when the job was added, with the
+	// job's own TMPDIR, and with the HOME --change_home gave the Cmd. Inheriting
+	// the calling process's environment instead pointed `rm -rf $HOME/scratch`
+	// at the user's real home - the one directory --change_home exists to keep
+	// the job out of - and, on the manager's lost-job path, at a different
+	// machine's home altogether.
+	Convey("Given a Job whose stored environment differs from this process's", t, func() {
+		cwd := t.TempDir()
+		reports := t.TempDir()
+		out := filepath.Join(reports, "env")
+		probe := envProbeBehaviour(out)
+
+		So(os.Getenv("HOME"), ShouldNotEqual, testStoredHome)
+		So(os.Getenv(testEnvVar), ShouldBeBlank)
+
+		Convey("a run behaviour executes with the Job's environment, not this process's", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd}
+			storeTestEnv(job)
+			actualCwd, _, tmpDir := realWorkSpace(job)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.testVar, ShouldEqual, "from_job_env")
+			So(got.home, ShouldEqual, testStoredHome)
+			So(got.tmpDir, ShouldEqual, tmpDir)
+			So(got.tmpDir, ShouldNotEqual, os.Getenv("TMPDIR"))
+			// without --change_home, HOME stays whatever the Job was added with
+			So(got.home, ShouldNotEqual, actualCwd)
+		})
+
+		Convey("--change_home points a run behaviour's HOME at the Job's working directory", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, ChangeHome: true}
+			storeTestEnv(job)
+			actualCwd, _, _ := realWorkSpace(job)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.home, ShouldEqual, actualCwd)
+			So(got.home, ShouldNotEqual, os.Getenv("HOME"))
+		})
+
+		Convey("an env override reaches a run behaviour", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd}
+			storeTestEnv(job)
+			realWorkSpace(job)
+			So(job.EnvAddOverride([]string{testEnvVar + "=from_override"}), ShouldBeNil)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			So(readProbedEnv(out).testVar, ShouldEqual, "from_override")
+		})
+
+		Convey("a CwdMatters Job's run behaviour gets its environment untouched", func() {
+			// wr creates no working directory for such a Job, so Execute gives
+			// its Cmd no TMPDIR and no HOME of wr's, whatever --change_home says.
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, CwdMatters: true, ChangeHome: true}
+			storeTestEnv(job)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.testVar, ShouldEqual, "from_job_env")
+			So(got.home, ShouldEqual, testStoredHome)
+			So(got.tmpDir, ShouldBeBlank)
+		})
+
+		Convey("the behaviours the manager pins carry the Job's environment", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, ChangeHome: true, Behaviours: Behaviours{probe}}
+			storeTestEnv(job)
+			actualCwd, _, _ := realWorkSpace(job)
+
+			pin := job.pinBehaviours()
+			So(pin.trigger(), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.testVar, ShouldEqual, "from_job_env")
+			So(got.home, ShouldEqual, actualCwd)
+		})
+
+		Convey("the manager gives a lost Job's run behaviour the environment from its database", func() {
+			// the manager keeps one copy of each distinct environment in its
+			// database and only the key naming it on the Job, so a pin taken
+			// there carries no environment at all and the behaviour would run
+			// with the MANAGER's. This is what triggerLostRunBehaviours does,
+			// without the concurrency token.
+			ctx := context.Background()
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, ChangeHome: true, Behaviours: Behaviours{probe}}
+			actualCwd, _, _ := realWorkSpace(job)
+
+			env, err := compressEnv(envOverride(os.Environ(),
+				[]string{"HOME=" + testStoredHome, testEnvVar + "=from_job_env"}))
+			So(err, ShouldBeNil)
+
+			testDB, _, err := initDB(ctx, filepath.Join(t.TempDir(), "queue.db"), "",
+				internal.Development, false, false)
+			So(err, ShouldBeNil)
+
+			defer func() { So(testDB.close(ctx), ShouldBeNil) }()
+
+			job.EnvKey, err = testDB.storeEnv(env)
+			So(err, ShouldBeNil)
+			So(job.EnvC, ShouldBeNil)
+
+			pin := job.pinBehaviours()
+			pin.fillEnvFromDB(ctx, testDB)
+			So(pin.trigger(), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.testVar, ShouldEqual, "from_job_env")
+			So(got.home, ShouldEqual, actualCwd)
+		})
+
+		Convey("only a run behaviour makes the Job's environment be decoded", func() {
+			// decoding is a decompress and a decode of every variable the Job was
+			// added with, on the path of every Job that exits, so a Job with no
+			// behaviours - most of them - and one with only a cleanup must not
+			// pay for it.
+			decodes := 0
+			envDecodeHook = func() { decodes++ }
+
+			defer func() { envDecodeHook = nil }()
+
+			job := &Job{Cwd: cwd, Cmd: testWSCmd}
+			storeTestEnv(job)
+			realWorkSpace(job)
+
+			So(job.TriggerBehaviours(false), ShouldBeNil)
+			So(decodes, ShouldEqual, 0)
+
+			job.Behaviours = Behaviours{{When: OnExit, Do: CleanupAll}}
+			So(job.TriggerBehaviours(false), ShouldBeNil)
+			So(decodes, ShouldEqual, 0)
+
+			job.Behaviours = Behaviours{probe}
+			realWorkSpace(job)
+
+			So(job.TriggerBehaviours(false), ShouldBeNil)
+			So(decodes, ShouldEqual, 1)
+			So(readProbedEnv(out).testVar, ShouldEqual, "from_job_env")
+		})
+	})
+}

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -624,16 +624,59 @@ func (j *Job) WallTime() time.Duration {
 // In both cases, alters the return value to apply any overrides stored in
 // job.EnvOverride.
 func (j *Job) Env() ([]string, error) {
-	overrideEs, err := j.envCurrentOverrides()
+	return jobEnv{envC: j.EnvC, overrides: j.envOverrideSnapshot(), retrieved: j.EnvCRetrieved}.decode()
+}
+
+// envDecodeHook, when set, is called every time a Job's stored environment is
+// decoded, so that a test can count the decodes a code path makes. Decoding is a
+// decompress plus a decode of every variable the Job was added with, on the path
+// of every Job that exits, and a path that does none of it cannot show that in
+// its result, only in the work it did. It is nil in production.
+var envDecodeHook func() //nolint:gochecknoglobals // the only seam onto work that has no result
+
+// jobEnv is a Job's environment in the compressed form the Job keeps it in:
+// EnvC, EnvOverride, and whether EnvC was asked for (see Env for what each case
+// means).
+//
+// Copying it costs three fields, while decoding it costs a decompress and a
+// decode of every variable, so a consumer that may not need the environment can
+// carry this and decode only if it turns out to need it; see jobRunEnv.
+type jobEnv struct {
+	envC      []byte
+	overrides []byte
+	retrieved bool
+}
+
+// storedEnvLocked copies the Job's stored environment. The caller must hold at
+// least the Job's read lock.
+//
+// Copying the slice headers is enough, since both are only ever replaced
+// wholesale - EnvC by the retrieval that fills it, EnvOverride by
+// EnvAddOverride.
+func (j *Job) storedEnvLocked() jobEnv {
+	return jobEnv{envC: j.EnvC, overrides: j.EnvOverride, retrieved: j.EnvCRetrieved}
+}
+
+// decode is Env for an environment already copied out of a Job.
+func (e jobEnv) decode() ([]string, error) {
+	if envDecodeHook != nil {
+		envDecodeHook()
+	}
+
+	overrideEs, err := decodeCompressedEnv(e.overrides)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(j.EnvC) == 0 {
-		return j.envWithoutStored(overrideEs)
+	if len(e.envC) == 0 {
+		if !e.retrieved {
+			return nil, nil
+		}
+
+		return applyEnvOverrides(os.Environ(), overrideEs), nil
 	}
 
-	env, err := j.decodeStoredEnv()
+	env, err := e.decodeStored()
 	if err != nil {
 		return nil, err
 	}
@@ -641,21 +684,29 @@ func (j *Job) Env() ([]string, error) {
 	return applyEnvOverrides(env, overrideEs), nil
 }
 
-// envWithoutStored returns the environment to use for a Job that has no stored
-// EnvC: the current environment (with overrides applied) if its environment was
-// retrieved, else nil.
-func (j *Job) envWithoutStored(overrideEs []string) ([]string, error) {
-	if !j.EnvCRetrieved {
+// decodeStored decodes e.envC, falling back to the current environment if a nil
+// environment was stored.
+func (e jobEnv) decodeStored() ([]string, error) {
+	env, err := decodeCompressedEnv(e.envC)
+	if err != nil {
+		return nil, err
+	}
+
+	if env == nil {
+		return os.Environ(), nil
+	}
+
+	return env, nil
+}
+
+// decodeCompressedEnv decompresses and decodes an environment stored by
+// compressEnv, answering nil for a blank one.
+func decodeCompressedEnv(compressed []byte) ([]string, error) {
+	if len(compressed) == 0 {
 		return nil, nil
 	}
 
-	return applyEnvOverrides(os.Environ(), overrideEs), nil
-}
-
-// decodeStoredEnv decompresses and decodes j.EnvC, falling back to the current
-// environment if a nil environment was stored.
-func (j *Job) decodeStoredEnv() ([]string, error) {
-	decompressed, err := decompress(j.EnvC)
+	decompressed, err := decompress(compressed)
 	if err != nil {
 		return nil, err
 	}
@@ -666,10 +717,6 @@ func (j *Job) decodeStoredEnv() ([]string, error) {
 
 	if err = dec.Decode(es); err != nil {
 		return nil, err
-	}
-
-	if es.Environ == nil {
-		return os.Environ(), nil
 	}
 
 	return es.Environ, nil
@@ -687,26 +734,7 @@ func applyEnvOverrides(env, overrideEs []string) []string {
 
 // envCurrentOverrides decompresses and decodes any existing EnvOverride.
 func (j *Job) envCurrentOverrides() ([]string, error) {
-	envOverride := j.envOverrideSnapshot()
-	if len(envOverride) == 0 {
-		return nil, nil
-	}
-
-	decompressed, err := decompress(envOverride)
-	if err != nil {
-		return nil, err
-	}
-
-	ch := new(codec.BincHandle)
-	dec := codec.NewDecoderBytes(decompressed, ch)
-	overrideEs := &envStr{}
-
-	err = dec.Decode(overrideEs)
-	if err != nil {
-		return nil, err
-	}
-
-	return overrideEs.Environ, err
+	return decodeCompressedEnv(j.envOverrideSnapshot())
 }
 
 func (j *Job) envOverrideSnapshot() []byte {

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -1406,7 +1406,7 @@ func TestReservedRunDoesNotInheritThePreviousRunsWorkingDir(t *testing.T) {
 
 			pin := r.live.pinBehaviours()
 			So(pin.workSpace.actualCwd, ShouldBeBlank)
-			So(pin.trigger(false), ShouldNotBeNil)
+			So(pin.trigger(), ShouldNotBeNil)
 			soPathsGone(ranIn)
 			soPathsExist(r.actualCwd)
 

--- a/jobqueue/server.go
+++ b/jobqueue/server.go
@@ -4673,8 +4673,14 @@ func (s *Server) triggerLostRunBehaviours(ctx context.Context, d lostJobDetails)
 
 	defer func() { <-s.lostCleanupTokens }()
 
+	// the manager keeps a job's environment in its database rather than on the
+	// job, so the bytes the pinned key names are fetched here: after every lock
+	// the pin was taken under was released, and before the behaviours that need
+	// them run. See pinnedBehaviours.fillEnvFromDB.
+	d.pin.fillEnvFromDB(ctx, s.db)
+
 	//nolint:contextcheck // behaviours run detached from the cancellable job context
-	if errt := d.pin.trigger(false); errt != nil {
+	if errt := d.pin.trigger(); errt != nil {
 		clog.Warn(ctx, "failed to run behaviours for a killed lost job", "err", errt)
 	}
 }

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -111,6 +111,12 @@ type jobRunEnv struct {
 	// manager keeps it rather than on the Job; see
 	// pinnedBehaviours.fillEnvFromDB.
 	envKey string
+
+	// unread is why the Job's environment could not be read, when the attempt to
+	// read it failed. It is what tells "the Job's environment is empty" - which
+	// runs the command with this process's, as the Job's own Cmd does - apart
+	// from "the Job's environment is unknown to us", which must not.
+	unread error
 }
 
 // cleanupWorkSpace resolves the snapshot's workspace and clears it out, doing
@@ -184,8 +190,14 @@ func (j *Job) workSpaceSnapshotLocked() jobWorkSpaceSnapshot {
 // same job as the Cmd, so the two run in the same environment.
 //
 // A nil result means the Job carried no environment and none was asked for, and
-// leaves exec.Cmd inheriting this process's.
+// leaves exec.Cmd inheriting this process's. An environment that could not be
+// read is an error instead, so the command is refused rather than run with the
+// triggering process's; see jobRunEnv.unread.
 func (s jobWorkSpaceSnapshot) runEnv(dir *runDir) ([]string, error) {
+	if s.env.unread != nil {
+		return nil, s.env.unread
+	}
+
 	env, err := s.env.stored.decode()
 	if err != nil {
 		return nil, err

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -74,17 +74,43 @@ var workSpaceResolveHook func() //nolint:gochecknoglobals // the only seam onto 
 // unconditionally rather than judging whether Unmount has already run.
 const muxfysCachePrefix = ".muxfys"
 
-// jobWorkSpaceSnapshot is the copy of a Job's fields that the workspace
-// resolution needs, taken under the Job's lock and used only after releasing it:
-// the resolution walks the filesystem, and ActualCwd is written under the lock
-// by applyLiveSnapshot while cleanup runs in the same manager process, so
-// reading it unlocked is a race that decides which directory gets deleted.
+// jobWorkSpaceSnapshot is the copy of a Job's state that its behaviours act on -
+// the fields the workspace resolution needs, and the environment a `run`
+// Behaviour's command executes with - taken under the Job's lock and used only
+// after releasing it: the resolution walks the filesystem, and ActualCwd is
+// written under the lock by applyLiveSnapshot while cleanup runs in the same
+// manager process, so reading it unlocked is a race that decides which directory
+// gets deleted.
 type jobWorkSpaceSnapshot struct {
 	cwdMatters bool
 	cwd        string
 	actualCwd  string
 	key        string
 	mounts     MountConfigs
+	env        jobRunEnv
+}
+
+// jobRunEnv is the Job state a `run` Behaviour needs to execute its command in
+// the environment the Job's Cmd ran in.
+//
+// The environment is carried in the compressed form the Job stores it in, and
+// decoded only when a `run` Behaviour actually fires: Behaviours.Trigger answers
+// "are there any behaviours at all?" before taking a snapshot because most Jobs
+// have none, and most of those that do have only a cleanup, while decoding costs
+// a decompress and a decode of every variable the Job was added with.
+type jobRunEnv struct {
+	// stored is the Job's own environment: what Execute gave its Cmd, before the
+	// directories below are put in it.
+	stored jobEnv
+
+	// changeHome says whether HOME is to become the Job's working directory, as
+	// Execute makes it for the Job's own Cmd.
+	changeHome bool
+
+	// envKey names stored.envC in the manager's database, which is where the
+	// manager keeps it rather than on the Job; see
+	// pinnedBehaviours.fillEnvFromDB.
+	envKey string
 }
 
 // cleanupWorkSpace resolves the snapshot's workspace and clears it out, doing
@@ -144,7 +170,41 @@ func (j *Job) workSpaceSnapshotLocked() jobWorkSpaceSnapshot {
 		actualCwd:  j.ActualCwd,
 		key:        j.Key(),
 		mounts:     j.MountConfigs,
+		env: jobRunEnv{
+			stored:     j.storedEnvLocked(),
+			changeHome: j.ChangeHome,
+			envKey:     j.EnvKey,
+		},
 	}
+}
+
+// runEnv is the environment a `run` Behaviour's command executes with: the one
+// Execute gave the Job's own Cmd, with the directories wr made for the Job put in
+// it exactly as Execute puts them (see runDir.dirEnv). The command is part of the
+// same job as the Cmd, so the two run in the same environment.
+//
+// A nil result means the Job carried no environment and none was asked for, and
+// leaves exec.Cmd inheriting this process's.
+func (s jobWorkSpaceSnapshot) runEnv(dir *runDir) ([]string, error) {
+	env, err := s.env.stored.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	dirEnv := dir.dirEnv(s.env.changeHome)
+	if len(dirEnv) == 0 {
+		return env, nil
+	}
+
+	if env == nil {
+		// the Job's own environment was never stored and never retrieved, so
+		// this process's is all there is to run with - which is what exec.Cmd
+		// would inherit anyway. Naming it is what lets the Job's own directories
+		// still be put in it.
+		env = os.Environ()
+	}
+
+	return envOverride(env, dirEnv), nil
 }
 
 // workSpacePaths is the lexical half of the resolution: the Job's directories,
@@ -400,6 +460,30 @@ type runDir struct {
 	// path is the directory's name, used when there is no handle and as the
 	// fallback where a handle cannot be named to exec.
 	path string
+
+	// tmp is the tmp dir wr made beside the working directory to be the Job's
+	// TMPDIR, or blank when wr made no workspace and so no tmp dir; see dirEnv.
+	tmp string
+}
+
+// dirEnv is the part of a `run` Behaviour's environment that comes from the
+// directories wr made for the Job: its TMPDIR, and its working directory as HOME
+// when the Job asked for that.
+//
+// Execute sets both on the Job's own Cmd, and only for a Job it made a workspace
+// for: a CwdMatters Job runs in the user's own Cwd with neither, whatever
+// --change_home says, so this answers nothing for one.
+func (r *runDir) dirEnv(changeHome bool) []string {
+	if r.tmp == "" {
+		return nil
+	}
+
+	dirEnv := []string{"TMPDIR=" + r.tmp}
+	if changeHome {
+		dirEnv = append(dirEnv, "HOME="+r.path)
+	}
+
+	return dirEnv
 }
 
 // openRunDir hands back the Job's working directory, held open.
@@ -414,7 +498,11 @@ func (ws *jobWorkSpace) openRunDir() (*runDir, error) {
 		return nil, fmt.Errorf("%w: refusing to run in %s: %w", errNotBelowBaseDir, ws.paths.actualCwd, err)
 	}
 
-	return &runDir{held: held, path: ws.paths.actualCwd}, nil
+	return &runDir{
+		held: held,
+		path: ws.paths.actualCwd,
+		tmp:  filepath.Join(ws.paths.workSpace, createdTmpName),
+	}, nil
 }
 
 // execDir is the name to give exec.Cmd's Dir.


### PR DESCRIPTION
A `run` behaviour executed with the wrong environment: `Behaviour.run` set `cmd.Dir` but never `cmd.Env`, so the command inherited whichever process happened to be running it.

It therefore did not get the environment captured when the job was added, nor `--env` overrides, nor `TMPDIR` pointing at the job's own tmp dir, nor the `HOME` that `--change_home` installs. Measured on a `ChangeHome` job: the `Cmd` saw `HOME=<actualCwd>` while the behaviour saw `/home/ubuntu`. So `--on_exit 'run:rm -rf $HOME/scratch'` acted on the user's real home — the directory `--change_home` exists to keep the job out of. `--on_exit 'run:module load x; ...'` could not work either, since the loaded modules live in the discarded environment.

On the lost-job path the same function runs in the **manager**, so the behaviour got the manager's environment — a different machine's under a cloud deployment. That half was worse than it first appeared: server-side jobs deliberately carry only `EnvKey` and not `EnvC`, so `job.Env()` on the manager returns nothing at all, and the manager could not have supplied the job's environment even if it had tried.

`jobWorkSpaceSnapshot` now carries the compressed environment, the `--env` overrides and `ChangeHome`, captured in the same locked moment as everything else — behaviours act on a snapshot rather than re-reading a live `*Job`, and that property is what stops a lost job's behaviours acting on its own retry, so the environment had to be captured the same way rather than fetched later. `HOME` and `TMPDIR` are derived from the *proven* run directory rather than carried, so they cannot name somewhere the proof did not establish. The manager fetches the stored environment from the database, and only when a `run` behaviour is actually present.

Cost is unchanged for jobs that do not need it: the capture copies slice headers only, and the decode happens inside the run itself. A new test hook pins that — zero decodes for a job with no behaviours, zero for a cleanup-only job, one once a `run` is present. `Behaviours.Trigger`'s "are there any behaviours at all?" early-out, which exists because most jobs have none, is untouched.

What the manager still cannot reproduce, and neither could anything before this change: a job added with no environment at all (`Job.Env()` then falls back to the decoding process's own environment), and the bsub-emulation additions, which are computed at execution time and never stored.

Found by an adversarial probe of develop.

`make test` and `make race` both 421 passed / 9 skipped (+1 on develop's 420); `make lint` 0 issues. Four guard mutations, each red on exactly the assertions it should be — dropping the stored environment leaves the `--change_home` case green, since `HOME` comes from the proven directory, so the two guards are independent.

`.docs/bugfixes/260902-7.md` has the mechanism, the cost measurements and the reproduction limits.
