### PR TITLE
Stop a wedged docker daemon hanging a job, and killing others' containers

### DIFF
--- a/.docs/bugfixes/260902-8.md
+++ b/.docs/bugfixes/260902-8.md
@@ -590,3 +590,83 @@ Reverted, `go vet` clean and green again.
 The other tests of `resolveContainerMem` lost their `So(err, ShouldBeNil)`
 along with the return value; they now assert `dm.failures`, which is what
 `noteCallResult` recorded, so they still say whether the call worked.
+
+## Review finding B: a doc comment that promised more than the code did
+
+### Where this came from
+
+The same review, on `jobqueue/client.go` around line 345:
+`checkingRendezvous.finished()` sent on a channel of capacity 1 under a doc
+comment saying "It never blocks". A second call would block for ever.
+
+### The mechanism
+
+One caller exists today (the end of `Execute`'s checking goroutine), so nothing
+calls it twice and the promise held by accident. It is still the wrong thing to
+leave in this file: the whole point of fix A above is that an unbuffered
+rendezvous hung a job for ever, and the comment is what the next person adding
+a `finished()` call - an early return from the checking loop, a `defer` - would
+read and trust. `await` giving up is what makes a second report possible at all,
+since the buffered one can then still be sitting unread.
+
+### The fix
+
+The send is now non-blocking, so the comment is true:
+
+```go
+	select {
+	case r.ch <- true:
+	default:
+	}
+```
+
+Dropping the report the buffer has no room for loses nothing: the rendezvous
+carries one fact, that the checking goroutine has stopped, and the buffered
+report already says it. Correcting the comment instead was the alternative, and
+it was rejected: "never blocks" is the property `await`'s give-up depends on,
+so it is better to make the code have it than to write down that it does not.
+
+### Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestCheckingRendezvous
+
+The new case in `TestCheckingRendezvous` calls `finished()` twice from a
+goroutine and waits on a channel with a `dockerTestBound` timeout, so a hang
+fails an assertion instead of wedging the suite.
+
+Failing output before the fix:
+
+```text
+=== RUN   TestCheckingRendezvous
+
+  Given a checking rendezvous whose checker never finishes
+    Waiting for it gives up instead of blocking for ever ✔
+      And a checker that finishes later does not block for ever
+    Waiting for a checker that does finish reports that it finished ✔
+    A checker that reports finishing twice does not block on the second report ✘
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 119:
+  Expected 'the second finished() blocked' to be blank (but it wasn't)!
+
+3 total assertions
+
+--- FAIL: TestCheckingRendezvous (30.13s)
+```
+
+Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 0.110s`.
+The 30s of red is the bound being exceeded; the 0.1s of green is the second
+report being dropped instead of parked.
+
+### Mutation checks
+
+`go vet ./jobqueue/` clean after each edit (`vet rc=0`).
+
+- [x] **RB-M1: the blocking send restored** - `r.ch <- true`. **RED**, 30.12s,
+  on the new case only, with the output quoted above. The other three cases
+  stay green, including "a checker that finishes later does not block for
+  ever" - that one sends into an empty buffer, so it cannot catch this.
+
+Reverted, `go vet` clean and green again.

--- a/.docs/bugfixes/260902-8.md
+++ b/.docs/bugfixes/260902-8.md
@@ -466,3 +466,127 @@ taken: it moved the new `newDockerInteractor`, `newDockerMonitor`, `callCtx`,
 `dockerMonitor` type and the rest of its methods. They are kept together with
 the type instead, as in `.docs/bugfixes/260902-3.md` where the same tool's
 reordering was declined.
+
+## Review finding A: a docker lookup error ran a successful job's on_failure
+
+### Where this came from
+
+A review of the branch, on `jobqueue/client.go` around line 1280:
+`resolveContainerMem` returned its container-lookup error for accumulation, and
+`Execute` joined it into `myerr`, which is half of what
+`job.TriggerBehaviours(err == nil && myerr == nil)` is given.
+
+### The mechanism
+
+Verified with the fake docker daemon described below: one 500 from
+`/containers/json` during the run of a command that exited 0 was enough to run
+the job's `on_failure` behaviours. That is the user's own failure handling - a
+`cleanup_all` that deletes the job's working directory, or any command they
+chose with `--on_failure 'run:...'` - fired by nothing worse than a docker
+daemon hiccup.
+
+The three tolerated failures fix A allows before giving up (`noteCallResult`)
+are enough to reach `myerr`, so the tolerance did not protect against this; it
+only bounded how many wrapped errors accumulated.
+
+This matters more now than when the branch was written. `myerr` used to be
+overwritten wholesale by `classifyExecOutcome`'s (`myerr = outcome.myerr`), so
+the lookup error never reached `Execute`'s return value - but it always reached
+`TriggerBehaviours`, which is called before that. PR #571 additionally keeps the
+accumulated `myerr` when the unmount's verdict wins, so it now reaches the
+return value too.
+
+### The fix
+
+`resolveContainerMem` no longer returns an error at all. `noteCallResult`
+already logs every failure, counts them, and gives up on monitoring after
+`dockerFailureTolerance`, which is the honest place for a monitoring problem:
+the job's command runs independently of docker's responsiveness, so all a
+failed reading costs the user is under-reported usage. Dropping the return
+value rather than ignoring it at the call site is what stops the next reader
+re-joining it.
+
+**What still propagates: a kill.** `killContainer`'s error keeps reaching
+`killErr` and so `myerr`, because the two are not the same kind of event. A
+reading we could not take is information we did not get; a kill we were asked
+to do and could not do leaves the user's container running after wr has
+reported the job dead, which no later check makes good, and which the user has
+to know about. The doc comments on both methods now say which side of that line
+they are on and why.
+
+`ContainerStats`' error was already not propagated ("a container that has gone
+away is normal and not the job's problem"), so this makes the whole method
+consistent with what it already did for its second call.
+
+One incidental change: the method's last four lines are now
+`return max(mem, dockerStats.MemoryMB), dockerStats.CPUSec`. `funlen` counts
+`resolveContainerMem` at 32 lines against a limit of 30 and only reported it
+once the signature line changed (`new-from-rev: master` had been hiding it),
+and `max` is the shortening that also reads better.
+
+The checking goroutine no longer writes `myerr` at all - that line was its only
+write of it - so the comment naming the three variables it writes under
+`stateMutex` now names the two that remain.
+
+### Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestDockerLookupErrorNotJobFailure
+
+Port-free and docker-free. `TestDockerLookupErrorNotJobFailure` runs a real
+`Client.Execute` over the in-process `captureSocket` client the live-touch
+tests already use, on a job whose command succeeds (`sleep 1.5`, long enough
+for one tick of the 1s resource ticker) and which carries both an `on_success`
+and an `on_failure` `run` behaviour that touch marker files. Which markers
+exist afterwards is exactly which set of the user's behaviours ran, so the
+assertion is on the job's outcome as the user experiences it, not on an
+intermediate error value.
+
+The docker side is a fake daemon: `failingListDockerSocket` serves the docker
+HTTP API on a unix socket in `t.TempDir()`, answering the first
+`/containers/json` (so `newDockerMonitor` can remember the existing
+containers) and returning 500 to every listing after it - a transient lookup
+failure, not a wedged daemon. `DOCKER_API_VERSION` is pinned so the moby client
+asks for a version instead of negotiating one. The first `Convey` leaf runs the
+same job with no `--monitor_docker` at all, as the control that says the
+harness reports a clean success when nothing docker-related is wrong.
+
+Failing output before the fix:
+
+```text
+=== RUN   TestDockerLookupErrorNotJobFailure
+
+  Given a job with success and failure behaviours, whose command succeeds ✔✔
+    Only its success behaviours are triggered ✔✔✔✔✔
+    A docker container lookup that fails while it runs does not make it a failure ✔✔✘
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 546:
+  Expected: "on_failure behaviours ran: false"
+  Actual:   "on_failure behaviours ran: true"
+
+10 total assertions
+
+--- FAIL: TestDockerLookupErrorNotJobFailure (3.01s)
+```
+
+Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 4.041s`.
+
+### Mutation checks
+
+`go vet ./jobqueue/` reported clean after every edit (`vet rc=0`), so no verdict
+here is a build failure masquerading as a dead guard.
+
+- [x] **RA-M1: the propagation restored** - `resolveContainerMem` returns
+  `findErr` again and `Execute` joins it into `myerr` again (its existing test
+  call sites take a `_` so that the package still builds). **RED**, 3.01s, with
+  the output quoted above: `on_failure behaviours ran: true`. The control leaf
+  stays green, so the new case is not passing because the harness never
+  triggers behaviours.
+
+Reverted, `go vet` clean and green again.
+
+The other tests of `resolveContainerMem` lost their `So(err, ShouldBeNil)`
+along with the return value; they now assert `dm.failures`, which is what
+`noteCallResult` recorded, so they still say whether the call worked.

--- a/.docs/bugfixes/260902-8.md
+++ b/.docs/bugfixes/260902-8.md
@@ -1,0 +1,235 @@
+# Bugfixes 260902-8
+
+Branch `fix-docker-monitor-safety`: two defects in the docker container
+monitoring that `Client.Execute` sets up for a job.
+
+- **A**: a wedged docker daemon hung the runner for ever, holding its scheduler
+  slot, for **every** `--with_docker` job.
+- **B**: `--monitor_docker <name>` adopted a container that was already running
+  under that name, and so could SIGKILL a container wr did not start.
+
+Both live in `jobqueue/client.go`'s `dockerMonitor` plumbing and its use inside
+`Execute`, which is why they share a branch. Each is one commit.
+
+## A: an unresponsive docker daemon hung a finished job for ever
+
+### Where this came from
+
+An adversarial probe of the monitoring path's error handling, asking what
+happens when docker answers slowly or not at all. The probe replaced the docker
+daemon with a unix socket that accepts connections and never writes a byte -
+`net.Listen("unix", ...)` plus an accept loop that holds each connection open -
+pointed `DOCKER_HOST` at it, and made the same call the check loop makes:
+
+```
+PROBE: ContainerStats(context.Background()) STILL BLOCKED after 5s
+```
+
+That is the whole bug in one line: nothing in the chain from the job's context
+to the moby client's HTTP request has a deadline.
+
+### The mechanism
+
+Verified link by link on the branch point (`e8c3e55a`):
+
+- The context is `context.Background()` from `cmd/runner.go:305`
+  (`jq.Execute(context.Background(), job, ...)`) - no deadline, never
+  cancelled.
+- The moby client is built with `client.NewClientWithOpts(client.FromEnv)`
+  (client.go:1132), which sets no `http.Client.Timeout`.
+- `resolveContainerMem` (client.go:1160) calls
+  `dm.interactor.ContainerStats(ctx, ...)` (client.go:1175) once a second from
+  inside the `CHECKING` select loop.
+- Blocked there, that goroutine stops servicing `case <-stopChecking`, so it
+  never reaches `finishedChecking <- true` (client.go:2070).
+- `finishedChecking` was unbuffered (client.go:1899) and `Execute` waits on it
+  with a bare `<-finishedChecking` (client.go:2082), *after* `cmd.Wait()` has
+  already returned. There is no other way out of that receive.
+- Both `stopTouching` sends are past that point, so the touch goroutine keeps
+  touching and the manager keeps believing the job is running.
+
+Net effect: a finished job stays "running" for ever, `Execute` never returns,
+the runner never reserves again and never exits, and its LSF/OpenStack slot is
+held for ever. `wr kill` does not help: it ends up in
+`dm.operator.KillContainer(ctx, ...)` (client.go:1922) on the same
+deadline-less context.
+
+This affects every `--with_docker` job, not only `--monitor_docker` ones,
+because `containerRunCmd` sets `j.MonitorDocker = j.Key()`
+(jobqueue/job.go:567), which arms `setupDockerMonitor`.
+
+### A second mechanism the probe found: the negotiation mutex
+
+A per-call `context.WithTimeout` is **not** sufficient on its own, which the
+probe established before the fix was designed. With one deadline-less call
+already in flight on a client, a *second* call that does have a deadline still
+blocks:
+
+```
+PROBE deadline-only: returned after 500.632554ms: Get "http://...
+  /v1.55/containers/someid/stats?one-shot=true&stream=false": context deadline exceeded
+PROBE second-call: blocked >5s
+```
+
+The cause is in the client library, not in wr: `moby/client@v0.5.0` resolves the
+API version once per client and single-flights it behind a plain
+`negotiateLock sync.Mutex` that is **held across the ping request**
+(`ping.go:84`, reached from `getAPIPath` -> `checkVersion` -> `Ping`). A
+`sync.Mutex` is not context-aware, so every later call on that client waits for
+the stuck holder regardless of its own deadline. That is also why `wr kill` hung
+behind the check loop's stuck stats call.
+
+### The fix
+
+Three parts, each buying something the others cannot.
+
+1. **An HTTP timeout on the client itself**, in the new `newDockerInteractor`:
+
+   ```go
+   cli, err := client.NewClientWithOpts(client.FromEnv, client.WithTimeout(timeout))
+   ```
+
+   `client.WithTimeout` sets `http.Client.Timeout`, which covers the whole
+   request including the response body read and cannot be bypassed by any call
+   path - including the version-negotiation ping above. This is what guarantees
+   a stuck holder of `negotiateLock` lets go.
+
+2. **A deadline per monitoring operation**, via `dockerMonitor.callCtx`, applied
+   in `resolveContainerMem`, `killContainer` and the `RememberCurrentContainers`
+   call in `newDockerMonitor`. This bounds the whole operation rather than each
+   HTTP request: `resolveContainerMem` can make several calls (list, then
+   stats), and a daemon that answers every request slowly but within the HTTP
+   timeout would otherwise still be able to stretch one check indefinitely. It
+   is also the layer a fake `container.Interactor` sees, so it is the part a
+   docker-free test can prove.
+
+3. **A bounded rendezvous.** `finishedChecking` is now a `checkingRendezvous`
+   whose channel is buffered (capacity 1) and whose `await(timeout)` gives up
+   after `checkingFinishTimeout` (60s), logging loudly. A per-call timeout alone
+   still leaves `Execute` parked on an unconditional receive if the checking
+   goroutine blocks in something else we do not control (the disk walk, an NFS
+   stat), and a buffered channel alone changes nothing about the receive - the
+   send that would fill the buffer never happens. Buffering is what makes giving
+   up safe rather than a goroutine leak: with an unbuffered channel, a checker
+   that finishes after `await` gave up blocks on its send for the lifetime of
+   the runner.
+
+Because `await` can now return without the checking goroutine having stopped,
+the three variables that goroutine writes and `Execute` reads afterwards -
+`myerr`, `closeErr` and the signal branch's `killErr` - now take `stateMutex`,
+like the shared state around them already did. Without that, giving up would
+turn a hang into a data race.
+
+`killErr` in `whenKilledByServer` is deliberately left unguarded: `Execute`
+reads it only after `<-killDoneCh`, which orders the two, and taking
+`stateMutex` there would deadlock against `Execute` holding it while waiting on
+that channel.
+
+### Tolerating a docker error rather than paying for it every second
+
+With the timeouts in place, a wedged daemon turns into one failed call per
+second, for the life of the job, each costing `dockerCallTimeout` and each
+accumulating another wrapped error into `myerr` - an unbounded error chain, and
+a non-nil `myerr` makes `job.TriggerBehaviours(err == nil && myerr == nil)` run
+the *failure* behaviours of a command that succeeded.
+
+So `noteCallResult` counts consecutive failures and, after
+`dockerFailureTolerance` (3), gives up on monitoring for the rest of the run:
+the calls stop, the log says so ("giving up on monitoring a job's docker
+container; its usage will be under-reported"), and at most three errors reach
+`myerr`. The job's command runs independently of docker's responsiveness, so a
+finished command still completes normally with whatever usage was measured.
+A job wr cannot monitor **at all** still fails with a clear reason rather than
+hanging: `newDockerMonitor` returning an error buries the job with
+`FailReasonDocker`.
+
+That tolerance would have been dead code in the most common mode.
+`findContainerID` dropped the error from its by-name lookup whenever the
+following cidfile lookup found nothing (which, for a plain container name, it
+always does), so a list call against a wedged daemon reported no error at all.
+The two errors are now joined.
+
+### Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run 'TestDockerMonitorUnresponsiveDaemon|TestCheckingRendezvous'
+
+Port-free and docker-free. `jobqueue/docker_monitor_test.go` injects a
+`stallingInteractor` (a `container.Interactor` whose every call blocks until its
+context is cancelled, which is how the real moby client behaves) and asserts
+that each monitoring operation returns within a generous bound, using a channel
+so that a hang fails an assertion instead of hanging the suite. The one case
+that needs the real moby client - the HTTP timeout - uses the probe's stalling
+unix socket, so it still needs no docker.
+
+Failing output before the fix (measured with every guard below reverted; each
+`false` is a bound exceeded, and `go vet ./jobqueue/` was clean in that state):
+
+```
+=== RUN   TestCheckingRendezvous
+
+  Given a checking rendezvous whose checker never finishes
+    Waiting for it gives up instead of blocking for ever ✘
+    Waiting for a checker that does finish reports that it finished ✔
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 67:
+  Expected 'await() blocked' to be blank (but it wasn't)!
+
+--- FAIL: TestCheckingRendezvous (30.03s)
+=== RUN   TestDockerMonitorUnresponsiveDaemon
+
+  Given a docker daemon that accepts calls but never answers them
+    Getting a monitored container's memory does not block for ever ✘
+    Finding a monitored container by name does not block for ever ✘
+    Killing a monitored container does not block for ever ✘
+    Creating a monitor does not block for ever ✘
+
+  * .../jobqueue/docker_monitor_test.go  Line 159:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 188:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 208:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 221:  Expected: true  Actual: false
+
+  Given a wedged docker daemon on a socket, our docker client gives up on it ✔✔✘
+
+  * .../jobqueue/docker_monitor_test.go  Line 240:  Expected: true  Actual: false
+
+--- FAIL: TestDockerMonitorUnresponsiveDaemon (150.12s)
+FAIL	github.com/VertebrateResequencing/wr/jobqueue	180.159s
+```
+
+Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 1.020s`,
+`21 total assertions`. The 180s of red is the six 30s bounds; the 1s of green is
+the same operations giving up on the daemon instead of waiting for it.
+
+### Mutation checks
+
+`go vet ./jobqueue/` was run after every edit and reported clean each time
+(`vet rc=0` in each block below), so no verdict here is a build failure
+masquerading as a dead guard. Each mutation was applied to the fixed file alone
+and reverted before the next.
+
+- [x] **M1: the per-call deadline removed** - `callCtx` returns
+  `ctx, func() {}`. **RED**, 120.38s: all four operations that go through a
+  fake interactor - lines 159 (stats of a known container), 188 (find by name),
+  208 (kill), 221 (monitor creation). The socket case stays green, because the
+  HTTP timeout still bites there.
+- [x] **M2: the HTTP timeout removed** - `client.NewClientWithOpts(client.FromEnv)`.
+  **RED**, 30.60s, on exactly one case: line 240, the real moby client against
+  the stalling socket. The fake-interactor cases stay green, because they never
+  reach HTTP. So the two timeouts are independent guards, and neither is
+  passing for the other's reason.
+- [x] **M3: the rendezvous made unbuffered again** - `make(chan bool)`. **RED**,
+  30.13s, at line 81: "And a checker that finishes later does not block for
+  ever". So something does catch it - the leak that giving up would otherwise
+  introduce is covered, not assumed.
+- [x] **M4: the await timeout removed** - a bare `<-r.ch`. **RED**, 30.03s, at
+  line 67: "Waiting for it gives up instead of blocking for ever".
+- [x] **M5: the give-up not honoured** - `resolveContainerMem`'s early return
+  reverted to `if dm == nil`. **RED**, 1.21s, at line 168: the interactor was
+  called 6 times where 3 are expected, ie. wr kept paying the timeout on every
+  check.
+
+All five reverted, `go vet` clean and green again
+(`ok ... 1.020s`).

--- a/.docs/bugfixes/260902-8.md
+++ b/.docs/bugfixes/260902-8.md
@@ -21,7 +21,7 @@ daemon with a unix socket that accepts connections and never writes a byte -
 `net.Listen("unix", ...)` plus an accept loop that holds each connection open -
 pointed `DOCKER_HOST` at it, and made the same call the check loop makes:
 
-```
+```text
 PROBE: ContainerStats(context.Background()) STILL BLOCKED after 5s
 ```
 
@@ -65,7 +65,7 @@ probe established before the fix was designed. With one deadline-less call
 already in flight on a client, a *second* call that does have a deadline still
 blocks:
 
-```
+```text
 PROBE deadline-only: returned after 500.632554ms: Get "http://...
   /v1.55/containers/someid/stats?one-shot=true&stream=false": context deadline exceeded
 PROBE second-call: blocked >5s
@@ -86,7 +86,7 @@ Three parts, each buying something the others cannot.
 1. **An HTTP timeout on the client itself**, in the new `newDockerInteractor`:
 
    ```go
-   cli, err := client.NewClientWithOpts(client.FromEnv, client.WithTimeout(timeout))
+   cli, err := client.New(client.FromEnv, client.WithTimeout(timeout))
    ```
 
    `client.WithTimeout` sets `http.Client.Timeout`, which covers the whole
@@ -166,7 +166,7 @@ unix socket, so it still needs no docker.
 Failing output before the fix (measured with every guard below reverted; each
 `false` is a bound exceeded, and `go vet ./jobqueue/` was clean in that state):
 
-```
+```text
 === RUN   TestCheckingRendezvous
 
   Given a checking rendezvous whose checker never finishes
@@ -174,7 +174,7 @@ Failing output before the fix (measured with every guard below reverted; each
     Waiting for a checker that does finish reports that it finished ✔
 
   * .../jobqueue/docker_monitor_test.go
-  Line 67:
+  Line 74:
   Expected 'await() blocked' to be blank (but it wasn't)!
 
 --- FAIL: TestCheckingRendezvous (30.03s)
@@ -186,20 +186,20 @@ Failing output before the fix (measured with every guard below reverted; each
     Killing a monitored container does not block for ever ✘
     Creating a monitor does not block for ever ✘
 
-  * .../jobqueue/docker_monitor_test.go  Line 159:  Expected: true  Actual: false
-  * .../jobqueue/docker_monitor_test.go  Line 188:  Expected: true  Actual: false
-  * .../jobqueue/docker_monitor_test.go  Line 208:  Expected: true  Actual: false
-  * .../jobqueue/docker_monitor_test.go  Line 221:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 169:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 200:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 220:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 233:  Expected: true  Actual: false
 
   Given a wedged docker daemon on a socket, our docker client gives up on it ✔✔✘
 
-  * .../jobqueue/docker_monitor_test.go  Line 240:  Expected: true  Actual: false
+  * .../jobqueue/docker_monitor_test.go  Line 252:  Expected: true  Actual: false
 
 --- FAIL: TestDockerMonitorUnresponsiveDaemon (150.12s)
 FAIL	github.com/VertebrateResequencing/wr/jobqueue	180.159s
 ```
 
-Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 1.020s`,
+Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 1.021s`,
 `21 total assertions`. The 180s of red is the six 30s bounds; the 1s of green is
 the same operations giving up on the daemon instead of waiting for it.
 
@@ -211,25 +211,258 @@ masquerading as a dead guard. Each mutation was applied to the fixed file alone
 and reverted before the next.
 
 - [x] **M1: the per-call deadline removed** - `callCtx` returns
-  `ctx, func() {}`. **RED**, 120.38s: all four operations that go through a
-  fake interactor - lines 159 (stats of a known container), 188 (find by name),
-  208 (kill), 221 (monitor creation). The socket case stays green, because the
+  `ctx, func() {}`. **RED**, 120.41s: all four operations that go through a
+  fake interactor - lines 169 (stats of a known container), 200 (find by name),
+  220 (kill), 233 (monitor creation). The socket case stays green, because the
   HTTP timeout still bites there.
-- [x] **M2: the HTTP timeout removed** - `client.NewClientWithOpts(client.FromEnv)`.
-  **RED**, 30.60s, on exactly one case: line 240, the real moby client against
+- [x] **M2: the HTTP timeout removed** - back to `client.New(client.FromEnv)`.
+  **RED**, 30.61s, on exactly one case: line 252, the real moby client against
   the stalling socket. The fake-interactor cases stay green, because they never
   reach HTTP. So the two timeouts are independent guards, and neither is
   passing for the other's reason.
 - [x] **M3: the rendezvous made unbuffered again** - `make(chan bool)`. **RED**,
-  30.13s, at line 81: "And a checker that finishes later does not block for
+  30.10s, at line 89: "And a checker that finishes later does not block for
   ever". So something does catch it - the leak that giving up would otherwise
   introduce is covered, not assumed.
 - [x] **M4: the await timeout removed** - a bare `<-r.ch`. **RED**, 30.03s, at
-  line 67: "Waiting for it gives up instead of blocking for ever".
+  line 74: "Waiting for it gives up instead of blocking for ever".
 - [x] **M5: the give-up not honoured** - `resolveContainerMem`'s early return
-  reverted to `if dm == nil`. **RED**, 1.21s, at line 168: the interactor was
+  reverted to `if dm == nil`. **RED**, 1.21s, at line 179: the interactor was
   called 6 times where 3 are expected, ie. wr kept paying the timeout on every
   check.
 
-All five reverted, `go vet` clean and green again
-(`ok ... 1.020s`).
+All five reverted, `go vet` clean and green again (`ok ... 1.021s`).
+
+## B: `--monitor_docker <name>` could SIGKILL someone else's container
+
+### Where this came from
+
+Reading `setupDockerMonitor` while fixing A: `RememberCurrentContainers` was
+called only in `"?"` mode, yet `findContainerID`'s by-name lookup is
+`GetNewContainerByName`, whose "new" means "not remembered". With nothing
+remembered, every currently running container is new.
+
+Confirmed against real docker (29.1.3) with a probe that started a container
+named `wrprobe_preexisting` *before* creating the operator, then asked the way
+each mode asks:
+
+```go
+PROBE: pre-existing container wrprobe_preexisting ADOPTED as new:
+       id 12e39aeb84f17d540e26de2761ba00e5e972dd144904404823a5fa5d3d460556
+       (would be SIGKILLed)
+PROBE: with RememberCurrentContainers, adopted = <nil>
+```
+
+### The mechanism
+
+`setupDockerMonitor` (jobqueue/client.go:1146 on the branch point) gated the
+remembering call:
+
+```go
+	if job.MonitorDocker == "?" {
+		dm.getFirstAppears = true
+
+		if errc := dm.operator.RememberCurrentContainers(ctx); errc != nil {
+```
+
+For a container name or a cidfile path, `Operator.existingContainers`
+(container/operator.go) therefore stayed empty, so:
+
+- `GetNewContainerByName` considered every running container, and returned the
+  first one with the requested name - which, if a container of that name was
+  already running, is that container, and is returned in preference to the one
+  the job later creates (the red output below shows the job's own 300MB
+  container losing to the pre-existing 500MB one).
+- `GetContainerByPath` -> `GetContainerByID` never consulted
+  `existingContainers` at all, so a stale or shared cidfile identified a
+  pre-existing container just as readily.
+
+That id then reaches `KillContainer` -> `ContainerKill{Signal: "SIGKILL"}` on
+`wr kill`, an OS signal to the runner, disk exhaustion, or peak memory over
+machine RAM. So `wr add --monitor_docker mytool` on a shared node that already
+runs a container called `mytool` - a service, a database, another user's job -
+made wr SIGKILL it. `Job.MonitorDocker`'s own doc (jobqueue/job.go) said "first
+**new** docker container", which was true only of `"?"` mode.
+
+### The fix
+
+`newDockerMonitor` now remembers the existing containers unconditionally, and
+the cidfile lookup goes through a new `Operator.GetNewContainerByPath`, which
+is `GetContainerByPath` plus the same "not remembered" filter its by-name
+sibling already applies. That is the whole change: three lines of behaviour and
+one small method, no new state, no change to what any existing exported method
+does.
+
+Remembering for every mode also means a job wr cannot list containers for is
+buried with `FailReasonDocker` ("failed to get docker containers") rather than
+running with monitoring that silently adopts the wrong container - the same
+early failure `"?"` mode always had, and (with A's timeout on that call) it
+cannot hang.
+
+`Job.MonitorDocker`'s doc comment now says what the code does, for every mode.
+
+### Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue \
+      -v -run TestDockerMonitorAdoption
+
+Port-free and docker-free: `TestDockerMonitorAdoption` drives
+`newDockerMonitor` + `resolveContainerMem` + `killContainer` over a
+`fakeInteractor` whose containers the test controls. Adoption is asserted
+through the reported memory rather than the private id field: the pre-existing
+container uses 500MB and the job's own uses 300MB, so the peak RAM the monitor
+returns says which container (if any) was adopted, and `killedIDs()` says which
+one a kill request would signal.
+
+Failing output before the fix:
+
+```text
+=== RUN   TestDockerMonitorAdoption
+
+  Given a container already running under the name a job asks to monitor ✔
+    It is not monitored, so nothing of it can be killed ✔✘✔
+    But a container of that name that appears afterwards is monitored ✔✘
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 383:
+  Expected: 100
+  Actual:   500
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 393:
+  Expected: 300
+  Actual:   500
+
+  Given a cidfile naming a container that is already running ✔✔
+    It is not monitored ✔✘✔✔
+    But the container the job goes on to create is monitored ✔✔✔
+
+  * .../jobqueue/docker_monitor_test.go
+  Line 416:
+  Expected: 100
+  Actual:   500
+
+  Given a monitor of the first container to appear, with one already running ✔
+    The already running one is not monitored ✔✔✔
+    The next one to appear is monitored ✔✔
+
+21 total assertions
+
+--- FAIL: TestDockerMonitorAdoption (0.00s)
+```text
+
+Line 393 is the sharper failure: even when the job's own container exists, the
+pre-existing one is what gets monitored (and killed). The `"?"` cases pass
+before and after, as they must - they are the control that says the fix did not
+work by making adoption stop happening.
+
+Green afterwards: `ok github.com/VertebrateResequencing/wr/jobqueue 1.023s`.
+
+### Mutation checks
+
+`go vet ./jobqueue/` clean after each edit (`vet rc=0`).
+
+- [x] **B-M1: the `== "?"` gate restored** around the remembering call. **RED**
+  on lines 383, 393 and 416 - both name cases and the cidfile case, with the
+  output quoted above. The `"?"` cases stay green.
+- [x] **B-M2: the cidfile lookup put back to `GetContainerByPath`**. **RED** on
+  line 416 only; both name cases stay green. So the two halves of the fix are
+  independent and neither is passing for the other's reason.
+
+Both reverted, `go vet` clean, green again (`ok ... 1.023s`).
+
+## Reported, not fixed: `"?"` mode adopts by list order, not by ownership
+
+`findContainerID` in `"?"` mode still takes `containers[0]`:
+
+```go
+	if dm.getFirstAppears {
+		containers, err := dm.operator.GetNewContainers(ctx)
+		if len(containers) > 0 {
+			dm.containerID = containers[0].ID
+		}
+
+		return err
+	}
+```
+
+Nothing checks that the container belongs to this job. Fix B narrows the window
+- the container must at least have appeared after the job's monitor was set up -
+but any unrelated container that starts during the job's run is still eligible,
+and with several new containers the choice is docker's list order. wr then
+reports its RAM as this job's, and SIGKILLs it on `wr kill` or a memory kill.
+`Job.MonitorDocker`'s doc admits the stats half of this ("if multiple jobs that
+run docker containers start running at the same time on the same machine, the
+reported stats could be wrong"); it does not admit the kill half.
+
+I left it alone because the obvious framing - "check the container is in this
+job's process tree" - does not work for docker: the container's processes are
+children of the daemon/containerd, not of the job's command, so there is no
+ancestry to test. A real fix needs a correlation wr does not currently collect
+(a label or name wr itself sets, matching `cmd.Process.Pid`'s namespace, or the
+container's `Created` time compared against `cmd.Start()`), plus a decision
+about what to do when the answer is ambiguous - refuse to adopt, or adopt and
+warn. That is a design choice for the repo owner, and `--with_docker` (which
+names the container after the job key, so it could be matched exactly) is the
+mode most users are on.
+
+## Files touched
+
+- `jobqueue/client.go`: the `dockerMonitor` plumbing (`newDockerInteractor`,
+  `newDockerMonitor`, `callCtx`, `noteCallResult`, `killContainer`,
+  `resolveContainerMem`, `findContainerID`), the new `checkingRendezvous`, the
+  three new constants, and `Execute`'s use of them.
+- `container/operator.go`: `GetNewContainerByPath`.
+- `jobqueue/job.go`: the `MonitorDocker` doc comment.
+- `jobqueue/docker_monitor_test.go`: new; `TestDockerMonitorUnresponsiveDaemon`,
+  `TestCheckingRendezvous` (fix A) and `TestDockerMonitorAdoption` (fix B).
+
+`cleanorder -min-diff` on each edited file made no change worth taking.
+
+## Gates
+
+From the repo root with all `OS_*` unset. Baseline measured in this clone on
+the branch point (`e8c3e55a`, detached): `make test` gave
+`420 passed · 9 skipped · 29 packages · 3m51s`, PASSED.
+
+After fix A (`go build ./... && go vet ./jobqueue/ && go vet ./container/...`
+clean):
+
+| gate | result |
+| --- | --- |
+| `make test` | `422 passed · 9 skipped · 29 packages · 4m51s`, PASSED |
+| `make race` | `422 passed · 9 skipped · 29 packages · 5m20s`, PASSED |
+| `make lint` | `0 issues.` |
+
+After fix B (build and vet clean):
+
+| gate | result |
+| --- | --- |
+| `make test` | `423 passed · 9 skipped · 29 packages · 3m42s`, PASSED |
+| `make race` | `423 passed · 9 skipped · 29 packages · 4m38s`, PASSED |
+| `make lint` | `0 issues.` |
+
+The +2 and +3 against the baseline are exactly the new test functions:
+`TestDockerMonitorUnresponsiveDaemon` and `TestCheckingRendezvous` in A,
+`TestDockerMonitorAdoption` in B.
+
+`golangci-lint cache clean` was run before the first lint, since this box has
+served cached issues keyed to deleted sibling clones. The first lint run then
+reported 6 issues, all in the new code, all fixed before commit: an `errcheck`
+on an ignored error return, a `noctx` on `net.Listen`, an unused `nolint`
+directive, two `wsl_v5` blank-line complaints, and a `govet` `gofix` report
+that `client.NewClientWithOpts` should be inlined - it is deprecated in
+`moby/client@v0.5.0` and marked `//go:fix inline`, so the call is now
+`client.New(client.FromEnv, client.WithTimeout(timeout))`, which is the same
+function (`NewClientWithOpts` is `return New(ops...)`). Plain `go vet` does not
+run that analyzer, and `new-from-rev: master` only surfaces it because the line
+changed. A's `make test`/`make race` numbers above predate that one-line
+substitution; B's runs cover it.
+
+`cleanorder -min-diff jobqueue/client.go` was run and its reordering was NOT
+taken: it moved the new `newDockerInteractor`, `newDockerMonitor`, `callCtx`,
+`noteCallResult` and `killContainer` blocks 800 lines away from the
+`dockerMonitor` type and the rest of its methods. They are kept together with
+the type instead, as in `.docs/bugfixes/260902-3.md` where the same tool's
+reordering was declined.

--- a/container/operator.go
+++ b/container/operator.go
@@ -176,6 +176,23 @@ func (o *Operator) GetNewContainerByName(ctx context.Context, name string) (*Con
 	return nil, nil //nolint:nilnil
 }
 
+// GetNewContainerByPath is like GetContainerByPath, but only new containers
+// (those not remembered by the last RememberCurrentContainers() call) are
+// considered, so that a stale or shared cidfile can't identify a container that
+// the caller did not create.
+func (o *Operator) GetNewContainerByPath(ctx context.Context, path string, dir string) (*Container, error) {
+	cntr, err := o.GetContainerByPath(ctx, path, dir)
+	if err != nil || cntr == nil {
+		return nil, err
+	}
+
+	if o.existingContainers[cntr.ID] {
+		return nil, nil //nolint:nilnil
+	}
+
+	return cntr, nil
+}
+
 // GetContainerByPath checks the file at the given path, and if the first line
 // contains the ID of a container, that container is returned.
 //

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1296,14 +1296,22 @@ func (dm *dockerMonitor) callCtx(ctx context.Context) (context.Context, context.
 
 // resolveContainerMem looks up (and caches) the monitored container's id and, if
 // found, returns the larger of mem and the container's memory plus its CPU
-// seconds. Any error finding the container is returned for accumulation.
+// seconds.
 //
 // The docker calls it makes get dm.callTimeout to complete, and after
 // dockerFailureTolerance consecutive failures it stops monitoring; see
 // noteCallResult.
-func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string, mem int) (int, int, error) {
+//
+// It returns no error, deliberately: noteCallResult logs and counts every
+// failure, and the job's command runs independently of docker's
+// responsiveness, so all a failed reading costs the user is under-reported
+// usage. Returned to Execute(), it would instead accumulate into myerr and so
+// make job.TriggerBehaviours() run the on_failure behaviours - a cleanup_all,
+// or any command the user chose - of a job whose command succeeded, on nothing
+// worse than a docker daemon hiccup.
+func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string, mem int) (int, int) {
 	if dm == nil || dm.givenUp {
-		return mem, 0, nil
+		return mem, 0
 	}
 
 	callCtx, cancel := dm.callCtx(ctx)
@@ -1318,7 +1326,7 @@ func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string,
 	if dm.containerID == "" {
 		dm.noteCallResult(ctx, findErr)
 
-		return mem, 0, findErr
+		return mem, 0
 	}
 
 	dockerStats, errs := dm.interactor.ContainerStats(callCtx, dm.containerID)
@@ -1326,16 +1334,10 @@ func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string,
 	dm.noteCallResult(ctx, errors.Join(findErr, errs))
 
 	if errs != nil {
-		// a container that has gone away is normal and not the job's problem,
-		// so unlike findErr this is not returned for accumulation
-		return mem, 0, findErr
+		return mem, 0
 	}
 
-	if dockerStats.MemoryMB > mem {
-		mem = dockerStats.MemoryMB
-	}
-
-	return mem, dockerStats.CPUSec, findErr
+	return max(mem, dockerStats.MemoryMB), dockerStats.CPUSec
 }
 
 // noteCallResult records whether a round of docker calls worked, and gives up
@@ -1364,6 +1366,11 @@ func (dm *dockerMonitor) noteCallResult(ctx context.Context, err error) {
 // killContainer kills the container being monitored, giving up after
 // dm.callTimeout so that an unresponsive docker daemon can't make a kill
 // request hang for ever.
+//
+// Unlike resolveContainerMem's readings, this error IS returned to Execute()
+// and does reach the job's outcome: a kill we were asked to do and could not
+// do leaves the user's container running, which is a real failure of this run
+// and not something a later check can make good.
 func (dm *dockerMonitor) killContainer(ctx context.Context) error {
 	callCtx, cancel := dm.callCtx(ctx)
 	defer cancel()
@@ -2147,10 +2154,10 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			return errk
 		}
 
-		// closeErr, killErr and myerr are written here but read by Execute()
-		// once the checking rendezvous is over, and that rendezvous can now
-		// give up on this goroutine, so their writes take stateMutex like the
-		// other shared state does.
+		// closeErr and killErr are written here but read by Execute() once the
+		// checking rendezvous is over, and that rendezvous can now give up on
+		// this goroutine, so their writes take stateMutex like the other shared
+		// state does.
 		closeReaders := func() {
 			stateMutex.Lock()
 			defer stateMutex.Unlock()
@@ -2222,14 +2229,13 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 				mem, errf := currentMemory(job.Pid)
 
 				// deal with docker monitoring
-				mem, cpuS, findErr := dm.resolveContainerMem(ctx, cmd.Dir, mem)
+				mem, cpuS := dm.resolveContainerMem(ctx, cmd.Dir, mem)
 
 				// get current disk usage
 				disk, errd := diskUsageCheck()
 
 				// now update peaks
 				stateMutex.Lock()
-				myerr = joinExecErr(myerr, findErr, "finding the docker container had issues")
 
 				if errf == nil && mem > peakmem {
 					peakmem = mem

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -343,9 +343,15 @@ func newCheckingRendezvous() *checkingRendezvous {
 	return &checkingRendezvous{ch: make(chan bool, 1)}
 }
 
-// finished reports that the checking goroutine has stopped. It never blocks.
+// finished reports that the checking goroutine has stopped. It never blocks: a
+// report that the buffer has no room for is dropped, since the buffered one
+// says the same thing, and a blocking send would park the caller for the
+// lifetime of the runner.
 func (r *checkingRendezvous) finished() {
-	r.ch <- true
+	select {
+	case r.ch <- true:
+	default:
+	}
 }
 
 // await waits for finished() to be called, giving up after timeout and

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1264,27 +1264,25 @@ func newDockerInteractor(timeout time.Duration) (container.Interactor, error) {
 // container to appear), monitored using the given interactor and allowing
 // timeout for each docker API call.
 //
-// In "?" mode the containers that already exist are remembered, so that only a
-// container that appears after this call is adopted.
+// The containers that already exist are remembered, so that only a container
+// that appears after this call can be adopted - and so killed - by the job,
+// whichever way monitorDocker identifies it.
 func newDockerMonitor(ctx context.Context, monitorDocker string, interactor container.Interactor,
 	timeout time.Duration,
 ) (*dockerMonitor, error) {
 	dm := &dockerMonitor{
-		operator:      container.NewOperator(interactor),
-		interactor:    interactor,
-		monitorDocker: monitorDocker,
-		callTimeout:   timeout,
+		operator:        container.NewOperator(interactor),
+		interactor:      interactor,
+		monitorDocker:   monitorDocker,
+		callTimeout:     timeout,
+		getFirstAppears: monitorDocker == "?",
 	}
 
-	if monitorDocker == "?" {
-		dm.getFirstAppears = true
+	callCtx, cancel := dm.callCtx(ctx)
+	defer cancel()
 
-		callCtx, cancel := dm.callCtx(ctx)
-		defer cancel()
-
-		if err := dm.operator.RememberCurrentContainers(callCtx); err != nil {
-			return nil, err
-		}
+	if err := dm.operator.RememberCurrentContainers(callCtx); err != nil {
+		return nil, err
 	}
 
 	return dm, nil
@@ -1394,7 +1392,7 @@ func (dm *dockerMonitor) findContainerID(ctx context.Context, cmdDir string) err
 	}
 
 	// monitorDocker might be a file path containing the id of a container
-	dockerContainer, pathErr := dm.operator.GetContainerByPath(ctx, dm.monitorDocker, cmdDir)
+	dockerContainer, pathErr := dm.operator.GetNewContainerByPath(ctx, dm.monitorDocker, cmdDir)
 	if dockerContainer != nil {
 		dm.containerID = dockerContainer.ID
 	}

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -158,6 +158,28 @@ const (
 	// executeSignalChannelBuffer is the buffer size of the OS signal channel.
 	executeSignalChannelBuffer = 5
 
+	// dockerCallTimeout is how long we allow any single docker API call made
+	// while monitoring a job's container to take. The moby client sets no HTTP
+	// timeout of its own and a runner's job context has no deadline, so without
+	// this a docker daemon that accepts connections but never answers blocks
+	// its caller for ever: the goroutine that would notice the job has finished
+	// stops servicing its stop channel, so a finished job never completes and
+	// its runner holds its scheduler slot for ever.
+	dockerCallTimeout = 10 * time.Second
+
+	// dockerFailureTolerance is how many consecutive failed docker calls we
+	// tolerate before giving up on monitoring a job's container. The job's
+	// command runs independently of docker's responsiveness, so it is better to
+	// let it finish with incomplete container resource usage than to keep
+	// paying dockerCallTimeout on every check.
+	dockerFailureTolerance = 3
+
+	// checkingFinishTimeout is how long Execute() waits for its resource
+	// checking goroutine to confirm that it has stopped. It is a backstop for
+	// that goroutine blocking in something we don't control: a finished job
+	// must be able to complete regardless.
+	checkingFinishTimeout = 60 * time.Second
+
 	// fusermountRetryDelaySeconds is how long we wait before retrying a mount
 	// that failed with "fusermount exited with code 256".
 	fusermountRetryDelaySeconds = 5
@@ -305,6 +327,36 @@ func (state *serverContactState) recordTouchResult(err error) {
 
 func (state *serverContactState) schedulerMemoryFallbackAllowed() bool {
 	return !state.lost.Load()
+}
+
+// checkingRendezvous lets Execute() wait for its resource checking goroutine to
+// confirm that it has stopped.
+type checkingRendezvous struct {
+	ch chan bool
+}
+
+// newCheckingRendezvous creates a checkingRendezvous. Its channel is buffered
+// so that finished() can never block: await() gives up after a timeout, and an
+// unbuffered send would then park the checking goroutine for the lifetime of
+// the runner.
+func newCheckingRendezvous() *checkingRendezvous {
+	return &checkingRendezvous{ch: make(chan bool, 1)}
+}
+
+// finished reports that the checking goroutine has stopped. It never blocks.
+func (r *checkingRendezvous) finished() {
+	r.ch <- true
+}
+
+// await waits for finished() to be called, giving up after timeout and
+// returning false.
+func (r *checkingRendezvous) await(timeout time.Duration) bool {
+	select {
+	case <-r.ch:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }
 
 type executeLiveState struct {
@@ -1156,10 +1208,16 @@ func prepareCommand(ctx context.Context, job *Job, shell, jc string) (*executeCm
 // dockerMonitor holds the docker client plumbing used to monitor a job's
 // container, and the id of the container once it has been identified.
 type dockerMonitor struct {
-	operator        *container.Operator
-	interactor      *docker.Interactor
-	monitorDocker   string
+	operator      *container.Operator
+	interactor    container.Interactor
+	monitorDocker string
+
+	// callTimeout is how long any single docker API call we make is allowed to
+	// take.
+	callTimeout     time.Duration
+	failures        int
 	getFirstAppears bool
+	givenUp         bool
 	containerID     string
 }
 
@@ -1171,51 +1229,107 @@ func (c *Client) setupDockerMonitor(ctx context.Context, job *Job) (*dockerMonit
 		return nil, nil //nolint:nilnil // no docker monitoring requested is a valid, non-error result.
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	interactor, err := newDockerInteractor(dockerCallTimeout)
 	if err != nil {
 		return nil, c.buryWithCause(job, FailReasonDocker, err, "failed to create docker client")
 	}
 
-	interactor := docker.NewInteractor(cli)
+	dm, err := newDockerMonitor(ctx, job.MonitorDocker, interactor, dockerCallTimeout)
+	if err != nil {
+		return nil, c.buryWithCause(job, FailReasonDocker, err, "failed to get docker containers")
+	}
+
+	return dm, nil
+}
+
+// newDockerInteractor creates an Interactor for talking to the local docker
+// daemon, that gives up on any request that takes longer than timeout.
+//
+// The timeout is applied to the client's HTTP requests, which no call path can
+// bypass: the moby client single-flights its API version negotiation behind a
+// plain mutex held across a request, so one deadline-less request to an
+// unresponsive daemon would otherwise block every later call on this client
+// regardless of their own deadlines.
+func newDockerInteractor(timeout time.Duration) (container.Interactor, error) {
+	cli, err := client.New(client.FromEnv, client.WithTimeout(timeout))
+	if err != nil {
+		return nil, err
+	}
+
+	return docker.NewInteractor(cli), nil
+}
+
+// newDockerMonitor creates a dockerMonitor for the container identified by
+// monitorDocker (its --name, the path to its --cidfile, or "?" for the first
+// container to appear), monitored using the given interactor and allowing
+// timeout for each docker API call.
+//
+// In "?" mode the containers that already exist are remembered, so that only a
+// container that appears after this call is adopted.
+func newDockerMonitor(ctx context.Context, monitorDocker string, interactor container.Interactor,
+	timeout time.Duration,
+) (*dockerMonitor, error) {
 	dm := &dockerMonitor{
 		operator:      container.NewOperator(interactor),
 		interactor:    interactor,
-		monitorDocker: job.MonitorDocker,
+		monitorDocker: monitorDocker,
+		callTimeout:   timeout,
 	}
 
-	// if we've been asked to monitor the first container that appears, remember
-	// existing containers
-	if job.MonitorDocker == "?" {
+	if monitorDocker == "?" {
 		dm.getFirstAppears = true
 
-		if errc := dm.operator.RememberCurrentContainers(ctx); errc != nil {
-			return nil, c.buryWithCause(job, FailReasonDocker, errc, "failed to get docker containers")
+		callCtx, cancel := dm.callCtx(ctx)
+		defer cancel()
+
+		if err := dm.operator.RememberCurrentContainers(callCtx); err != nil {
+			return nil, err
 		}
 	}
 
 	return dm, nil
 }
 
+// callCtx returns ctx with dm.callTimeout applied, so that the docker calls
+// made with it can't block for ever.
+func (dm *dockerMonitor) callCtx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, dm.callTimeout)
+}
+
 // resolveContainerMem looks up (and caches) the monitored container's id and, if
 // found, returns the larger of mem and the container's memory plus its CPU
 // seconds. Any error finding the container is returned for accumulation.
+//
+// The docker calls it makes get dm.callTimeout to complete, and after
+// dockerFailureTolerance consecutive failures it stops monitoring; see
+// noteCallResult.
 func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string, mem int) (int, int, error) {
-	if dm == nil {
+	if dm == nil || dm.givenUp {
 		return mem, 0, nil
 	}
+
+	callCtx, cancel := dm.callCtx(ctx)
+	defer cancel()
 
 	var findErr error
 
 	if dm.containerID == "" {
-		findErr = dm.findContainerID(ctx, cmdDir)
+		findErr = dm.findContainerID(callCtx, cmdDir)
 	}
 
 	if dm.containerID == "" {
+		dm.noteCallResult(ctx, findErr)
+
 		return mem, 0, findErr
 	}
 
-	dockerStats, errs := dm.interactor.ContainerStats(ctx, dm.containerID)
+	dockerStats, errs := dm.interactor.ContainerStats(callCtx, dm.containerID)
+
+	dm.noteCallResult(ctx, errors.Join(findErr, errs))
+
 	if errs != nil {
+		// a container that has gone away is normal and not the job's problem,
+		// so unlike findErr this is not returned for accumulation
 		return mem, 0, findErr
 	}
 
@@ -1224,6 +1338,39 @@ func (dm *dockerMonitor) resolveContainerMem(ctx context.Context, cmdDir string,
 	}
 
 	return mem, dockerStats.CPUSec, findErr
+}
+
+// noteCallResult records whether a round of docker calls worked, and gives up
+// on monitoring this job's container after dockerFailureTolerance consecutive
+// failures, logging why.
+func (dm *dockerMonitor) noteCallResult(ctx context.Context, err error) {
+	if err == nil {
+		dm.failures = 0
+
+		return
+	}
+
+	dm.failures++
+
+	clog.Warn(ctx, "a docker call failed while monitoring a job's container",
+		"container", dm.monitorDocker, "failures", dm.failures, "err", err)
+
+	if dm.failures >= dockerFailureTolerance {
+		dm.givenUp = true
+
+		clog.Warn(ctx, "giving up on monitoring a job's docker container; its usage will be under-reported",
+			"container", dm.monitorDocker)
+	}
+}
+
+// killContainer kills the container being monitored, giving up after
+// dm.callTimeout so that an unresponsive docker daemon can't make a kill
+// request hang for ever.
+func (dm *dockerMonitor) killContainer(ctx context.Context) error {
+	callCtx, cancel := dm.callCtx(ctx)
+	defer cancel()
+
+	return dm.operator.KillContainer(callCtx, dm.containerID)
 }
 
 // findContainerID tries to identify the container to monitor, caching its id on
@@ -1239,20 +1386,23 @@ func (dm *dockerMonitor) findContainerID(ctx context.Context, cmdDir string) err
 	}
 
 	// monitorDocker might be the name of a new container
-	dockerContainer, err := dm.operator.GetNewContainerByName(ctx, dm.monitorDocker)
+	dockerContainer, nameErr := dm.operator.GetNewContainerByName(ctx, dm.monitorDocker)
 	if dockerContainer != nil {
 		dm.containerID = dockerContainer.ID
 
-		return err
+		return nameErr
 	}
 
 	// monitorDocker might be a file path containing the id of a container
-	dockerContainer, err = dm.operator.GetContainerByPath(ctx, dm.monitorDocker, cmdDir)
+	dockerContainer, pathErr := dm.operator.GetContainerByPath(ctx, dm.monitorDocker, cmdDir)
 	if dockerContainer != nil {
 		dm.containerID = dockerContainer.ID
 	}
 
-	return err
+	// nameErr is joined rather than dropped: it is how an unresponsive docker
+	// daemon gets noticed (see noteCallResult) when we're looking for a
+	// container by name.
+	return errors.Join(nameErr, pathErr)
 }
 
 // addBsubEnv augments env with the PATH override and LSF emulation variables a
@@ -1938,7 +2088,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 		return used, nil
 	}
-	finishedChecking := make(chan bool)
+	finishedChecking := newCheckingRendezvous()
 
 	go func() {
 		killCmd := func() error {
@@ -1961,7 +2111,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 			if dm != nil && dm.containerID != "" {
 				// kill the docker container as well
-				errd := dm.operator.KillContainer(ctx, dm.containerID)
+				errd := dm.killContainer(ctx)
 				if errk == nil {
 					errk = errd
 				} else {
@@ -1999,7 +2149,14 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			return errk
 		}
 
+		// closeErr, killErr and myerr are written here but read by Execute()
+		// once the checking rendezvous is over, and that rendezvous can now
+		// give up on this goroutine, so their writes take stateMutex like the
+		// other shared state does.
 		closeReaders := func() {
+			stateMutex.Lock()
+			defer stateMutex.Unlock()
+
 			errc := errReader.Close()
 			if errc != nil {
 				closeErr = errc
@@ -2031,9 +2188,11 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			case signal := <-sigs:
 				clog.Warn(ctx, "aborting due to signal", "sig", signal.String())
 
-				killErr = killCmd()
+				errk := killCmd()
 
 				stateMutex.Lock()
+				killErr = errk
+
 				if time.Now().After(endT) {
 					// we allow things to go over time, but if signalled, we now
 					// know it may be because we used too much time
@@ -2066,13 +2225,14 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 				// deal with docker monitoring
 				mem, cpuS, findErr := dm.resolveContainerMem(ctx, cmd.Dir, mem)
-				myerr = joinExecErr(myerr, findErr, "finding the docker container had issues")
 
 				// get current disk usage
 				disk, errd := diskUsageCheck()
 
 				// now update peaks
 				stateMutex.Lock()
+				myerr = joinExecErr(myerr, findErr, "finding the docker container had issues")
+
 				if errf == nil && mem > peakmem {
 					peakmem = mem
 
@@ -2109,7 +2269,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 			}
 		}
 
-		finishedChecking <- true
+		finishedChecking.finished()
 	}()
 
 	// wait for the command to exit
@@ -2121,7 +2281,10 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 
 	stopChecking <- true
 
-	<-finishedChecking
+	if !finishedChecking.await(checkingFinishTimeout) {
+		clog.Warn(ctx, "gave up waiting for the resource checking goroutine to stop", "cmd", job.Cmd)
+	}
+
 	stateMutex.Lock()
 	defer stateMutex.Unlock()
 

--- a/jobqueue/docker_monitor_test.go
+++ b/jobqueue/docker_monitor_test.go
@@ -103,6 +103,23 @@ func TestCheckingRendezvous(t *testing.T) {
 
 			So(rendezvous.await(dockerTestBound), ShouldBeTrue)
 		})
+
+		Convey("A checker that reports finishing twice does not block on the second report", func() {
+			finishedCh := make(chan bool, 1)
+
+			go func() {
+				rendezvous.finished()
+				rendezvous.finished()
+
+				finishedCh <- true
+			}()
+
+			select {
+			case <-finishedCh:
+			case <-time.After(dockerTestBound):
+				So("the second finished() blocked", ShouldBeBlank)
+			}
+		})
 	})
 }
 

--- a/jobqueue/docker_monitor_test.go
+++ b/jobqueue/docker_monitor_test.go
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/VertebrateResequencing/wr/container"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// dockerTestCallTimeout is the per-docker-call timeout we give monitors
+	// under test, so that a test of the give-up behaviour is quick.
+	dockerTestCallTimeout = 100 * time.Millisecond
+
+	// dockerTestBound is how long we let something that must not block for ever
+	// take before failing the test. It is generous: exceeding it means the code
+	// under test hung, and we want that to fail an assertion rather than hang
+	// the whole suite.
+	dockerTestBound = 30 * time.Second
+)
+
+func TestCheckingRendezvous(t *testing.T) {
+	Convey("Given a checking rendezvous whose checker never finishes", t, func() {
+		rendezvous := newCheckingRendezvous()
+
+		Convey("Waiting for it gives up instead of blocking for ever", func() {
+			awaited := make(chan bool, 1)
+
+			go func() {
+				awaited <- rendezvous.await(dockerTestCallTimeout)
+			}()
+
+			select {
+			case finished := <-awaited:
+				So(finished, ShouldBeFalse)
+			case <-time.After(dockerTestBound):
+				So("await() blocked", ShouldBeBlank)
+			}
+
+			Convey("And a checker that finishes later does not block for ever", func() {
+				finishedCh := make(chan bool, 1)
+
+				go func() {
+					rendezvous.finished()
+
+					finishedCh <- true
+				}()
+
+				select {
+				case <-finishedCh:
+				case <-time.After(dockerTestBound):
+					So("finished() blocked", ShouldBeBlank)
+				}
+			})
+		})
+
+		Convey("Waiting for a checker that does finish reports that it finished", func() {
+			go rendezvous.finished()
+
+			So(rendezvous.await(dockerTestBound), ShouldBeTrue)
+		})
+	})
+}
+
+// stallingInteractor is a container.Interactor that simulates a docker daemon
+// which accepts calls but never answers them: every call blocks until the
+// caller's context is cancelled (which is how the real moby client behaves,
+// since it makes ctx-bound HTTP requests).
+type stallingInteractor struct {
+	mu    sync.Mutex
+	calls int
+}
+
+// callCount returns how many calls have been made to this interactor.
+func (s *stallingInteractor) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.calls
+}
+
+// stall blocks until ctx is cancelled, then returns ctx's error.
+func (s *stallingInteractor) stall(ctx context.Context) error {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+
+	<-ctx.Done()
+
+	return ctx.Err()
+}
+
+func (s *stallingInteractor) ContainerList(ctx context.Context) ([]*container.Container, error) {
+	return nil, s.stall(ctx)
+}
+
+func (s *stallingInteractor) ContainerStats(ctx context.Context, _ string) (*container.Stats, error) {
+	return nil, s.stall(ctx)
+}
+
+func (s *stallingInteractor) ContainerKill(ctx context.Context, _ string) error {
+	return s.stall(ctx)
+}
+
+func TestDockerMonitorUnresponsiveDaemon(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a docker daemon that accepts calls but never answers them", t, func() {
+		stalled := &stallingInteractor{}
+
+		Convey("Getting a monitored container's memory does not block for ever", func() {
+			dm := &dockerMonitor{
+				operator:      container.NewOperator(stalled),
+				interactor:    stalled,
+				monitorDocker: "mycontainer",
+				callTimeout:   dockerTestCallTimeout,
+				containerID:   "alreadyfound",
+			}
+
+			memCh := make(chan int, 1)
+			errCh := make(chan error, 1)
+
+			go func() {
+				mem, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
+
+				memCh <- mem
+
+				errCh <- err
+			}()
+
+			statsErr, returned := awaitErr(errCh)
+			So(returned, ShouldBeTrue)
+			So(statsErr, ShouldBeNil)
+			So(<-memCh, ShouldEqual, 100)
+
+			Convey("And monitoring is given up on after repeated failures", func() {
+				for range dockerFailureTolerance + 2 {
+					_, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
+					So(err, ShouldBeNil)
+				}
+
+				So(stalled.callCount(), ShouldEqual, dockerFailureTolerance)
+			})
+		})
+
+		Convey("Finding a monitored container by name does not block for ever", func() {
+			dm := &dockerMonitor{
+				operator:      container.NewOperator(stalled),
+				interactor:    stalled,
+				monitorDocker: "mycontainer",
+				callTimeout:   dockerTestCallTimeout,
+			}
+
+			errCh := make(chan error, 1)
+
+			go func() {
+				_, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
+
+				errCh <- err
+			}()
+
+			err, returned := awaitErr(errCh)
+			So(returned, ShouldBeTrue)
+			So(err, ShouldNotBeNil)
+			So(dm.containerID, ShouldBeBlank)
+		})
+
+		Convey("Killing a monitored container does not block for ever", func() {
+			dm := &dockerMonitor{
+				operator:    container.NewOperator(stalled),
+				interactor:  stalled,
+				callTimeout: dockerTestCallTimeout,
+				containerID: "alreadyfound",
+			}
+
+			errCh := make(chan error, 1)
+
+			go func() {
+				errCh <- dm.killContainer(ctx)
+			}()
+
+			err, returned := awaitErr(errCh)
+			So(returned, ShouldBeTrue)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Creating a monitor does not block for ever", func() {
+			errCh := make(chan error, 1)
+
+			go func() {
+				_, err := newDockerMonitor(ctx, "?", stalled, dockerTestCallTimeout)
+				errCh <- err
+			}()
+
+			err, returned := awaitErr(errCh)
+			So(returned, ShouldBeTrue)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("Given a wedged docker daemon on a socket, our docker client gives up on it", t, func() {
+		t.Setenv("DOCKER_HOST", stallingDockerSocket(t))
+
+		interactor, err := newDockerInteractor(dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		errCh := make(chan error, 1)
+
+		go func() {
+			_, errS := interactor.ContainerStats(ctx, "someid")
+			errCh <- errS
+		}()
+
+		statsErr, returned := awaitErr(errCh)
+		So(returned, ShouldBeTrue)
+		So(statsErr, ShouldNotBeNil)
+	})
+}
+
+// awaitErr waits up to dockerTestBound for an error to arrive on ch, returning
+// it and whether it arrived in time.
+func awaitErr(ch <-chan error) (error, bool) {
+	select {
+	case err := <-ch:
+		return err, true
+	case <-time.After(dockerTestBound):
+		return nil, false
+	}
+}
+
+// stallingDockerSocket creates a unix socket that accepts connections and never
+// answers, returning the DOCKER_HOST value that addresses it. It simulates a
+// wedged docker daemon without needing docker.
+func stallingDockerSocket(t *testing.T) string {
+	t.Helper()
+
+	sock := filepath.Join(t.TempDir(), "docker.sock")
+
+	var listenConfig net.ListenConfig
+
+	listener, err := listenConfig.Listen(context.Background(), "unix", sock)
+	So(err, ShouldBeNil)
+
+	t.Cleanup(func() {
+		listener.Close()
+	})
+
+	go func() {
+		var conns []net.Conn
+
+		defer func() {
+			for _, conn := range conns {
+				conn.Close()
+			}
+		}()
+
+		for {
+			conn, errA := listener.Accept()
+			if errA != nil {
+				return
+			}
+
+			conns = append(conns, conn)
+		}
+	}()
+
+	return "unix://" + sock
+}

--- a/jobqueue/docker_monitor_test.go
+++ b/jobqueue/docker_monitor_test.go
@@ -27,8 +27,11 @@ package jobqueue
 
 import (
 	"context"
+	"errors"
 	"net"
+	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +39,10 @@ import (
 	"github.com/VertebrateResequencing/wr/container"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+// errNoSuchContainer is what a fake interactor returns for a container that
+// does not exist, as docker would.
+var errNoSuchContainer = errors.New("no such container")
 
 const (
 	// dockerTestCallTimeout is the per-docker-call timeout we give monitors
@@ -295,4 +302,149 @@ func stallingDockerSocket(t *testing.T) string {
 	}()
 
 	return "unix://" + sock
+}
+
+// fakeInteractor is a container.Interactor over a set of containers the test
+// controls, recording which of them get killed.
+type fakeInteractor struct {
+	mu         sync.Mutex
+	mems       map[string]int
+	containers []*container.Container
+	killed     []string
+}
+
+// newFakeInteractor creates a fakeInteractor with no containers.
+func newFakeInteractor() *fakeInteractor {
+	return &fakeInteractor{mems: make(map[string]int)}
+}
+
+// add makes a container with the given id and name, using the given memory in
+// MB, exist.
+func (f *fakeInteractor) add(id, name string, memMB int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	cntr := &container.Container{ID: id, Names: []string{"/" + name}}
+	cntr.TrimNamePrefixes()
+
+	f.containers = append(f.containers, cntr)
+	f.mems[id] = memMB
+}
+
+// killedIDs returns the ids of the containers that have been killed.
+func (f *fakeInteractor) killedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.killed)
+}
+
+func (f *fakeInteractor) ContainerList(_ context.Context) ([]*container.Container, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return slices.Clone(f.containers), nil
+}
+
+func (f *fakeInteractor) ContainerStats(_ context.Context, containerID string) (*container.Stats, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	memMB, exists := f.mems[containerID]
+	if !exists {
+		return nil, errNoSuchContainer
+	}
+
+	return &container.Stats{MemoryMB: memMB}, nil
+}
+
+func (f *fakeInteractor) ContainerKill(_ context.Context, containerID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.killed = append(f.killed, containerID)
+
+	return nil
+}
+
+func TestDockerMonitorAdoption(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a container already running under the name a job asks to monitor", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "mytool", 500)
+
+		dm, err := newDockerMonitor(ctx, "mytool", fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		Convey("It is not monitored, so nothing of it can be killed", func() {
+			mem, cpu, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 100)
+			So(cpu, ShouldEqual, 0)
+			So(fake.killedIDs(), ShouldBeEmpty)
+		})
+
+		Convey("But a container of that name that appears afterwards is monitored", func() {
+			fake.add("jobs", "mytool", 300)
+
+			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 300)
+
+			Convey("And a kill request kills only that container", func() {
+				So(dm.killContainer(ctx), ShouldBeNil)
+				So(fake.killedIDs(), ShouldResemble, []string{"jobs"})
+			})
+		})
+	})
+
+	Convey("Given a cidfile naming a container that is already running", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "someone_elses", 500)
+
+		dir := t.TempDir()
+		cidPath := filepath.Join(dir, "job.cid")
+		So(os.WriteFile(cidPath, []byte("preexisting\n"), 0600), ShouldBeNil)
+
+		dm, err := newDockerMonitor(ctx, cidPath, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		Convey("It is not monitored", func() {
+			mem, _, errr := dm.resolveContainerMem(ctx, dir, 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 100)
+		})
+
+		Convey("But the container the job goes on to create is monitored", func() {
+			fake.add("jobs", "jobs_own", 300)
+			So(os.WriteFile(cidPath, []byte("jobs\n"), 0600), ShouldBeNil)
+
+			mem, _, errr := dm.resolveContainerMem(ctx, dir, 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 300)
+		})
+	})
+
+	Convey("Given a monitor of the first container to appear, with one already running", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "someone_elses", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		Convey("The already running one is not monitored", func() {
+			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 100)
+		})
+
+		Convey("The next one to appear is monitored", func() {
+			fake.add("jobs", "jobs_own", 300)
+
+			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(errr, ShouldBeNil)
+			So(mem, ShouldEqual, 300)
+		})
+	})
 }

--- a/jobqueue/docker_monitor_test.go
+++ b/jobqueue/docker_monitor_test.go
@@ -29,9 +29,12 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -54,6 +57,10 @@ const (
 	// under test hung, and we want that to fail an assertion rather than hang
 	// the whole suite.
 	dockerTestBound = 30 * time.Second
+
+	// dockerTestAPIVersion is the docker API version our fake daemon serves; the
+	// moby client asks for a pinned version directly instead of negotiating one.
+	dockerTestAPIVersion = "1.51"
 )
 
 func TestCheckingRendezvous(t *testing.T) {
@@ -155,25 +162,21 @@ func TestDockerMonitorUnresponsiveDaemon(t *testing.T) {
 			}
 
 			memCh := make(chan int, 1)
-			errCh := make(chan error, 1)
 
 			go func() {
-				mem, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
+				mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
 
 				memCh <- mem
-
-				errCh <- err
 			}()
 
-			statsErr, returned := awaitErr(errCh)
+			mem, returned := awaitMem(memCh)
 			So(returned, ShouldBeTrue)
-			So(statsErr, ShouldBeNil)
-			So(<-memCh, ShouldEqual, 100)
+			So(mem, ShouldEqual, 100)
+			So(dm.failures, ShouldEqual, 1)
 
 			Convey("And monitoring is given up on after repeated failures", func() {
 				for range dockerFailureTolerance + 2 {
-					_, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
-					So(err, ShouldBeNil)
+					dm.resolveContainerMem(ctx, "/tmp", 100)
 				}
 
 				So(stalled.callCount(), ShouldEqual, dockerFailureTolerance)
@@ -188,18 +191,19 @@ func TestDockerMonitorUnresponsiveDaemon(t *testing.T) {
 				callTimeout:   dockerTestCallTimeout,
 			}
 
-			errCh := make(chan error, 1)
+			memCh := make(chan int, 1)
 
 			go func() {
-				_, _, err := dm.resolveContainerMem(ctx, "/tmp", 100)
+				mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
 
-				errCh <- err
+				memCh <- mem
 			}()
 
-			err, returned := awaitErr(errCh)
+			mem, returned := awaitMem(memCh)
 			So(returned, ShouldBeTrue)
-			So(err, ShouldNotBeNil)
+			So(mem, ShouldEqual, 100)
 			So(dm.containerID, ShouldBeBlank)
+			So(dm.failures, ShouldEqual, 1)
 		})
 
 		Convey("Killing a monitored container does not block for ever", func() {
@@ -252,6 +256,17 @@ func TestDockerMonitorUnresponsiveDaemon(t *testing.T) {
 		So(returned, ShouldBeTrue)
 		So(statsErr, ShouldNotBeNil)
 	})
+}
+
+// awaitMem waits up to dockerTestBound for a memory reading to arrive on ch,
+// returning it and whether it arrived in time.
+func awaitMem(ch <-chan int) (int, bool) {
+	select {
+	case mem := <-ch:
+		return mem, true
+	case <-time.After(dockerTestBound):
+		return 0, false
+	}
 }
 
 // awaitErr waits up to dockerTestBound for an error to arrive on ch, returning
@@ -378,8 +393,8 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("It is not monitored, so nothing of it can be killed", func() {
-			mem, cpu, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
-			So(errr, ShouldBeNil)
+			mem, cpu := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 100)
 			So(cpu, ShouldEqual, 0)
 			So(fake.killedIDs(), ShouldBeEmpty)
@@ -388,8 +403,8 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		Convey("But a container of that name that appears afterwards is monitored", func() {
 			fake.add("jobs", "mytool", 300)
 
-			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
-			So(errr, ShouldBeNil)
+			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 300)
 
 			Convey("And a kill request kills only that container", func() {
@@ -411,8 +426,8 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("It is not monitored", func() {
-			mem, _, errr := dm.resolveContainerMem(ctx, dir, 100)
-			So(errr, ShouldBeNil)
+			mem, _ := dm.resolveContainerMem(ctx, dir, 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 100)
 		})
 
@@ -420,8 +435,8 @@ func TestDockerMonitorAdoption(t *testing.T) {
 			fake.add("jobs", "jobs_own", 300)
 			So(os.WriteFile(cidPath, []byte("jobs\n"), 0600), ShouldBeNil)
 
-			mem, _, errr := dm.resolveContainerMem(ctx, dir, 100)
-			So(errr, ShouldBeNil)
+			mem, _ := dm.resolveContainerMem(ctx, dir, 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 300)
 		})
 	})
@@ -434,17 +449,124 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("The already running one is not monitored", func() {
-			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
-			So(errr, ShouldBeNil)
+			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 100)
 		})
 
 		Convey("The next one to appear is monitored", func() {
 			fake.add("jobs", "jobs_own", 300)
 
-			mem, _, errr := dm.resolveContainerMem(ctx, "/tmp", 100)
-			So(errr, ShouldBeNil)
+			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 300)
+		})
+	})
+}
+
+// failingListDockerSocket serves a fake docker API on a unix socket, returning
+// the DOCKER_HOST value that addresses it. It answers the first container
+// listing (so that a monitor can be created for a job) and fails every listing
+// after that, which is what a docker daemon hiccup during a job's run looks
+// like. It needs no docker.
+func failingListDockerSocket(t *testing.T) string {
+	t.Helper()
+
+	sock := filepath.Join(t.TempDir(), "docker.sock")
+
+	var listenConfig net.ListenConfig
+
+	listener, err := listenConfig.Listen(context.Background(), "unix", sock)
+	So(err, ShouldBeNil)
+
+	var (
+		mu    sync.Mutex
+		lists int
+	)
+
+	server := &http.Server{
+		ReadHeaderTimeout: dockerTestBound,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasSuffix(r.URL.Path, "/containers/json") {
+				http.Error(w, `{"message":"not implemented by this fake"}`, http.StatusNotFound)
+
+				return
+			}
+
+			mu.Lock()
+			lists++
+			first := lists == 1
+			mu.Unlock()
+
+			if !first {
+				http.Error(w, `{"message":"a transient docker problem"}`, http.StatusInternalServerError)
+
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+
+			//nolint:errcheck // a client that has gone away is not this fake's problem.
+			w.Write([]byte("[]"))
+		}),
+	}
+
+	go func() {
+		//nolint:errcheck // Serve only ever ends with the error from our Close below.
+		server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+
+	return "unix://" + sock
+}
+
+// soBehavioursRan asserts whether the `run` behaviour that creates the marker
+// file at path ran, naming the behaviour set in any failure so that the output
+// says which one wrongly ran or wrongly did not.
+func soBehavioursRan(name, path string, wanted bool) {
+	_, err := os.Stat(path)
+
+	So(name+" behaviours ran: "+strconv.FormatBool(err == nil), ShouldEqual,
+		name+" behaviours ran: "+strconv.FormatBool(wanted))
+}
+
+func TestDockerLookupErrorNotJobFailure(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a job with success and failure behaviours, whose command succeeds", t, func() {
+		markers := t.TempDir()
+		successMarker := filepath.Join(markers, "success")
+		failureMarker := filepath.Join(markers, "failure")
+
+		client := newLiveExecuteCaptureClient(&liveTouchCapture{})
+		job := liveExecuteJob(client, liveExecuteCwd(t), "sleep 1.5")
+		job.Behaviours = Behaviours{
+			{When: OnSuccess, Do: Run, Arg: "touch " + successMarker},
+			{When: OnFailure, Do: Run, Arg: "touch " + failureMarker},
+		}
+
+		Convey("Only its success behaviours are triggered", func() {
+			So(client.Execute(context.Background(), job, "/bin/bash"), ShouldBeNil)
+
+			soBehavioursRan("on_failure", failureMarker, false)
+			soBehavioursRan("on_success", successMarker, true)
+		})
+
+		Convey("A docker container lookup that fails while it runs does not make it a failure", func() {
+			t.Setenv("DOCKER_HOST", failingListDockerSocket(t))
+			t.Setenv("DOCKER_API_VERSION", dockerTestAPIVersion)
+
+			job.MonitorDocker = "mytool"
+
+			So(client.Execute(context.Background(), job, "/bin/bash"), ShouldBeNil)
+
+			soBehavioursRan("on_failure", failureMarker, false)
+			soBehavioursRan("on_success", successMarker, true)
 		})
 	})
 }

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -381,6 +381,11 @@ type Job struct {
 	// --name or path to its --cidfile, adding its peak RAM and CPU usage to the
 	// reported RAM and CPU usage of this job.
 	//
+	// Only a container that appears after the job starts is monitored, however
+	// it is identified: a container that is already running under that name (or
+	// named in a stale cidfile) belongs to someone else, and monitoring it
+	// would make wr kill it when this job is killed or runs out of resources.
+	//
 	// If the special argument "?" is supplied, monitoring will apply to the
 	// first new docker container that appears after the Cmd starts to run.
 	// NB: if multiple jobs that run docker containers start running at the same


### PR DESCRIPTION
Two independent bugs in wr's docker monitoring, each demonstrated. One commit apiece.

## A wedged docker daemon hung a finished job for ever, holding its scheduler slot

Affected every `--with_docker` job, not just `--monitor_docker`, because `containerRunCmd` sets `MonitorDocker` to the job's key and that arms the monitor.

The context came from `cmd/runner.go` as `context.Background()` — no deadline, never cancelled — and the docker client was built with no HTTP timeout. A `ContainerStats` call inside the once-a-second check loop could therefore block for ever; blocked there, that goroutine stopped servicing `stopChecking` and never sent on `finishedChecking`, which is unbuffered, so `Execute` parked on its receive **after** `cmd.Wait()` had already returned. Both `stopTouching` sends are past that point, so the touch loop kept the job looking alive. Net: a finished job stayed "running" indefinitely, the runner never reserved again and never exited, its LSF or OpenStack slot was held, and `wr kill` hung too. Measured: `ContainerStats(context.Background(), ...)` still blocked after 5s against a socket that accepts and never answers.

A per-call deadline alone is not sufficient, which shaped the fix: `moby/client` holds `negotiateLock sync.Mutex` across its version-negotiation ping, and a mutex is not context-aware — so the first call returns `context deadline exceeded` while the next blocks behind the lock (measured: 500ms, then over 5s). Three parts were needed, and each buys something the others do not:

* an HTTP-level timeout on the client, which no call path can bypass, including the negotiation ping — this is what guarantees the stuck lock holder lets go;
* a per-operation deadline, which bounds a whole operation (list *then* stats) and is the layer a fake interactor can prove without docker;
* a buffered rendezvous plus a bounded wait, because a timeout alone still leaves `Execute` on an unconditional receive if the checker blocks in something else, and a buffer alone does nothing about that receive. The buffer is what makes giving up safe rather than a permanent goroutine leak.

Monitoring now also gives up after three consecutive failures. Without that, a wedged daemon costs ten seconds per tick for the job's life and grows an unbounded error chain — which would flip a *successful* job onto its failure behaviours. `myerr`, `closeErr` and the signal branch's kill error now take the state mutex, since giving up on the checker would otherwise turn a hang into a data race. A job wr genuinely cannot monitor still buries with `FailReasonDocker`.

## `--monitor_docker <name>` adopted and SIGKILLed a container wr did not start

`RememberCurrentContainers` was called only when `MonitorDocker == "?"`, so for a container name or a cidfile the "existing containers" set stayed empty and every running container looked new; the cidfile route never consulted it at all. That id then reached `ContainerKill{Signal: "SIGKILL"}` on `wr kill`, an OS signal to the runner, disk exhaustion, or peak memory over machine RAM.

So `wr add --monitor_docker mytool` on a shared node already running a container called `mytool` — a service, a database, another user's job — made wr kill it. Verified with real docker: a container started before the monitor existed was adopted as new, and correctly ignored once the existing set was remembered.

Existing containers are now remembered in every mode, and the cidfile lookup goes through a new-only variant, so wr can only ever adopt a container that appeared after the job started. `Job.MonitorDocker`'s doc previously promised "first **new** docker container", which was untrue for the name path; it now matches the code.

Adoption is asserted through reported peak RAM in the tests, so a failure reads as the real harm — 500MB billed to a job whose own container used 300MB.

## Not fixed, deliberately

In `"?"` mode the code still takes the first container in docker's list with no ownership check. Remembering existing containers narrows the window, but any unrelated container starting during the run is still eligible. The obvious framing does not work: a container's processes are children of the daemon, not of the job's command, so there is no ancestry to test. A real fix needs a correlation wr does not currently collect — a label or name wr sets itself, or a creation time compared against the command's start — plus a policy for the ambiguous case. Written up in the checklist.

Found by an adversarial probe of develop.

`make test` and `make race` both 423 passed / 9 skipped (develop's 420 plus the new tests, baseline measured on this tree); `make lint` 0 issues. Seven guard mutations across the two fixes, each red on exactly the case it should be — including one confirming the channel buffer is load-bearing rather than decorative.

`.docs/bugfixes/260902-8.md` records both mechanisms, the measurements and what was left alone.
