### PR TITLE
Fix wr mount daemonizing into / and swallowing every error

### DIFF
--- a/.docs/bugfixes/260903-1.md
+++ b/.docs/bugfixes/260903-1.md
@@ -1,0 +1,392 @@
+# Bugfixes 260903-1
+
+Branch `fix-mount-daemon-workdir`: `wr mount` daemonized with `WorkDir: "/"` and
+an otherwise empty `daemon.Context`, so every relative path in the user's mount
+options resolved against `/` instead of against the directory they typed the
+command in, and everything the daemon said - including every error it died of -
+went to `/dev/null`. The failure was completely silent: no mount, no message,
+and a shell exit status of 0.
+
+## Where this came from
+
+A probe of the two halves of `cmd/mount.go`'s daemonization, at the branch point
+`e8c3e55a`, using the binary built from it and a standalone go-daemon program
+that reproduces the same `daemon.Context`.
+
+The command's `-f`/`--foreground` mode keeps the user's working directory and
+their stderr, so both mechanisms are invisible in the mode the command is
+developed and demonstrated in. Running the same options both ways is what shows
+them.
+
+## The two mechanisms
+
+Both come from `mountCmd.Run` (cmd/mount.go, line 208 at the branch point):
+
+```go
+dContext := &daemon.Context{
+    WorkDir: "/",
+}
+```
+
+### 1. Every relative path resolved against `/`
+
+`go-daemon` starts the child with `Dir: d.WorkDir`
+(`daemon_unix.go:94`, inside `parent()`), so the daemon's working directory is
+`/`.
+
+`mountParseSimple` (cmd/mount.go:360 at the branch point) never sets `Mount`, so
+`wr mount -m 'cw:bucket/path'` left it empty. muxfys then defaulted it to
+`"mnt"` and took `filepath.Abs` of that (`muxfys.go:224-232`) - against `/`,
+giving `/mnt`. An empty `CacheBase` became `os.Getwd()` (`muxfys.go:250-255`),
+i.e. `/`, so muxfys made its cache as `/.muxfys_cacheXXXX`
+(`remote.go:190`). As a normal user both fail; as root - which is wr's own cloud
+deployment mode, and containers - it mounts `/mnt` and litters `/`.
+
+The same held for every relative path a user can supply: a relative `Mount`, a
+relative `CacheBase`, and a relative `MountTarget.CacheDir` (which muxfys also
+resolves with `filepath.Abs`, `remote.go:170-178`).
+
+This directly contradicted the command's own help text: "If not supplied,
+defaults to the subdirectory "mnt" in the current working directory", and
+"the cache directories will be made in the current working directory".
+
+### 2. All output was discarded
+
+With `LogFileName` empty, `Context.openFiles` leaves `d.logFile` nil, and
+`Context.files` (`daemon_unix.go:202-219`) then hands the child `d.nullFile` as
+BOTH its stdout (fd 1) and its stderr (fd 2). That `nullFile` is opened
+READ-ONLY (`os.Open(os.DevNull)`, `daemon_unix.go:128`), so the child's writes
+to its own stderr do not merely go nowhere, they fail outright.
+
+So `die()` in the daemon wrote to a closed door, and since the failure was the
+CHILD's, the shell saw the parent's exit 0. The user got no message, no mount,
+and no daemon.
+
+Measured with the standalone probe (`daemon.Context{WorkDir: "/"}`, the exact
+branch-point shape):
+
+```
+child cwd: /
+child fd1: /dev/null
+child fd2: /dev/null
+write to stderr: n=0 err=write /dev/stderr: bad file descriptor
+```
+
+## What a user experienced today
+
+Both mechanisms, from a directory of their own, with the branch-point binary
+(`$S/wr-baseline`), as a normal user:
+
+```
+$ wr mount -m 'zz:mybucket'            # an option typo
+exit=0                                 # ... and nothing else at all
+
+$ wr mount -f -m 'zz:mybucket'         # the same, in foreground mode
+EROR[09-03|06:20:20] 'zz:mybucket' did not start with c or u
+exit=1
+
+$ wr mount -j '[{"Mount":"mnt","Targets":[]}]'
+exit=0
+$ ls -a                                # no mnt: it went for /mnt
+.  ..
+
+$ wr mount -f -j '[{"Mount":"mnt","Targets":[]}]'
+EROR[09-03|06:20:20] could not mount: at least one RemoteConfig must be supplied
+exit=1
+$ ls -a                                # -f mounts where the user asked
+.  ..  mnt
+```
+
+```
+$ wr mount -m 'cw:mybucket/path'       # the documented common case
+exit=0                                 # ... and nothing else at all
+```
+
+Composed with a separate problem in the dependency - muxfys deletes a writable
+mount's cache at unmount even when the upload failed - the documented "mount a
+writable bucket, write into it, SIGTERM to upload" workflow can lose
+hand-written data with the error message going to `/dev/null`. See "Out of
+scope" below.
+
+## The fix
+
+Two changes, one per mechanism, plus one guard that the second change makes
+necessary.
+
+### Parse and resolve before the fork, against the user's directory
+
+`cmd/mount.go`'s `Run` now parses the options and resolves their paths BEFORE
+daemonizing:
+
+```go
+configs := resolvedMountConfigs()
+
+if foreground {
+    mountAndWait(configs)
+
+    return
+}
+
+mountDaemonized(configs)
+```
+
+`resolvedMountConfigs` is `mountParse(mountJSON, mountSimple).Resolve(mountCwd())`,
+and `mountAndWait` takes the configs it is to mount rather than parsing them
+itself. Two consequences: a bad option now dies in the process that still has
+the user's terminal, with exit status 1; and every path the daemon uses is
+already absolute.
+
+`MountConfigs.Resolve(cwd)` is new, in `jobqueue/mount.go` beside the
+`MountConfig` type whose contract it implements. It returns a COPY in which an
+unset `Mount` becomes `cwd/mnt` and an unset `CacheBase` becomes `cwd` (the
+documented defaults), and a relative `Mount`, `CacheBase` or `Target.CacheDir`
+is resolved against `cwd` - so it can also climb out of it, eg. `"../shared"`.
+
+Why in `jobqueue` and not in `cmd`: `cmd/*.go` is CLI wiring, and the three
+existing derivations of where a mount and its cache land - `resolveMountPoint`,
+`resolveCacheBase`, `resolveCacheDir` - are already jobqueue's, unexported,
+with `resolveCacheDir` carrying the comment that "a second derivation of where a
+cache lands is a second chance to get it wrong". Resolving in `cmd` would have
+been that second derivation.
+
+`Resolve` is applied by `wr mount` only. `wr add` (cmd/add.go:1098) and
+`wr mod` (cmd/mod.go:366) parse the same options with the same `mountParse`, and
+their MountConfigs must stay as the user wrote them: a Job's mounts are resolved
+against that JOB's working directory, by `Job.Mount`, when it runs. That is why
+the resolution is a separate step over the parsed configs rather than something
+`mountParse` does.
+
+Two paths are deliberately left alone by `Resolve`, since neither depends on a
+working directory: an absolute one, and one starting with `~`, which muxfys
+expands to the user's home directory (`homedir.Expand`, `muxfys.go:226` and
+`remote.go:171`). Joining `~/mnt` onto a cwd would have BROKEN a case that works
+today.
+
+### Resolving before the fork, rather than moving the daemon's WorkDir
+
+Setting `WorkDir` to the user's directory is a one-line alternative, and it was
+not taken. A daemon holding a working directory keeps that directory busy for as
+long as it holds it, and a mount point can be the very directory the command was
+run in: `mkdir mnt && cd mnt && wr mount -j '[{"Mount":"."}]'` is a legal way to
+ask for it, and a daemon sitting in its own mount point cannot unmount itself -
+`fusermount -u` fails with "device or resource busy" on a process whose cwd is
+inside the mount. For a command whose uploads only happen at unmount, an
+unmount that cannot complete is the worst failure available.
+
+So the daemon still runs in `/`, and is TOLD where the user's directory is:
+
+```go
+dContext := &daemon.Context{
+    WorkDir:     "/",
+    LogFileName: mountDaemonLogDest,
+    Env:         append(os.Environ(), mountCwdEnvVar+"="+mountCwd()),
+}
+```
+
+`WR_MOUNT_CWD` is needed because `Reborn()` daemonizes by re-EXECUTING the
+command: the child parses the same options again in its own `Run`, and would
+resolve them against its own `/` without it. `mountCwd()` prefers the variable
+and falls back to `os.Getwd()`, so parent and child run the same resolution over
+the same input.
+
+### A log destination that is the terminal the command was typed in
+
+`LogFileName` makes go-daemon hand the child a real file for fd 1 and fd 2, and
+of the available destinations the user's own stderr is the one that reaches the
+person who typed the command. It is spelt as the file descriptor:
+
+```go
+const mountDaemonLogDest = "/dev/fd/2"
+```
+
+and not as `"/dev/stderr"`, because go-daemon special-cases that exact name to
+hand the child our own `os.Stderr` (`daemon_unix.go:152-155`) and then CLOSES it
+in the deferred `closeFiles()`, leaving the parent unable to report a failure to
+daemonize. Measured, both ways, with the probe:
+
+```
+"/dev/stderr": child fd2 = <the terminal>; parent write after Reborn:
+               n=0 err=write /dev/stderr: file already closed
+"/dev/fd/2":   child fd2 = <the terminal>; parent write after Reborn: fine
+```
+
+`/dev/fd/2` also survives the cases that could have made it worse than the
+status quo: with stderr redirected to a file or a pipe the child gets that file
+or pipe, and with stderr CLOSED (`2>&-`) it gets the `/dev/null` the Go runtime
+has already put on fd 2, so the mount still happens either way.
+
+### Ignoring SIGPIPE in the daemon
+
+Pointing the daemon's stderr at the user's terminal introduces one new way to
+lose data, and it is closed here rather than left:
+
+```go
+signal.Ignore(syscall.SIGPIPE)
+```
+
+If the user's stderr is a pipe whose reader has gone (`wr mount ... 2>&1 |
+head -1`), a write to fd 2 gets EPIPE, and Go's default for EPIPE on fd 1 or 2
+is to raise SIGPIPE and terminate. The daemon writes to fd 2 exactly when
+something has gone wrong - including at unmount, when a cached writable mount
+still has uploads to do - so the default would kill the mount at the worst
+possible moment. Verified with the probe: without the `Ignore` the child dies
+before its next statement; with it, the write returns
+`err=write /dev/stderr: broken pipe` and the daemon carries on.
+
+## Verified by test
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -v -run TestMountConfigsResolve
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./cmd/ -v -run TestMountResolvesToUsersDir
+
+- `jobqueue/mount_test.go`, `TestMountConfigsResolve`: what paths a mount
+  configured from a given directory ends up using. Unset `Mount` and
+  `CacheBase`, relative ones, ones that climb out with `..`, absolute ones and
+  `~` ones, plus a target's `CacheDir`, and that the caller's own
+  `MountConfigs` are not altered.
+- `cmd/mount_test.go`, `TestMountResolvesToUsersDir`: the options a user
+  supplies to `wr mount`, through the same call `Run` makes before daemonizing.
+  One case runs from the directory itself (`t.Chdir`), the other from `/` with
+  `WR_MOUNT_CWD` set - the daemon's situation - and both must land in the user's
+  directory.
+
+## Verified by hand
+
+The daemonization itself cannot be driven from a committable port-free test:
+`Reborn()` re-executes the command as a new process, and what the child does
+with its working directory and its file descriptors is only observable in that
+child. Both halves were driven by hand instead, with the branch-point binary
+(`wr-baseline`) and the fixed one (`wr-fixed`) built from the same tree, in
+fresh empty directories, as a normal user. The branch-point outputs are quoted
+under "What a user experienced today"; the fixed ones:
+
+```
+$ wr-fixed mount -m 'zz:mybucket'
+EROR[09-03|06:26:21] 'zz:mybucket' did not start with c or u
+exit=1
+
+$ wr-fixed mount -j '[{"Mount":"mnt","Targets":[]}]'
+parent exit=0
+EROR[09-03|06:26:32] could not mount: at least one RemoteConfig must be supplied
+$ ls -a
+.  ..  mnt
+
+$ wr-fixed mount -m 'cw:mybucket/path'
+parent exit=0
+EROR[09-03|06:26:46] had a problem creating an S3 accessor: could not access S3: The specified bucket does not exist.
+```
+
+Both mechanisms, in both directions: the mount point now appears in the user's
+directory instead of at `/mnt`, and the daemon's errors now appear on the
+terminal instead of at `/dev/null`. The parent's exit status stays 0 for a
+failure that is the DAEMON's - it has daemonized successfully by then, and does
+not wait for the child - but the message is now the user's to see; an option
+error, which is now caught before the fork, exits 1.
+
+go-daemon's behaviour for this version (v0.1.6) was read
+(`files()` and `openFiles()`/`parent()` in `daemon_unix.go`) and then confirmed
+with a standalone program using the same `daemon.Context`, quoted above: child
+cwd `/`, read-only `/dev/null` on fds 1 and 2, the `/dev/stderr` special case
+closing the parent's stderr, `/dev/fd/2` not doing so, and the SIGPIPE death and
+its absence under `signal.Ignore`.
+
+A live mount of a real writable bucket was NOT attempted; the box has S3
+credentials but no bucket that is mine to write to. The S3-facing error above is
+as far as the real remote was driven.
+
+## Mutation checks
+
+`go vet ./cmd/ ./jobqueue/` was run after every edit below and reported clean
+each time, so no verdict here is a build failure masquerading as a dead guard.
+
+- [x] M1: the resolution reverted - `MountConfigs.Resolve` body replaced with
+  `_ = cwd; return slices.Clone(mcs)`. Vet clean. **RED** in both packages:
+  `TestMountConfigsResolve` (`Expected: "/user/dir/mnt" Actual: ""`,
+  `Expected: "/user/dir/mymnt" Actual: "mymnt"`,
+  `Expected: "/user/shared/mnt" Actual: "../shared/mnt"`) and
+  `TestMountResolvesToUsersDir`
+  (`Expected: "/tmp/TestMountResolvesToUsersDir3735519968/001/mnt" Actual: ""`).
+- [x] M2: the cmd wiring reverted - `resolvedMountConfigs` returning
+  `mountParse(mountJSON, mountSimple)` without `.Resolve(...)`. Vet clean.
+  **RED**: `TestMountResolvesToUsersDir` (`Actual: ""` and `Actual: "mymnt"`),
+  while `TestMountConfigsResolve` stays green. So the cmd test guards the
+  wiring, not just the helper.
+- [x] M3: the daemon's route to the user's directory reverted - `mountCwd()`'s
+  `os.Getenv(mountCwdEnvVar)` branch removed, so it always uses `os.Getwd()`.
+  Vet clean. **RED** on exactly the daemon cases, reproducing the bug itself:
+
+  ```
+  * cmd/mount_test.go
+  Line 59:
+  Expected: "/tmp/TestMountResolvesToUsersDir1308155633/002/mnt"
+  Actual:   "/mnt"
+  ```
+
+All mutations reverted and green again.
+
+## Out of scope: muxfys deletes a writable mount's cache even when the upload failed
+
+Reported, not changed - it is in the dependency, not in wr.
+
+`MuxFys.Unmount` (muxfys v5.0.0, muxfys.go:455) calls `uploadCreated()` and
+FOLDS its error into the returned error, then deletes every cache directory it
+created regardless:
+
+```go
+if !(len(doNotUpload) == 1 && doNotUpload[0]) {
+    uerr := fs.uploadCreated()
+    ...                                  // uerr recorded, not acted on
+}
+
+// delete any cachedirs we created
+for _, remote := range fs.remotes {
+    if remote.cacheIsTmp {
+        errd := remote.deleteCache()
+        ...
+```
+
+So a failed upload of a file the user wrote into a writable cached mount is
+followed by the deletion of the only remaining copy. That is the composition
+that made this bug's silence expensive rather than merely annoying, and it is
+what the daemon's `die()` was failing to tell anyone about. Fixing it means
+changing muxfys.
+
+## Out of scope: `wr mount` has no `--foreground` sibling for unmounting
+
+There is no `cmd/unmount.go`; the only way out of a `wr mount` is a signal, as
+the help text says. Nothing here invents one.
+
+## Files touched
+
+- `cmd/mount.go`: `Run` parses and resolves before daemonizing; new
+  `mountDaemonized` (the daemon context, with its log destination and the
+  environment variable that carries the user's directory, plus the SIGPIPE
+  guard), `mountCwd` and `resolvedMountConfigs`; `mountAndWait` takes the
+  configs to mount. No change to the option parsing itself or to the help text,
+  which already described the fixed behaviour.
+- `jobqueue/mount.go`: `MountConfigs.Resolve` and its `resolveAgainst` helper,
+  the `defaultMountDir` and `homeDirPrefix` constants, and `Key()` using the
+  first of those for the `"mnt"` it already spelled out.
+- `cmd/mount_test.go` (new), `jobqueue/mount_test.go` (new).
+
+## Gates
+
+From the repo root with all `OS_*` unset, on the committed tree:
+
+- `go build ./... && go vet ./cmd/ && go vet ./jobqueue/`: clean.
+- `make test`: `422 passed · 9 skipped · 29 packages · 3m47s`, PASSED.
+- `make race`: `422 passed · 9 skipped · 29 packages · 5m0s`, PASSED.
+- `make lint`: `0 issues.` (after `golangci-lint cache clean`).
+
+Baseline, measured on this branch point (`e8c3e55a`) with all five files stashed
+(`git stash -u`): `make test` gave `420 passed · 9 skipped · 29 packages · 3m43s`
+and `make lint` gave `0 issues.` The two extra tests are
+`TestMountConfigsResolve` and `TestMountResolvesToUsersDir`.
+
+`go test ./cmd/` is ALREADY failing on the branch point, for an unrelated
+reason: a cobra selector flag leaking between tests, so `cmd/suspend_test.go`
+line 62 gets `'-f, -i, -l and -a are mutually exclusive'` eight times. Measured
+on the pristine tree (`git stash -u`, `go test -tags netgo --count 1 ./cmd/`,
+`FAIL ... 50.407s`) before anything in `cmd/` was touched. The test suite's
+`cmd` lanes split that package with `-run` filters, which is why `make test`
+passes while `go test ./cmd/` does not. Not chased.

--- a/.docs/bugfixes/260903-1.md
+++ b/.docs/bugfixes/260903-1.md
@@ -324,6 +324,107 @@ each time, so no verdict here is a build failure masquerading as a dead guard.
 
 All mutations reverted and green again.
 
+## Review finding A: `WR_MOUNT_CWD` could reintroduce the bug
+
+Reported on PR #574: `mountCwd()` preferred `WR_MOUNT_CWD` over the actual
+working directory in EVERY process, so a user who had that variable exported -
+from a shell profile, or a stale export from a debugging session - got their
+relative paths resolved against its value even in the pre-fork resolve, which is
+the same class of bug this branch fixes: a value from outside deciding where
+relative paths land.
+
+Verified on both sides of the fork. The parent calls `mountCwd()` through
+`resolvedMountConfigs()` (which `Run` calls before daemonizing) and again in
+`mountDaemonized` to fill the child's environment; the child, being a fresh run
+of the command, calls it through `resolvedMountConfigs()` too. Only the last of
+those three may believe the variable.
+
+There was a second route to the same outcome, in the parent's own hand: the
+child's environment was `append(os.Environ(), "WR_MOUNT_CWD="+cwd)`, and a
+duplicated name in an environment is not a replacement. go-daemon starts the
+child with `os.StartProcess` (`daemon_unix.go:104`), which passes the strings
+through as they are, and `syscall.copyenv` maps a name to the "first mention of
+key", so `os.Getenv` in the child answers with the user's value and ignores
+ours. Measured with a standalone probe, environment
+`["WR_MOUNT_CWD=/users-stale-value", "WR_MOUNT_CWD=/what-the-parent-appended"]`:
+
+```text
+child sees WR_MOUNT_CWD="/users-stale-value"
+```
+
+(`os/exec` dedupes and keeps the last, which is why this has to be probed with
+`os.StartProcess`, the call go-daemon actually makes.)
+
+### The fix
+
+`mountCwd()` reads the variable only when `daemon.WasReborn()` is true.
+go-daemon marks the process it re-executes with `_GO_DAEMON=1`
+(`daemon_unix.go:193`, in `prepareEnv()`; the constants are `MARK_NAME` and
+`MARK_VALUE` and the check is `WasReborn()`, `daemon.go:11-21`), which is the
+one thing that distinguishes the child from the parent, since the child is
+otherwise the same executable with the same arguments. Its fallback stays
+`os.Getwd()`, which is right for both: the user's directory in the parent, and
+in a child that somehow has no variable, no worse than before.
+
+`mountDaemonEnv` builds the child's environment by DELETING any `WR_MOUNT_CWD`
+in ours before appending our own, so the value the child reads is the one we
+resolved against.
+
+Only these two, and no new mechanism: the variable is still how the child
+learns the directory, because `Reborn()` re-executes the command and there is
+nothing else to carry it.
+
+### Verified by test
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./cmd/ -v -run TestMountResolvesToUsersDir
+
+`cmd/mount_test.go` now models the two processes separately, with
+`setMountParentForTest` and `setMountDaemonForTest` setting the working
+directory, the variable and the go-daemon mark of each. Every leaf sets all
+three, because `t.Chdir` and `t.Setenv` only undo themselves when the test as a
+whole ends, not when a Convey leaf does. The new leaves are "a `WR_MOUNT_CWD` of
+their own does not move them elsewhere" (the parent) and "nor does it reach the
+daemon they start" (what `mountDaemonEnv` hands to `Reborn`); the daemon leaves,
+which must keep honouring the variable, now carry the mark.
+
+RED before the fix, with the user's `WR_MOUNT_CWD` at `.../004` and the
+directory they ran the command in at `.../003`:
+
+```text
+* cmd/mount_test.go
+Line 58:
+Expected: "/tmp/TestMountResolvesToUsersDir2928995667/003/mnt"
+Actual:   "/tmp/TestMountResolvesToUsersDir2928995667/004/mnt"
+```
+
+and for the environment half, with `.../005` the user's directory and `.../006`
+their stale value:
+
+```text
+* cmd/mount_test.go
+Line 66:
+Expected: []string{"/tmp/TestMountResolvesToUsersDir2317796744/005"}
+Actual:   []string{"/tmp/TestMountResolvesToUsersDir2317796744/006",
+          "/tmp/TestMountResolvesToUsersDir2317796744/005"}
+```
+
+### Mutation checks
+
+`go vet ./cmd/ ./jobqueue/` was clean for each, so neither verdict is a build
+failure masquerading as a dead guard.
+
+- [x] M4: the preference for the variable restored - the `daemon.WasReborn()`
+  guard removed from `mountCwd()`. Vet clean. **RED** on the parent leaves
+  (`Expected: ".../003/mnt" Actual: ".../004/mnt"`, and the environment leaf
+  then carries only the stale value: `Expected: [".../005"]
+  Actual: [".../006"]`), while the daemon leaves stay green.
+- [x] M5: the append restored in `mountDaemonEnv`. Vet clean. **RED** on the
+  environment leaf only (`Actual: [".../006", ".../005"]`), which is the child
+  reading the user's value instead of ours.
+
+Both reverted and green again.
+
 ## Out of scope: muxfys deletes a writable mount's cache even when the upload failed
 
 Reported, not changed - it is in the dependency, not in wr.

--- a/.docs/bugfixes/260903-1.md
+++ b/.docs/bugfixes/260903-1.md
@@ -425,6 +425,75 @@ failure masquerading as a dead guard.
 
 Both reverted and green again.
 
+## Review finding B: `~cache` was treated as a home path
+
+Reported on PR #574: `resolveAgainst()` left any path starting with `"~"`
+unresolved, which also matched a relative path with no slash in it, like
+`"~cache"`. Nothing else in this repo treats such a path as the home directory -
+`internal.TildaToHome` (internal/utils.go:216) only converts a `"~/"` prefix -
+so `~cache` was the one relative path that did not mean a subdirectory of the
+user's directory.
+
+muxfys agrees, and more sharply. `homedir.Expand` (go-homedir, homedir.go:58-77)
+returns the home directory for a bare `"~"`, joins the rest for a `"~/"` one,
+and ERRORS with "cannot expand user-specific home dir" for anything else, and
+`New` and `newRemote` return that error (muxfys.go:226-229, remote.go:171-174).
+So an unresolved `~mnt` Mount or `~cache` CacheDir did not merely mean something
+unexpected, it could not mount at all.
+
+### The fix
+
+`resolveAgainst()` now leaves alone only what does not depend on a working
+directory: an unset path, an absolute one, the bare `"~"`, and a `"~/"` one. The
+`homeDirPrefix` constant is `"~/"`, matching `internal.TildaToHome`'s rule, and
+the new `homeDir` constant is the `"~"` it is built from.
+
+Bare `"~"` stays a home path rather than becoming `cwd/~`. That is a departure
+from `internal.TildaToHome`, which converts only the prefix, and it follows the
+consumer instead: `homedir.Expand`, which is what actually resolves these paths,
+expands `"~"` to the home directory, so joining it onto cwd would break a case
+that works today - the same reason `~/mnt` is left alone.
+
+`~cache` is now resolved against cwd like any other relative path, which also
+takes the leading tilda off the front of it, so the path muxfys is given is one
+`homedir.Expand` passes through instead of refusing.
+
+### Verified by test
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -v -run TestMountConfigsResolve
+
+Two cases added to `TestMountConfigsResolve`'s table: "a path that only starts
+with a tilda is relative like any other" (`~mnt`, `~cache` and a `~target1`
+CacheDir, all under `/user/dir`) and "the home directory itself is left for the
+mount to expand" (a bare `~` for each of the three). The existing `~/mnt` case
+covers the prefix.
+
+RED before the fix:
+
+```text
+* jobqueue/mount_test.go
+Line 134:
+Expected: "/user/dir/~mnt"
+Actual:   "~mnt"
+```
+
+The bare `~` case was green before and after, which is the point of it: it
+records what the tightened rule must not break.
+
+### Mutation checks
+
+`go vet ./cmd/ ./jobqueue/` was clean, so the verdict is not a build failure
+masquerading as a dead guard.
+
+- [x] M6: the bare `"~"` prefix match restored -
+  `strings.HasPrefix(path, homeDir)` in place of the `homeDir`/`homeDirPrefix`
+  pair. Vet clean. **RED** on exactly the `~cache` case
+  (`Expected: "/user/dir/~mnt" Actual: "~mnt"`), with the bare `~` and `~/`
+  cases still green.
+
+Reverted and green again.
+
 ## Out of scope: muxfys deletes a writable mount's cache even when the upload failed
 
 Reported, not changed - it is in the dependency, not in wr.
@@ -452,6 +521,26 @@ that made this bug's silence expensive rather than merely annoying, and it is
 what the daemon's `die()` was failing to tell anyone about. Fixing it means
 changing muxfys.
 
+## Out of scope: muxfys does not expand `~` in CacheBase
+
+Found while checking finding B against the dependency, pre-dates this branch,
+and not changed here.
+
+`Mount` and a target's `CacheDir` go through `homedir.Expand` (muxfys.go:226,
+remote.go:171), but `CacheBase` goes through nothing: `New` takes it as it is,
+defaulting an empty one to `os.Getwd()` (muxfys.go:250-255), and hands it
+straight to `ioutil.TempDir` (remote.go:190). So a `CacheBase` of `~/cache` is
+used as the literal relative directory `"~/cache"`, and has been broken all
+along, in the daemon and in `-f` mode alike.
+
+`Resolve` leaves it alone anyway, along with the `~/` paths it can rely on
+muxfys to expand, since making a wr command expand `~` itself is a second
+derivation of the same thing muxfys does for the other two paths, and the fix
+belongs where the inconsistency is. Finding B does improve the neighbouring
+case: a `CacheBase` of `~cache` used to reach `ioutil.TempDir` as `"~cache"`,
+relative to the daemon's `/`, and is now an absolute path in the user's
+directory.
+
 ## Out of scope: `wr mount` has no `--foreground` sibling for unmounting
 
 There is no `cmd/unmount.go`; the only way out of a `wr mount` is a signal, as
@@ -462,12 +551,12 @@ the help text says. Nothing here invents one.
 - `cmd/mount.go`: `Run` parses and resolves before daemonizing; new
   `mountDaemonized` (the daemon context, with its log destination and the
   environment variable that carries the user's directory, plus the SIGPIPE
-  guard), `mountCwd` and `resolvedMountConfigs`; `mountAndWait` takes the
-  configs to mount. No change to the option parsing itself or to the help text,
-  which already described the fixed behaviour.
+  guard), `mountDaemonEnv`, `mountCwd` and `resolvedMountConfigs`;
+  `mountAndWait` takes the configs to mount. No change to the option parsing
+  itself or to the help text, which already described the fixed behaviour.
 - `jobqueue/mount.go`: `MountConfigs.Resolve` and its `resolveAgainst` helper,
-  the `defaultMountDir` and `homeDirPrefix` constants, and `Key()` using the
-  first of those for the `"mnt"` it already spelled out.
+  the `defaultMountDir`, `homeDir` and `homeDirPrefix` constants, and `Key()`
+  using the first of those for the `"mnt"` it already spelled out.
 - `cmd/mount_test.go` (new), `jobqueue/mount_test.go` (new).
 
 ## Gates

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -49,6 +49,21 @@ const defaultMountRetries = 10
 // that tell a mount to unmount and exit.
 const deathSignalBuffer = 2
 
+// mountCwdEnvVar is the environment variable that tells a daemonized mount
+// which directory the user ran the command in, since the daemon itself does not
+// run in it.
+const mountCwdEnvVar = "WR_MOUNT_CWD"
+
+// mountDaemonLogDest is the LogFileName that makes go-daemon give the
+// daemonized mount the stderr the user is looking at. Without it the daemon
+// gets a read-only /dev/null as both its stdout and its stderr, and everything
+// it says - including every error it dies of - is lost.
+//
+// It is spelt as the file descriptor rather than as "/dev/stderr" because
+// go-daemon special-cases that name to hand the child our own os.Stderr, and
+// then closes it, leaving us unable to report a failure to daemonize.
+const mountDaemonLogDest = "/dev/fd/2"
+
 // options for this cmd.
 var (
 	mountSimple  string
@@ -201,31 +216,20 @@ not cached, only serial writes are possible.`,
 
 		muxfys.SetLogHandler(l15h.CallerInfoHandler(log15.LvlFilterHandler(logLevel, log15.StderrHandler)))
 
+		// parse the options and resolve their paths before daemonizing, so that
+		// bad options are reported on the terminal of the person who typed the
+		// command, and so that relative paths mean what they say: the directory
+		// they ran us in, not the "/" the daemon runs in
+		configs := resolvedMountConfigs()
+
 		// now daemonize unless in foreground mode
 		if foreground {
-			mountAndWait()
-		} else {
-			dContext := &daemon.Context{
-				WorkDir: "/",
-			}
+			mountAndWait(configs)
 
-			child, err := dContext.Reborn()
-			if err != nil {
-				die("failed to daemonize: %s", err)
-			}
-
-			if child == nil {
-				// daemonized child, that will run until signalled to stop
-				defer func() {
-					err := dContext.Release()
-					if err != nil {
-						warn("daemon release failed: %s", err)
-					}
-				}()
-
-				mountAndWait()
-			}
+			return
 		}
+
+		mountDaemonized(configs)
 	},
 }
 
@@ -240,10 +244,72 @@ func init() {
 	mountCmd.Flags().BoolVarP(&mountVerbose, "verbose", "v", false, "print timing info on all remote calls")
 }
 
-// mountAndWait does the main work of this cmd.
-func mountAndWait() {
-	// mount everything
-	configs := mountParse(mountJSON, mountSimple)
+// mountDaemonized daemonizes and then does the work of this cmd in the
+// daemonized child process, which runs until signalled to stop.
+//
+// The daemon runs in "/" rather than in the user's working directory, so that
+// it does not keep that directory (which can be the very directory it mounts
+// on) busy for as long as it is mounted. Since it is a fresh run of this
+// command, which parses the same options again, it is told where that directory
+// is in its environment, and resolves those options against it exactly as we
+// did.
+func mountDaemonized(configs jobqueue.MountConfigs) {
+	dContext := &daemon.Context{
+		WorkDir:     "/",
+		LogFileName: mountDaemonLogDest,
+		Env:         append(os.Environ(), mountCwdEnvVar+"="+mountCwd()),
+	}
+
+	child, err := dContext.Reborn()
+	if err != nil {
+		die("failed to daemonize: %s", err)
+	}
+
+	if child != nil {
+		return
+	}
+
+	defer func() {
+		err := dContext.Release()
+		if err != nil {
+			warn("daemon release failed: %s", err)
+		}
+	}()
+
+	// our messages now go to the terminal the user typed the command in; if
+	// that goes away, writing to it must not kill a mount that still has
+	// uploads to do
+	signal.Ignore(syscall.SIGPIPE)
+
+	mountAndWait(configs)
+}
+
+// mountCwd returns the directory the user ran this command in, which their
+// relative Mount, CacheBase and CacheDir options are relative to. A daemonized
+// mount is told this by mountDaemonized, since it does not run in it.
+func mountCwd() string {
+	if cwd := os.Getenv(mountCwdEnvVar); cwd != "" {
+		return cwd
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		die("could not determine the working directory: %s", err)
+	}
+
+	return cwd
+}
+
+// resolvedMountConfigs parses this cmd's mount options and resolves the paths
+// in them against the directory the user ran the command in, dying on any
+// problem with the options.
+func resolvedMountConfigs() jobqueue.MountConfigs {
+	return mountParse(mountJSON, mountSimple).Resolve(mountCwd())
+}
+
+// mountAndWait mounts the given configs, then waits for a signal to unmount
+// them and return.
+func mountAndWait(configs jobqueue.MountConfigs) {
 	mounted := make([]*muxfys.MuxFys, 0, len(configs))
 
 	for _, mc := range configs {

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -257,7 +258,7 @@ func mountDaemonized(configs jobqueue.MountConfigs) {
 	dContext := &daemon.Context{
 		WorkDir:     "/",
 		LogFileName: mountDaemonLogDest,
-		Env:         append(os.Environ(), mountCwdEnvVar+"="+mountCwd()),
+		Env:         mountDaemonEnv(mountCwd()),
 	}
 
 	child, err := dContext.Reborn()
@@ -284,12 +285,37 @@ func mountDaemonized(configs jobqueue.MountConfigs) {
 	mountAndWait(configs)
 }
 
+// mountDaemonEnv returns the environment for the daemonized child: our own,
+// with mountCwdEnvVar set to the given directory.
+//
+// Any mountCwdEnvVar the user already had is REMOVED rather than left to be
+// shadowed by ours: go-daemon starts the child with os.StartProcess
+// (daemon_unix.go:104), which passes duplicated names through as they are, and
+// os.Getenv then answers with the FIRST of them (syscall.copyenv keeps the
+// "first mention of key"), which would be theirs.
+func mountDaemonEnv(cwd string) []string {
+	env := slices.DeleteFunc(os.Environ(), func(nameValue string) bool {
+		return strings.HasPrefix(nameValue, mountCwdEnvVar+"=")
+	})
+
+	return append(env, mountCwdEnvVar+"="+cwd)
+}
+
 // mountCwd returns the directory the user ran this command in, which their
-// relative Mount, CacheBase and CacheDir options are relative to. A daemonized
-// mount is told this by mountDaemonized, since it does not run in it.
+// relative Mount, CacheBase and CacheDir options are relative to.
+//
+// Only a daemonized mount may believe mountCwdEnvVar, which mountDaemonized
+// told it because it does not run in that directory. In any other process that
+// variable is just something in the user's environment, and letting it decide
+// where their relative paths land would be the bug this whole mechanism exists
+// to fix. go-daemon marks the process it re-executes with _GO_DAEMON=1
+// (daemon_unix.go:193, read by daemon.WasReborn), which is how we tell the two
+// apart.
 func mountCwd() string {
-	if cwd := os.Getenv(mountCwdEnvVar); cwd != "" {
-		return cwd
+	if daemon.WasReborn() {
+		if cwd := os.Getenv(mountCwdEnvVar); cwd != "" {
+			return cwd
+		}
 	}
 
 	cwd, err := os.Getwd()

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -27,20 +27,22 @@ package cmd
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/sevlyar/go-daemon"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestMountResolvesToUsersDir(t *testing.T) {
 	Convey("Given a user who mounts a bucket with --mounts and no other options", t, func() {
-		dir, err := filepath.EvalSymlinks(t.TempDir())
-		So(err, ShouldBeNil)
+		dir := dirForTest(t)
+		otherDir := dirForTest(t)
 
 		setMountOptionsForTest(t, "", "cw:mybucket/path")
 
 		Convey("the mount point and cache are in the directory they ran wr mount in", func() {
-			t.Chdir(dir)
+			setMountParentForTest(t, dir, "")
 
 			configs := resolvedMountConfigs()
 
@@ -49,9 +51,24 @@ func TestMountResolvesToUsersDir(t *testing.T) {
 			So(configs[0].CacheBase, ShouldEqual, dir)
 		})
 
+		Convey("a WR_MOUNT_CWD of their own does not move them elsewhere", func() {
+			setMountParentForTest(t, dir, otherDir)
+
+			configs := resolvedMountConfigs()
+
+			So(configs, ShouldHaveLength, 1)
+			So(configs[0].Mount, ShouldEqual, filepath.Join(dir, "mnt"))
+			So(configs[0].CacheBase, ShouldEqual, dir)
+		})
+
+		Convey("nor does it reach the daemon they start", func() {
+			setMountParentForTest(t, dir, otherDir)
+
+			So(mountCwdEnvValues(mountDaemonEnv(mountCwd())), ShouldResemble, []string{dir})
+		})
+
 		Convey("they are in that directory for the daemon too, which runs from /", func() {
-			t.Setenv(mountCwdEnvVar, dir)
-			t.Chdir("/")
+			setMountDaemonForTest(t, dir)
 
 			configs := resolvedMountConfigs()
 
@@ -62,14 +79,12 @@ func TestMountResolvesToUsersDir(t *testing.T) {
 	})
 
 	Convey("Given a user who mounts with a relative --mount_json CacheDir", t, func() {
-		dir, err := filepath.EvalSymlinks(t.TempDir())
-		So(err, ShouldBeNil)
+		dir := dirForTest(t)
 
 		setMountOptionsForTest(t, `[{"Mount":"mymnt","Targets":[{"Path":"mybucket","CacheDir":"mycache"}]}]`, "")
 
 		Convey("the mount point and cache dir are in the directory the daemon was started from", func() {
-			t.Setenv(mountCwdEnvVar, dir)
-			t.Chdir("/")
+			setMountDaemonForTest(t, dir)
 
 			configs := resolvedMountConfigs()
 
@@ -79,6 +94,18 @@ func TestMountResolvesToUsersDir(t *testing.T) {
 			So(configs[0].Targets[0].CacheDir, ShouldEqual, filepath.Join(dir, "mycache"))
 		})
 	})
+}
+
+// dirForTest returns a symlink-free directory that only exists for the duration
+// of the test, since the paths a mount resolves to are compared as the strings
+// they are.
+func dirForTest(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	So(err, ShouldBeNil)
+
+	return dir
 }
 
 // setMountOptionsForTest sets the mount command's option variables for the
@@ -96,4 +123,49 @@ func setMountOptionsForTest(t *testing.T, jsonString, simpleString string) {
 
 	mountJSON = jsonString
 	mountSimple = simpleString
+}
+
+// setMountParentForTest puts this process in the situation of the wr mount the
+// user typed: running in cwd, with envCwd as the value of mountCwdEnvVar in its
+// environment, which only a daemonized mount may believe.
+func setMountParentForTest(t *testing.T, cwd, envCwd string) {
+	t.Helper()
+
+	setMountProcessForTest(t, cwd, envCwd, "")
+}
+
+// mountCwdEnvValues returns the value of every mountCwdEnvVar entry in the
+// given environment, in the order the child process would see them: with a
+// duplicated name, os.Getenv answers with the first.
+func mountCwdEnvValues(env []string) []string {
+	values := make([]string, 0, 1)
+
+	for _, nameValue := range env {
+		if value, ok := strings.CutPrefix(nameValue, mountCwdEnvVar+"="); ok {
+			values = append(values, value)
+		}
+	}
+
+	return values
+}
+
+// setMountDaemonForTest puts this process in the situation of a daemonized
+// mount: re-executed by go-daemon with its mark set, running from "/", and told
+// the user's directory in mountCwdEnvVar.
+func setMountDaemonForTest(t *testing.T, envCwd string) {
+	t.Helper()
+
+	setMountProcessForTest(t, "/", envCwd, daemon.MARK_VALUE)
+}
+
+// setMountProcessForTest gives this process the working directory,
+// mountCwdEnvVar value and go-daemon mark of the wr mount process being
+// modelled. Each of the three is always set, since t.Chdir and t.Setenv only
+// undo themselves when the test as a whole ends, not when a Convey leaf does.
+func setMountProcessForTest(t *testing.T, cwd, envCwd, daemonMark string) {
+	t.Helper()
+
+	t.Setenv(daemon.MARK_NAME, daemonMark)
+	t.Setenv(mountCwdEnvVar, envCwd)
+	t.Chdir(cwd)
 }

--- a/cmd/mount_test.go
+++ b/cmd/mount_test.go
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMountResolvesToUsersDir(t *testing.T) {
+	Convey("Given a user who mounts a bucket with --mounts and no other options", t, func() {
+		dir, err := filepath.EvalSymlinks(t.TempDir())
+		So(err, ShouldBeNil)
+
+		setMountOptionsForTest(t, "", "cw:mybucket/path")
+
+		Convey("the mount point and cache are in the directory they ran wr mount in", func() {
+			t.Chdir(dir)
+
+			configs := resolvedMountConfigs()
+
+			So(configs, ShouldHaveLength, 1)
+			So(configs[0].Mount, ShouldEqual, filepath.Join(dir, "mnt"))
+			So(configs[0].CacheBase, ShouldEqual, dir)
+		})
+
+		Convey("they are in that directory for the daemon too, which runs from /", func() {
+			t.Setenv(mountCwdEnvVar, dir)
+			t.Chdir("/")
+
+			configs := resolvedMountConfigs()
+
+			So(configs, ShouldHaveLength, 1)
+			So(configs[0].Mount, ShouldEqual, filepath.Join(dir, "mnt"))
+			So(configs[0].CacheBase, ShouldEqual, dir)
+		})
+	})
+
+	Convey("Given a user who mounts with a relative --mount_json CacheDir", t, func() {
+		dir, err := filepath.EvalSymlinks(t.TempDir())
+		So(err, ShouldBeNil)
+
+		setMountOptionsForTest(t, `[{"Mount":"mymnt","Targets":[{"Path":"mybucket","CacheDir":"mycache"}]}]`, "")
+
+		Convey("the mount point and cache dir are in the directory the daemon was started from", func() {
+			t.Setenv(mountCwdEnvVar, dir)
+			t.Chdir("/")
+
+			configs := resolvedMountConfigs()
+
+			So(configs, ShouldHaveLength, 1)
+			So(configs[0].Mount, ShouldEqual, filepath.Join(dir, "mymnt"))
+			So(configs[0].Targets, ShouldHaveLength, 1)
+			So(configs[0].Targets[0].CacheDir, ShouldEqual, filepath.Join(dir, "mycache"))
+		})
+	})
+}
+
+// setMountOptionsForTest sets the mount command's option variables for the
+// duration of the test, restoring them afterwards.
+func setMountOptionsForTest(t *testing.T, jsonString, simpleString string) {
+	t.Helper()
+
+	oldJSON := mountJSON
+	oldSimple := mountSimple
+
+	t.Cleanup(func() {
+		mountJSON = oldJSON
+		mountSimple = oldSimple
+	})
+
+	mountJSON = jsonString
+	mountSimple = simpleString
+}

--- a/jobqueue/mount.go
+++ b/jobqueue/mount.go
@@ -203,12 +203,18 @@ func (mcs MountConfigs) Resolve(cwd string) MountConfigs {
 // not depend on the working directory: an unset path (which the caller must
 // give its own default), an absolute one, the home directory, or one inside it.
 func resolveAgainst(path, dir string) string {
-	if path == "" || path == homeDir || filepath.IsAbs(path) ||
-		strings.HasPrefix(path, homeDirPrefix) {
+	if pathIgnoresDir(path) {
 		return path
 	}
 
 	return filepath.Join(dir, path)
+}
+
+// pathIgnoresDir tells you if path means the same thing wherever it is resolved
+// from: an unset path, an absolute one, the home directory, or one inside it.
+func pathIgnoresDir(path string) bool {
+	return path == "" || path == homeDir || filepath.IsAbs(path) ||
+		strings.HasPrefix(path, homeDirPrefix)
 }
 
 // String provides a JSON representation of the MountConfigs.

--- a/jobqueue/mount.go
+++ b/jobqueue/mount.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Genome Research Ltd.
+ * Copyright (c) 2017-2019, 2026 Genome Research Ltd.
  *
  * Author: Sendu Bala <sb10@sanger.ac.uk>
  *
@@ -30,9 +30,19 @@ package jobqueue
 import (
 	"bytes"
 	"encoding/json"
+	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 )
+
+// defaultMountDir is the subdirectory of the working directory that a
+// MountConfig with no Mount of its own is mounted on.
+const defaultMountDir = "mnt"
+
+// homeDirPrefix is the start of a path that means the user's home directory,
+// which muxfys expands for us.
+const homeDirPrefix = "~"
 
 // MountConfig struct is used for setting in a Job to specify that a remote file
 // system or object store should be fuse mounted prior to running the Job's Cmd.
@@ -144,6 +154,55 @@ type MountTarget struct {
 // MountConfigs is a slice of MountConfig.
 type MountConfigs []MountConfig
 
+// Resolve returns a copy of these MountConfigs in which every path is one that
+// means the same thing from any working directory: an unset Mount becomes the
+// "mnt" subdirectory of cwd and an unset CacheBase becomes cwd (the documented
+// defaults), while a relative Mount, CacheBase or Target CacheDir is resolved
+// against cwd (so it can also climb out of it, eg. "../shared").
+//
+// Paths that already mean the same thing from anywhere - absolute ones, and
+// ones starting with "~", which the mount expands to the user's home directory
+// - are left as they are.
+//
+// It is for a command that must mount from a different working directory than
+// the user was in when they configured the mount, which is what 'wr mount'
+// does when it daemonizes.
+func (mcs MountConfigs) Resolve(cwd string) MountConfigs {
+	resolved := make(MountConfigs, 0, len(mcs))
+
+	for _, mc := range mcs {
+		mc.Mount = resolveAgainst(mc.Mount, cwd)
+		if mc.Mount == "" {
+			mc.Mount = filepath.Join(cwd, defaultMountDir)
+		}
+
+		mc.CacheBase = resolveAgainst(mc.CacheBase, cwd)
+		if mc.CacheBase == "" {
+			mc.CacheBase = cwd
+		}
+
+		mc.Targets = slices.Clone(mc.Targets)
+		for i, mt := range mc.Targets {
+			mc.Targets[i].CacheDir = resolveAgainst(mt.CacheDir, cwd)
+		}
+
+		resolved = append(resolved, mc)
+	}
+
+	return resolved
+}
+
+// resolveAgainst returns path resolved against dir, unless it is one that does
+// not depend on the working directory: an unset path (which the caller must
+// give its own default), an absolute one, or one starting with "~".
+func resolveAgainst(path, dir string) string {
+	if path == "" || filepath.IsAbs(path) || strings.HasPrefix(path, homeDirPrefix) {
+		return path
+	}
+
+	return filepath.Join(dir, path)
+}
+
 // String provides a JSON representation of the MountConfigs.
 func (mcs MountConfigs) String() string {
 	if len(mcs) == 0 {
@@ -181,7 +240,7 @@ func (mcs MountConfigs) Key() string {
 	for _, mc := range mcs.sortedByMount() {
 		mount := mc.Mount
 		if mount == "" {
-			mount = "mnt"
+			mount = defaultMountDir
 		}
 
 		key.WriteString(mount)

--- a/jobqueue/mount.go
+++ b/jobqueue/mount.go
@@ -40,9 +40,15 @@ import (
 // MountConfig with no Mount of its own is mounted on.
 const defaultMountDir = "mnt"
 
-// homeDirPrefix is the start of a path that means the user's home directory,
-// which muxfys expands for us.
-const homeDirPrefix = "~"
+// homeDir is the path that means the user's home directory, and homeDirPrefix
+// starts a path inside it; muxfys expands both for us (homedir.Expand). As in
+// internal.TildaToHome, a tilda not followed by a "/" is neither of these:
+// "~cache" is a legal relative directory name, and muxfys refuses to expand it
+// ("cannot expand user-specific home dir").
+const (
+	homeDir       = "~"
+	homeDirPrefix = homeDir + "/"
+)
 
 // MountConfig struct is used for setting in a Job to specify that a remote file
 // system or object store should be fuse mounted prior to running the Job's Cmd.
@@ -161,8 +167,9 @@ type MountConfigs []MountConfig
 // against cwd (so it can also climb out of it, eg. "../shared").
 //
 // Paths that already mean the same thing from anywhere - absolute ones, and
-// ones starting with "~", which the mount expands to the user's home directory
-// - are left as they are.
+// "~" and "~/..." ones, which the mount expands to the user's home directory
+// - are left as they are. A tilda not followed by a "/" is not one of those:
+// "~cache" is resolved against cwd like any other relative path.
 //
 // It is for a command that must mount from a different working directory than
 // the user was in when they configured the mount, which is what 'wr mount'
@@ -194,9 +201,10 @@ func (mcs MountConfigs) Resolve(cwd string) MountConfigs {
 
 // resolveAgainst returns path resolved against dir, unless it is one that does
 // not depend on the working directory: an unset path (which the caller must
-// give its own default), an absolute one, or one starting with "~".
+// give its own default), an absolute one, the home directory, or one inside it.
 func resolveAgainst(path, dir string) string {
-	if path == "" || filepath.IsAbs(path) || strings.HasPrefix(path, homeDirPrefix) {
+	if path == "" || path == homeDir || filepath.IsAbs(path) ||
+		strings.HasPrefix(path, homeDirPrefix) {
 		return path
 	}
 

--- a/jobqueue/mount_test.go
+++ b/jobqueue/mount_test.go
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// testResolveCwd is the directory the user is in when they configure the mounts
+// of the Resolve tests.
+const testResolveCwd = "/user/dir"
+
+// testResolveBucket is the remote path of the targets of those mounts.
+const testResolveBucket = "bucket/path"
+
+func TestMountConfigsResolve(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	for _, tc := range []struct {
+		name          string
+		config        MountConfig
+		wantMount     string
+		wantCacheBase string
+		wantCacheDirs []string
+	}{
+		{
+			name:          "an unconfigured mount is in the mnt subdirectory of the user's directory",
+			config:        MountConfig{Targets: []MountTarget{{Path: testResolveBucket, Cache: true}}},
+			wantMount:     "/user/dir/mnt",
+			wantCacheBase: "/user/dir",
+			wantCacheDirs: []string{""},
+		},
+		{
+			name: "relative paths are relative to the user's directory",
+			config: MountConfig{
+				Mount:     "mymnt",
+				CacheBase: "cache",
+				Targets:   []MountTarget{{Path: testResolveBucket, CacheDir: "target1"}},
+			},
+			wantMount:     "/user/dir/mymnt",
+			wantCacheBase: "/user/dir/cache",
+			wantCacheDirs: []string{"/user/dir/target1"},
+		},
+		{
+			name: "relative paths can climb out of the user's directory",
+			config: MountConfig{
+				Mount:     "../shared/mnt",
+				CacheBase: "../shared/cache",
+				Targets:   []MountTarget{{Path: testResolveBucket, CacheDir: "../shared/target1"}},
+			},
+			wantMount:     "/user/shared/mnt",
+			wantCacheBase: "/user/shared/cache",
+			wantCacheDirs: []string{"/user/shared/target1"},
+		},
+		{
+			name: "absolute paths are left alone",
+			config: MountConfig{
+				Mount:     "/elsewhere/mnt",
+				CacheBase: "/elsewhere/cache",
+				Targets: []MountTarget{
+					{Path: testResolveBucket, CacheDir: "/elsewhere/target1"},
+					{Path: testResolveBucket, CacheDir: "/elsewhere/target2"},
+				},
+			},
+			wantMount:     "/elsewhere/mnt",
+			wantCacheBase: "/elsewhere/cache",
+			wantCacheDirs: []string{"/elsewhere/target1", "/elsewhere/target2"},
+		},
+		{
+			name: "home directory paths are left for the mount to expand",
+			config: MountConfig{
+				Mount:     "~/mnt",
+				CacheBase: "~/cache",
+				Targets:   []MountTarget{{Path: testResolveBucket, CacheDir: "~/target1"}},
+			},
+			wantMount:     "~/mnt",
+			wantCacheBase: "~/cache",
+			wantCacheDirs: []string{"~/target1"},
+		},
+	} {
+		Convey("Resolve says "+tc.name, t, func() {
+			resolved := MountConfigs{tc.config}.Resolve(testResolveCwd)
+
+			So(resolved, ShouldHaveLength, 1)
+			So(resolved[0].Mount, ShouldEqual, tc.wantMount)
+			So(resolved[0].CacheBase, ShouldEqual, tc.wantCacheBase)
+			So(resolvedCacheDirs(resolved[0]), ShouldResemble, tc.wantCacheDirs)
+		})
+	}
+
+	Convey("Resolve does not alter the MountConfigs it was asked about", t, func() {
+		mcs := MountConfigs{{Targets: []MountTarget{{Path: testResolveBucket, CacheDir: "cache"}}}}
+
+		resolved := mcs.Resolve(testResolveCwd)
+
+		So(resolved[0].Mount, ShouldEqual, "/user/dir/mnt")
+		So(resolved[0].Targets[0].CacheDir, ShouldEqual, "/user/dir/cache")
+		So(mcs[0].Mount, ShouldEqual, "")
+		So(mcs[0].CacheBase, ShouldEqual, "")
+		So(mcs[0].Targets[0].CacheDir, ShouldEqual, "cache")
+	})
+}
+
+// resolvedCacheDirs returns the CacheDir of each of the MountConfig's Targets.
+func resolvedCacheDirs(mc MountConfig) []string {
+	dirs := make([]string, len(mc.Targets))
+
+	for i, mt := range mc.Targets {
+		dirs[i] = mt.CacheDir
+	}
+
+	return dirs
+}

--- a/jobqueue/mount_test.go
+++ b/jobqueue/mount_test.go
@@ -104,6 +104,28 @@ func TestMountConfigsResolve(t *testing.T) {
 			wantCacheBase: "~/cache",
 			wantCacheDirs: []string{"~/target1"},
 		},
+		{
+			name: "the home directory itself is left for the mount to expand",
+			config: MountConfig{
+				Mount:     "~",
+				CacheBase: "~",
+				Targets:   []MountTarget{{Path: testResolveBucket, CacheDir: "~"}},
+			},
+			wantMount:     "~",
+			wantCacheBase: "~",
+			wantCacheDirs: []string{"~"},
+		},
+		{
+			name: "a path that only starts with a tilda is relative like any other",
+			config: MountConfig{
+				Mount:     "~mnt",
+				CacheBase: "~cache",
+				Targets:   []MountTarget{{Path: testResolveBucket, CacheDir: "~target1"}},
+			},
+			wantMount:     "/user/dir/~mnt",
+			wantCacheBase: "/user/dir/~cache",
+			wantCacheDirs: []string{"/user/dir/~target1"},
+		},
 	} {
 		Convey("Resolve says "+tc.name, t, func() {
 			resolved := MountConfigs{tc.config}.Resolve(testResolveCwd)


### PR DESCRIPTION
`wr mount` daemonized into `/` and discarded every error message, so a mount that failed reported nothing at all — exit 0, no output, no mount, no daemon.

Two mechanisms, both measured against go-daemon v0.1.6:

* **Every relative path resolved against `/`.** The daemon context set `WorkDir: "/"`, which go-daemon passes as the child's directory. An empty `Mount` becomes `"mnt"` and then `filepath.Abs` — against `/`, so `/mnt`. An empty `CacheBase` becomes `os.Getwd()`, i.e. `/`, so muxfys creates its cache as `/.muxfys_cacheXXXX`. As a normal user both fail; as root, which is wr's own cloud deployment mode, it mounts `/mnt` and litters `/`.
* **All output was discarded, and worse than to `/dev/null`.** With no `LogFileName`, go-daemon hands the child its `nullFile` as both stdout and stderr — and that file is opened **read-only**, so the child's writes fail with `bad file descriptor`. Measured on the branch point: `wr mount -m 'zz:mybucket'` gave exit 0 and no output whatsoever, while the same command with `-f` correctly reported the malformed option and exited 1. `--foreground` keeps the user's directory and its stderr, which is why this was invisible in the mode the command is developed in.

The mount configurations are now resolved against the user's directory **before** daemonizing, so option errors reach the terminal with a non-zero exit. `WorkDir` deliberately stays `/`: a daemon whose working directory is inside its own mount cannot unmount itself, and `mkdir mnt && cd mnt && wr mount -j '[{"Mount":"."}]'` is legal — for a command whose uploads only happen at unmount, that would be fatal. The daemon is told the directory through the environment instead, because `Reborn()` re-execs and the child re-parses the options.

`Resolve` is applied by `wr mount` only. `wr add` and `wr mod` share the same option parsing, but their configurations must stay relative to each job's own working directory.

Two smaller findings fixed with it, each verified by probe rather than assumed: the daemon's log goes to `/dev/fd/2` rather than `/dev/stderr`, because go-daemon special-cases the latter and closes it, losing the "failed to daemonize" message; and the daemon now ignores `SIGPIPE`, because `wr mount ... 2>&1 | head -1` otherwise kills it and aborts pending uploads.

Found by an adversarial probe of develop.

`make test` and `make race` both 422 passed / 9 skipped (+2 on develop's 420, measured on this tree); `make lint` 0 issues. Three guard mutations, each red on the right cases, including one that reproduces the original bug verbatim (`Expected ".../002/mnt"`, `Actual "/mnt"`).

Path resolution is covered by tests at both the `jobqueue` contract and the exact call the command makes before daemonizing. That failures now reach the terminal is verified by hand rather than by test — only the re-exec'd child can show it, and `cmd` has no seam for `die()` that would not amount to a redesign. The checklist records what was tested versus what was verified by hand.

Not touched, and worth its own decision: muxfys deletes a writable mount's cache at unmount even when the upload failed, so a transient S3 failure destroys the only local copy. Combined with the silence above, the documented mount-and-write workflow could lose hand-written data with no message. That deletion is in the dependency.
