### PR TITLE
Give a job-added job's workspace a sibling cwd, not one inside its parent's

### DIFF
--- a/.docs/bugfixes/260903-11.md
+++ b/.docs/bugfixes/260903-11.md
@@ -547,7 +547,7 @@ by name and inside `make test`, which shards around it.
 
 # A `run` behaviour's command gets no `WR_JOB_CWD`
 
-- [ ] There are now two implementations of "put the directories wr made for
+- [x] There are now two implementations of "put the directories wr made for
   this job into an environment", and they disagree. `envWithRunDirs`
   (jobqueue/client.go:575, this branch) sets `TMPDIR`, `HOME` when
   `ChangeHome`, and `WR_JOB_CWD`, and removes an inherited `WR_JOB_CWD` when
@@ -555,7 +555,7 @@ by name and inside `make test`, which shards around it.
   merged #572) sets only `TMPDIR` and `HOME`. So a `run` behaviour whose
   command calls `wr add` - `on_success: {"run": "wr add -f followup.txt"}` -
   gets no `WR_JOB_CWD`, `Behaviour.run` sets `cmd.Dir = dir.execDir()`
-  (jobqueue/behaviours.go:378), and `wr add` falls back to `os.Getwd()` and
+  (jobqueue/behaviours.go:357), and `wr add` falls back to `os.Getwd()` and
   lands the new job's workspace inside the adding job's: the bug this branch
   exists to fix, still live down that path.
 
@@ -613,7 +613,7 @@ func envWithRunDirs(env []string, dirs jobRunDirs, changeHome bool) []string
 
 - `jobqueue/client.go:1987` (`Execute`, the Job's own Cmd):
   `envWithRunDirs(env, jobRunDirs{cwd: job.Cwd, actualCwd: actualCwd, tmp: tmpDir}, job.ChangeHome)`
-- `jobqueue/workspace.go:217` (`runEnv`, a `run` Behaviour's command):
+- `jobqueue/workspace.go:218` (`runEnv`, a `run` Behaviour's command):
   `envWithRunDirs(env, jobRunDirs{cwd: s.cwd, actualCwd: dir.path, tmp: dir.tmp}, s.env.changeHome)`
 
 **Why that seam.** `envWithRunDirs` took a whole `*Job` only to read `Cwd` and
@@ -629,9 +629,12 @@ expressible. `s.cwd` is passed uncleaned, so the behaviour path exports the
 identical string `Execute` exports.
 
 Verified there is now exactly one computation: across all non-test Go,
-`"TMPDIR="` and `JobCwdEnvVar+"="` appear only at `jobqueue/job_run_env.go:98`
-and `"HOME="` only at `:101`; the only other mention of the variable is the
-reader at `cmd/add.go:955`. `grep -rn dirEnv --include='*.go'` is empty.
+one `over` literal at `jobqueue/job_run_env.go:103` is the only place
+`"TMPDIR="` is written and the only place `JobCwdEnvVar+"="` is exported, and
+`:106` the only place `"HOME="` is. The variable's name appears once more in
+that file, at `:98`, where the other branch deletes it, and once outside it, at
+`cmd/add.go:955`, where `wr add` reads it. `grep -rn dirEnv --include='*.go'`
+is empty.
 
 ### The `tmpDir == ""` case
 
@@ -651,7 +654,7 @@ implemented first and was wrong: with it, a `cwd_matters` Job that named no
 environment at all left `runEnv` returning nil, `Behaviour.run` set
 `cmd.Env = nil` (jobqueue/behaviours.go:358), and the command inherited the
 triggering runner's or manager's OWN `WR_JOB_CWD` verbatim. `Execute` has no
-such hole: `jobEnv.decode` (jobqueue/job.go:669-671) returns `nil, nil` only
+such hole: `jobEnv.decode` (jobqueue/job.go:671-673) returns `nil, nil` only
 when `len(envC) == 0 && !retrieved`, and a reserved Job always has
 `EnvCRetrieved` true, so the deletion always has a slice to run over.
 
@@ -742,9 +745,11 @@ Every verdict below was taken only after `go vet ./cmd/ ./jobqueue/` exited 0,
 so none is a build failure masquerading as a dead guard.
 
 - [x] M6: stop exporting `WR_JOB_CWD` on the run-behaviour path only. Vet OK.
-  **RED**: `behaviours_env_test.go Line 194: Expected:
-  "/tmp/TestBehaviourRunEnv1840746745/009" Actual: ""`, 107 assertions; the
-  other ten Conveys stay green, so it is that case alone.
+  **RED** on both of the run-path cases that assert the variable's value:
+  `behaviours_env_test.go Line 194: Expected:
+  "/tmp/TestBehaviourRunEnv2695470135/009" Actual: ""`, and `Line 254` the same
+  shape for the no-stored-environment case. The other ten leaves stay green, so
+  it is those two alone.
 - [x] M7: stop removing an inherited value (`!wrMade()` branch returns `env`).
   Vet OK. **RED on both paths**: `behaviours_env_test.go Line 208` and `Line
   225` both `Expected '/grandparent' to be blank`, and `job_run_env_test.go Line
@@ -759,30 +764,108 @@ so none is a build failure masquerading as a dead guard.
   ""`). Vet OK. **RED**: `behaviours_env_test.go Line 225: Expected
   '/grandparent' to be blank (but it wasn't)!`, 107 assertions.
 - [x] M11: make the nil-environment guard never fire (`if false && env == nil`,
-  so it compiles). Vet OK. **RED** on the same `Line 225`.
+  so it compiles). Vet OK. **RED** on that same `Line 225` AND on `Line 257:
+  Expected: "from_triggering_process" Actual: ""` - the second being the only
+  assertion that can see this branch of the guard, since `envOverride` appends
+  to a nil slice and so still produces a correct `HOME`, `TMPDIR` and
+  `WR_JOB_CWD` from nothing. 119 assertions.
 - [x] All reverted from saved copies; `go build ./...`,
   `go vet ./cmd/ ./jobqueue/`, `gofmt -l jobqueue/ cmd/` clean, tests green
   again.
 
-### Outstanding review findings
+### Three review findings, and what closed them
 
-Three, raised by the cycle-2 review and not yet fixed at this commit:
+The first review PASSed the structure and failed on the substance twice. All
+three findings are fixed above; they are recorded here because each names a way
+this fix could have looked done and not been.
 
-1. **`Execute`'s `job.Cwd` mapping lost its pin.** Before the refactor the
-   helper read `job.Cwd` itself and `job_run_env_test.go` called it with a real
-   `&Job{Cwd: origCwd}`, so `So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)`
-   and `So(env, ShouldNotContain, JobCwdEnvVar+"="+workSpace)` pinned it. The
-   mapping now lives at the call site, untested. M12 - `client.go:1987` passing
-   `cwd: actualCwd`, ie. restoring the original bug for the Job's own Cmd - has
-   `go vet` exit 0 and **SURVIVES** every targeted suite.
-2. **A `wrMade()`-branch nil-environment case has no kept test.** With the
-   guard disabled, `envOverride(nil, over)` returns exactly `over`, so the
-   command runs with three variables and no `PATH` while `HOME`, `TMPDIR` and
-   `WR_JOB_CWD` all still read correctly. Only a variable present solely in the
-   triggering process makes the fallback observable. This is also what
-   `.docs/bugfixes/260902-7.md` records as checked for #572.
-3. **Two `jobqueue/job_run_env.go` comments are still untrue.** The nil
-   paragraph ("A nil env comes back nil") holds only on the `!wrMade()` branch;
-   and the `jobRunDirs` type comment and its `actualCwd` field comment disagree
-   with each other, neither being true of both call sites (`Execute` passes `""`
-   for a `cwd_matters` Job, `runEnv` passes the Job's own Cwd).
+**1. The refactor moved `Execute`'s `job.Cwd` read out of coverage.** Before it,
+the helper read `job.Cwd` itself and `job_run_env_test.go` called it with a real
+`&Job{Cwd: origCwd}`, so `So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)` and
+`So(env, ShouldNotContain, JobCwdEnvVar+"="+workSpace)` pinned the mapping. With
+the mapping at the call site, **M12** - `client.go:1987` passing
+`cwd: actualCwd`, ie. telling the Job's own Cmd that its Cwd is the disposable
+working directory, which is the original bug - had `go vet` exit 0 and SURVIVED
+every targeted suite. The central value of the branch was unpinned on the
+`Execute` path.
+
+Closed at the supported boundary rather than with a unit test on the mapping:
+the live Convey at `jobqueue/jobqueue_test.go:4551`, which already drives the
+real `jq.Execute` for two Jobs sharing one Cwd (one `cwd_matters`, one not) and
+reads their stdout back, now has both perl commands print `$ENV{WR_JOB_CWD}` as
+a third field. The `cwd_matters` Job must report it EMPTY; the other must report
+the shared Cwd and not its own `ActualCwd`. Both directions, on the real path,
+from the job's own output. M12 is now **RED**: `jobqueue_test.go` `Line 4636`,
+`1287 total assertions`, `--- FAIL (25.88s)`, with `Actual` ending
+`.../jobqueue_cwd/3/5/5/<uniq>/cwd` where `Expected` ends at the shared
+`jobqueue tmpdir`.
+
+Two consequential edits came with it: the two perl commands were hoisted into
+`passCmd`/`failCmd` locals, since each was repeated three times (`Add`,
+`job.Cmd`, `GetByEssence`) and would otherwise have had to be kept in sync six
+times; and the reassignment `tmpDir = <actualCwd's sibling>+"tmp"` became a new
+`wrTmpDir`, because the new archived-read assertion needs `tmpDir` still to name
+the Job's Cwd at a point where the old code had already overwritten it. The
+`ShouldStartWith` hash constant changed with the `Cmd`, since `Job.Key()` hashes
+it: `d/4/1/7364d743329da784e74f2d69d438d` became
+`3/5/5/65da5ced642d9c5026565e20149b5`, read from the test's own output and
+re-derived independently from `Job.Key()` and `calculateHashedDir`.
+
+**2. The `wrMade()` half of `runEnv`'s nil-environment guard had no kept test.**
+`envOverride` appends to a nil slice, so with the guard disabled a Job that
+named no environment still gets a correct `HOME`, `TMPDIR` and `WR_JOB_CWD` -
+and nothing else, `PATH` included. Only a variable present solely in the
+triggering process makes the fallback observable, which is why the first two
+probes written for it survived mutation. This is also the behaviour
+`.docs/bugfixes/260902-7.md` records as checked for #572 ("`HOME` and `TMPDIR`
+are still applied over that fallback, so `--change_home` holds even here").
+
+Closed by a fourth Convey in `jobqueue/behaviours_env_test.go`: a
+non-`cwd_matters` Job with `--change_home`, no stored environment at all, a real
+workspace, and `testEnvVar` planted only in the triggering process. It asserts
+`HOME`, `TMPDIR` and `WR_JOB_CWD` as usual and then that planted variable,
+which is the assertion that can see the guard. M11 now fires on it (`Line 257`)
+as well as on the `cwd_matters` case (`Line 225`).
+
+It plants the variable with `os.Setenv` plus a GoConvey `Reset` rather than
+`t.Setenv`, and the reason is measured: `t.Setenv`'s restore waits for the
+whole test, while the enclosing block asserts that this variable is named
+nowhere but the Job, and GoConvey re-runs that body once per leaf - so a
+`t.Setenv` there failed every later leaf. `Reset` runs even while a
+`FailureHalts` panic is in flight, so the undo happens on both paths, and that
+same blank-check is what would catch it if it ever did not. The idiom matches
+`jobqueue/behaviours_test.go:424`.
+
+**3. Two of the rewritten doc comments were still untrue.** "A nil env comes
+back nil" held only on the `!wrMade()` branch; and the `jobRunDirs` type comment
+contradicted its own `actualCwd` field comment, neither being true of both call
+sites. Both now state the divergence instead of asserting one side: `Execute`
+passes the blank `resolveWorkingDir` hands it for a `cwd_matters` Job, `runEnv`
+passes the Job's own Cwd, and neither is wrong because nothing reads the field
+when wr made no working directory. Making the call sites agree instead was
+rejected, and the reviewer accepted the reason: `runEnv` would have to consult
+`wrMade` to choose what to pass, which is a second reading of the discriminator
+outside the one place that owns it.
+
+### Known gap, not chased
+
+The claim that `s.cwd` is exported uncleaned, byte-identical to what `Execute`
+exports, is unpinned: a mutation cleaning or absolutising it in `runEnv` moves
+no assertion, because every test Cwd is an already-absolute, already-clean
+`t.TempDir()`. Low severity - a cleaned value still names the same directory,
+and a relative Cwd cannot reach `runEnv` at all, since `paths()` and
+`cwdRunDir` refuse one first. Recorded rather than fixed.
+
+### Files touched
+
+- `jobqueue/job_run_env.go` (new): `jobRunDirs`, `wrMade`, and `envWithRunDirs`
+  moved out of `client.go` and re-parameterised off `*Job`.
+- `jobqueue/client.go`: the helper removed; `Execute`'s one call site.
+- `jobqueue/workspace.go`: `runDir.dirEnv` deleted; `runEnv` calls the shared
+  helper and names `os.Environ()` unconditionally; three comments.
+- `jobqueue/behaviours_env_test.go`: the probe fixtures extended to report
+  `WR_JOB_CWD`, `storeTestEnv` made variadic, four new Conveys.
+- `jobqueue/job_run_env_test.go`: re-parameterised onto `jobRunDirs`, with the
+  `cwd_matters` case strengthened to pass `changeHome` true.
+- `jobqueue/jobqueue_test.go`: `WR_JOB_CWD` added to the live cwd/TMPDIR/HOME
+  Convey, in both directions.

--- a/.docs/bugfixes/260903-11.md
+++ b/.docs/bugfixes/260903-11.md
@@ -542,3 +542,247 @@ and outside this change, so it is reported rather than chased. `cmd` went 59 ->
 `cmd/suspend_test.go` (a cobra selector flag leaking between tests), which is
 the known pre-existing failure. Not chased. Both new `cmd` tests pass when run
 by name and inside `make test`, which shards around it.
+
+---
+
+# A `run` behaviour's command gets no `WR_JOB_CWD`
+
+- [ ] There are now two implementations of "put the directories wr made for
+  this job into an environment", and they disagree. `envWithRunDirs`
+  (jobqueue/client.go:575, this branch) sets `TMPDIR`, `HOME` when
+  `ChangeHome`, and `WR_JOB_CWD`, and removes an inherited `WR_JOB_CWD` when
+  there is no tmpDir. `runDir.dirEnv` (jobqueue/workspace.go:488, from the
+  merged #572) sets only `TMPDIR` and `HOME`. So a `run` behaviour whose
+  command calls `wr add` - `on_success: {"run": "wr add -f followup.txt"}` -
+  gets no `WR_JOB_CWD`, `Behaviour.run` sets `cmd.Dir = dir.execDir()`
+  (jobqueue/behaviours.go:378), and `wr add` falls back to `os.Getwd()` and
+  lands the new job's workspace inside the adding job's: the bug this branch
+  exists to fix, still live down that path.
+
+  - Red command (throwaway probe, `jobqueue/zz_probe_test.go`, since removed;
+    log kept at
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/red-probe.log`).
+    It drove the production entry point, `(&Behaviour{When: OnExit, Do: Run,
+    Arg: "printf ... \"$WR_JOB_CWD\" > out"}).Trigger(OnExit, job)`, and read
+    the file the command wrote:
+
+        unset $(compgen -v | grep '^OS_')
+        CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ \
+          -run TestProbeRunBehaviourJobCwd -v
+
+    ```
+      run behaviour and WR_JOB_CWD
+        a wr-created workspace job's run behaviour is told the Job's Cwd ✔✔✔✔✘
+        a cwd_matters job's run behaviour sees no stale inherited value ✔✔✔✘
+
+    Failures:
+
+      * jobqueue/zz_probe_test.go
+      Line 31:
+      Expected: "/tmp/TestProbeRunBehaviourJobCwd2193276075/001"
+      Actual:   ""
+      (Should equal)!
+
+      * jobqueue/zz_probe_test.go
+      Line 46:
+      Expected '/grandparent' to be blank (but it wasn't)!
+
+    9 total assertions
+
+    --- FAIL: TestProbeRunBehaviourJobCwd (0.01s)
+    ```
+
+    Both halves of the invariant are broken on the run-behaviour path: the
+    variable is absent where it must be present, and a stale inherited one
+    survives where it must be cleared.
+
+## The fix: one implementation, two callers
+
+`envWithRunDirs` moved out of `jobqueue/client.go` into a new
+`jobqueue/job_run_env.go`, re-parameterised off `*Job`, and `runDir.dirEnv` was
+deleted. Both commands wr runs for a Job now take their environment from the
+one function:
+
+```go
+type jobRunDirs struct{ cwd, actualCwd, tmp string }
+
+func (d jobRunDirs) wrMade() bool { return d.tmp != "" }
+
+func envWithRunDirs(env []string, dirs jobRunDirs, changeHome bool) []string
+```
+
+- `jobqueue/client.go:1987` (`Execute`, the Job's own Cmd):
+  `envWithRunDirs(env, jobRunDirs{cwd: job.Cwd, actualCwd: actualCwd, tmp: tmpDir}, job.ChangeHome)`
+- `jobqueue/workspace.go:217` (`runEnv`, a `run` Behaviour's command):
+  `envWithRunDirs(env, jobRunDirs{cwd: s.cwd, actualCwd: dir.path, tmp: dir.tmp}, s.env.changeHome)`
+
+**Why that seam.** `envWithRunDirs` took a whole `*Job` only to read `Cwd` and
+`ChangeHome`, and the behaviour path deliberately has no Job: the snapshot
+exists so nothing downstream re-reads one (jobqueue/workspace.go's
+`workSpaceSnapshotLocked`). So the Job had to be narrowed to its two facts. A
+method on `runDir` was rejected because `Execute` has no `runDir`, and building
+a fake one would fake the held-descriptor semantics `runDir` documents. The
+three paths are a data clump that already travelled together, and a flat
+five-parameter signature would have put three same-typed path strings adjacent;
+the parameter object makes both call sites name every field, so a swap is not
+expressible. `s.cwd` is passed uncleaned, so the behaviour path exports the
+identical string `Execute` exports.
+
+Verified there is now exactly one computation: across all non-test Go,
+`"TMPDIR="` and `JobCwdEnvVar+"="` appear only at `jobqueue/job_run_env.go:98`
+and `"HOME="` only at `:101`; the only other mention of the variable is the
+reader at `cmd/add.go:955`. `grep -rn dirEnv --include='*.go'` is empty.
+
+### The `tmpDir == ""` case
+
+Both paths now take the same `!wrMade()` branch, which REMOVES any inherited
+`JobCwdEnvVar` rather than leaving it. `runEnv`'s old `len(dirEnv) == 0 ->
+return env` early exit is gone; that early exit was the second half of the bug,
+since a `cwd_matters` job's run behaviour kept a stale value naming a different
+directory. `tmp` is still the condition rather than a new flag, for commit 1's
+reason: `resolveWorkingDir` makes no directories at all for a `cwd_matters` Job,
+and `mkHashedDir` returns the working directory and the tmp dir together.
+
+### The nil-environment case
+
+`runEnv` names `os.Environ()` whenever the decoded environment is nil - NOT only
+when wr made directories. The narrower guard (`env == nil && dirs.wrMade()`) was
+implemented first and was wrong: with it, a `cwd_matters` Job that named no
+environment at all left `runEnv` returning nil, `Behaviour.run` set
+`cmd.Env = nil` (jobqueue/behaviours.go:358), and the command inherited the
+triggering runner's or manager's OWN `WR_JOB_CWD` verbatim. `Execute` has no
+such hole: `jobEnv.decode` (jobqueue/job.go:669-671) returns `nil, nil` only
+when `len(envC) == 0 && !retrieved`, and a reserved Job always has
+`EnvCRetrieved` true, so the deletion always has a slice to run over.
+
+Measured on the tree that had the narrower guard, driving the production entry
+point with `WR_JOB_CWD=/grandparent` in the triggering process and a
+`CwdMatters` Job carrying no stored environment (`go vet` exit 0):
+
+```
+  A CwdMatters Job with no stored environment ✔✔✔✘
+
+  * jobqueue/zz_orch_m9_test.go
+  Line 26:
+  Expected '/grandparent' to be blank (but it wasn't)!
+
+4 total assertions
+
+--- FAIL: TestOrchM9 (0.00s)
+```
+
+So the guard is unconditional and `runEnv` can no longer return nil. That costs
+nothing real: `cmd.Env = nil` and `cmd.Env = os.Environ()` name the same
+variables - `exec.Cmd` documents nil as the current process's environment - and
+the only difference is that the named copy is subject to the helper's deletion,
+which is the point. `Behaviour.run` is `runEnv`'s only consumer and never
+distinguishes nil from non-nil. The error paths still return `nil, err`, so no
+"never nil" claim is made anywhere. `jobqueue/job_run_env_test.go:94` still
+pins `envWithRunDirs(nil, dirs, false)` as nil, which is the helper's own
+contract and unaffected.
+
+### Doc comments corrected
+
+- `runDir.dirEnv`'s ("Execute sets both on the Job's own Cmd...") went with the
+  function.
+- `jobWorkSpaceSnapshot.runEnv`'s claimed the directories went in "exactly as
+  Execute puts them (see runDir.dirEnv)" and that "a nil result... leaves
+  exec.Cmd inheriting this process's". It now says they go in "by the
+  envWithRunDirs Execute itself uses", and that where the Job named no
+  environment the command gets this process's but NAMED, so `envWithRunDirs`
+  decides `JobCwdEnvVar` over it too.
+- `runDir.tmp`'s field comment pointed at `dirEnv`; it now points at
+  `jobRunDirs.wrMade`.
+- `envWithRunDirs`'s own comment lost commit 1's broken line break and now
+  states both directions of the invariant.
+
+### Red command for the run-behaviour path
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -run TestBehaviourRunEnv -v
+
+The regression test lives in `jobqueue/behaviours_env_test.go`, extending that
+file's existing probe fixtures rather than adding a parallel set: `probedEnv`
+gained a `jobCwd` field, `envProbeBehaviour` a fourth `printf` line, and
+`storeTestEnv` became variadic so a stale value arrives in the Job's own stored
+environment the way production delivers one. Three new Conveys drive
+`(&Behaviour{When: OnExit, Do: Run, ...}).Trigger(OnExit, job)` and read the
+file the behaviour's own bash process wrote.
+
+Red before the fix, with the pre-fix `runEnv` restored (`gofmt` clean,
+`go vet ./cmd/ ./jobqueue/` exit 0):
+
+```
+    a run behaviour is told the Job's own Cwd, not the working directory it runs in ✔✔✔✔✔✘✔✔
+    a CwdMatters Job's run behaviour is told nothing, not even what it inherited ✔✔✔✔✘✔✔
+
+Failures:
+
+  * jobqueue/behaviours_env_test.go
+  Line 194:
+  Expected: "/tmp/TestBehaviourRunEnv660693416/009"
+  Actual:   ""
+  (Should equal)!
+
+  * jobqueue/behaviours_env_test.go
+  Line 208:
+  Expected '/grandparent' to be blank (but it wasn't)!
+
+99 total assertions
+
+--- FAIL: TestBehaviourRunEnv (0.06s)
+```
+
+Green afterwards: `108 total assertions` / `--- PASS: TestBehaviourRunEnv`, and
+`119 total assertions` / `--- PASS: TestJobRunEnv`.
+
+### Mutation checks
+
+Every verdict below was taken only after `go vet ./cmd/ ./jobqueue/` exited 0,
+so none is a build failure masquerading as a dead guard.
+
+- [x] M6: stop exporting `WR_JOB_CWD` on the run-behaviour path only. Vet OK.
+  **RED**: `behaviours_env_test.go Line 194: Expected:
+  "/tmp/TestBehaviourRunEnv1840746745/009" Actual: ""`, 107 assertions; the
+  other ten Conveys stay green, so it is that case alone.
+- [x] M7: stop removing an inherited value (`!wrMade()` branch returns `env`).
+  Vet OK. **RED on both paths**: `behaviours_env_test.go Line 208` and `Line
+  225` both `Expected '/grandparent' to be blank`, and `job_run_env_test.go Line
+  90: Expected: []string{"FOO=bar"} Actual: []string{"FOO=bar",
+  "WR_JOB_CWD=/grandparent"}`.
+- [x] M8: export it for a `cwd_matters` job (`!wrMade()` branch replaced with
+  `envOverride(env, []string{JobCwdEnvVar + "=" + dirs.cwd})`). Vet OK. **RED on
+  both paths**: `behaviours_env_test.go Line 208`, `Line 225`, and
+  `job_run_env_test.go Line 84: Actual: []string{"FOO=bar",
+  "WR_JOB_CWD=/some/user/dir"}`.
+- [x] M10: reintroduce the nil-environment hole (`if env == nil && dir.tmp !=
+  ""`). Vet OK. **RED**: `behaviours_env_test.go Line 225: Expected
+  '/grandparent' to be blank (but it wasn't)!`, 107 assertions.
+- [x] M11: make the nil-environment guard never fire (`if false && env == nil`,
+  so it compiles). Vet OK. **RED** on the same `Line 225`.
+- [x] All reverted from saved copies; `go build ./...`,
+  `go vet ./cmd/ ./jobqueue/`, `gofmt -l jobqueue/ cmd/` clean, tests green
+  again.
+
+### Outstanding review findings
+
+Three, raised by the cycle-2 review and not yet fixed at this commit:
+
+1. **`Execute`'s `job.Cwd` mapping lost its pin.** Before the refactor the
+   helper read `job.Cwd` itself and `job_run_env_test.go` called it with a real
+   `&Job{Cwd: origCwd}`, so `So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)`
+   and `So(env, ShouldNotContain, JobCwdEnvVar+"="+workSpace)` pinned it. The
+   mapping now lives at the call site, untested. M12 - `client.go:1987` passing
+   `cwd: actualCwd`, ie. restoring the original bug for the Job's own Cmd - has
+   `go vet` exit 0 and **SURVIVES** every targeted suite.
+2. **A `wrMade()`-branch nil-environment case has no kept test.** With the
+   guard disabled, `envOverride(nil, over)` returns exactly `over`, so the
+   command runs with three variables and no `PATH` while `HOME`, `TMPDIR` and
+   `WR_JOB_CWD` all still read correctly. Only a variable present solely in the
+   triggering process makes the fallback observable. This is also what
+   `.docs/bugfixes/260902-7.md` records as checked for #572.
+3. **Two `jobqueue/job_run_env.go` comments are still untrue.** The nil
+   paragraph ("A nil env comes back nil") holds only on the `!wrMade()` branch;
+   and the `jobRunDirs` type comment and its `actualCwd` field comment disagree
+   with each other, neither being true of both call sites (`Execute` passes `""`
+   for a `cwd_matters` Job, `runEnv` passes the Job's own Cwd).

--- a/.docs/bugfixes/260903-11.md
+++ b/.docs/bugfixes/260903-11.md
@@ -1,0 +1,337 @@
+# Bugfixes 260903-11
+
+Branch `fix-nested-job-cwd`: a job that adds jobs - an ordinary, documented
+pattern - got its children's working directories built INSIDE its own, because
+`wr add`'s default `--cwd` is `os.Getwd()` and `os.Getwd()` inside a job is the
+disposable working directory wr made for that job.
+
+## The default-composition chain
+
+Four links, all on the branch point (`902eccf0`):
+
+1. `cmd/add.go:607` - `--cwd` defaults to the empty string.
+2. `cmd/add.go:909` `defaultCwd` - with no `--cwd`, the default is
+   `os.Getwd()`, unless the manager is remote and the job is not
+   `--cwd_matters`, in which case it is `/tmp` with a warning.
+   `cmd/add.go:1162` assigns that to `jd.Cwd` for every line of the commands
+   file that names no `cwd` of its own.
+3. `jobqueue/client.go:1294` `resolveWorkingDir` - for a job whose Cwd does NOT
+   matter, `mkHashedDir(job.Cwd, job.Key())` creates
+   `<Cwd>/<AppName>_cwd/k0/k1/k2/<k3..><digits>/cwd` and `.../tmp`, and
+   `client.go:1306` sets `cmd.Dir` to that `cwd`. For a `--cwd_matters` job it
+   returns `("", "", nil)` and `cmd.Dir` is `job.Cwd` itself
+   (`client.go:1288`).
+4. So `os.Getwd()` in the job's own command is that created working directory,
+   and a `wr add` run there with no `--cwd` gave the new job a `Cwd` of the
+   adding job's working directory. `mkHashedDir` then built the new job's
+   working directory five levels below THAT.
+
+Measured (probe, quoted verbatim below): parent `Cwd` `<base>`, parent working
+directory `<base>/jobqueue_cwd/e/6/6/<uniq>/cwd`, child `Cwd` the same string,
+child working directory
+`<base>/jobqueue_cwd/e/6/6/<uniq>/cwd/jobqueue_cwd/c/f/3/<uniq2>/cwd`.
+
+## The two consequences
+
+### Data loss - found with a probe
+
+`wr add` offers `--on_exit '[{"cleanup":true}]'`, and cleanup deletes the whole
+created working directory. With the child's work nested inside it, the parent's
+cleanup - which runs when the PARENT exits, while the child may still be
+running - takes the child with it. A throwaway probe drove the production entry
+point, `(&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, parent)`, on
+the nested shape above:
+
+```
+parent cleanup err = <nil>
+child's live work .../cwd/jobqueue_cwd/c/f/3/<uniq2>/cwd/child-output.txt:
+  no such file or directory
+exists? .../cwd/jobqueue_cwd/c/f/3/<uniq2>/cwd   false
+exists? .../cwd/jobqueue_cwd/c/f/3/<uniq2>/tmp   false
+```
+
+No error, no warning: the child's live output is simply gone, and so is the
+child's whole workspace and TMPDIR. This is not a race the deletion has to win -
+it deletes a directory the child is still writing to.
+
+### Workspaces never reclaimed - found from a user report
+
+A user complained that their wr tmp directories were not being cleaned up. The
+mechanism, from the same nesting: the parent's sweep cannot remove a subtree the
+child is actively recreating (or one holding a live mount, which gives EBUSY),
+and `dirChain.removeUpward` (jobqueue/utils.go:1061) "stops early at a dir it
+cannot remove - which is expected when another Job is running from the same
+base, so that is not an error". The parent's own `<uniq>` directory is then
+non-empty, so the upward walk stops there and the parent's whole workspace is
+stranded, silently.
+
+A probe with an un-removable child subtree (a `chmod 0500`, standing in for the
+recreating child and for a mount's EBUSY) confirms it:
+
+```
+parent cleanup err = RemoveAll cwd: permission denied
+child's live work survived? true
+still there? .../jobqueue_cwd/e/6/6/<uniq>/cwd/jobqueue_cwd/c/f/3/<uniq2>/cwd  true
+still there? .../jobqueue_cwd/e/6/6/<uniq>/cwd                                 true
+still there? .../jobqueue_cwd/e/6/6/<uniq>                                     true
+still there? .../jobqueue_cwd                                                  true
+```
+
+The same scenario with the fixed default - the child's `Cwd` being the parent's
+`Cwd`, so its workspace a SIBLING:
+
+```
+parent cleanup err = <nil>
+child's live work survived? true
+still there? .../jobqueue_cwd/c/f/3/<uniq2>/cwd   true   (the child's, untouched)
+still there? .../jobqueue_cwd/e/6/6/<uniq>/cwd    false  (the parent's, reclaimed)
+still there? .../jobqueue_cwd/e/6/6/<uniq>        false
+```
+
+Both consequences disappear, because nesting cannot happen. That is why the fix
+is at the default rather than in the sweep: a guard in cleanup would have to
+recognise a child's live workspace, and there is nothing in a nested working
+directory that says whose it is.
+
+## The fix
+
+### Detection: the runner tells the job its own Cwd
+
+The runner already rewrites the job's environment before running it - `TMPDIR`,
+and `HOME` when `--change_home` is set. That block is now
+`jobRunEnv` (jobqueue/client.go), which also exports `WR_JOB_CWD`
+(`jobqueue.JobCwdEnvVar`):
+
+```go
+func jobRunEnv(env []string, job *Job, actualCwd, tmpDir string) []string {
+	if tmpDir == "" {
+		return slices.DeleteFunc(env, func(envvar string) bool {
+			return strings.HasPrefix(envvar, JobCwdEnvVar+"=")
+		})
+	}
+
+	// (this works fine even if tmpDir has a space in one of the dir names)
+	over := []string{"TMPDIR=" + tmpDir, JobCwdEnvVar + "=" + job.Cwd}
+
+	if job.ChangeHome {
+		over = append(over, "HOME="+actualCwd)
+	}
+
+	return envOverride(env, over)
+}
+```
+
+This is authoritative rather than a path-shape guess: it is set by the same code
+that moved the run out of its Cwd, from the `job.Cwd` it moved it out of.
+
+`tmpDir` is the condition, not a new flag, because `tmpDir` is non-empty exactly
+when wr created a working directory: `resolveWorkingDir` returns `("", "", nil)`
+for a `--cwd_matters` job, and `mkHashedDir` returns both `cwd` and `tmpDir`
+non-empty on success. So the invariant is: **`WR_JOB_CWD` is present exactly
+when wr moved the run out of its Cwd, and names the Cwd it was moved out of.**
+
+The `tmpDir == ""` branch REMOVES the variable rather than just leaving it. A
+`--cwd_matters` job's Cwd is where it really runs, so `os.Getwd()` is the right
+answer for anything it adds - but its captured environment may carry a
+`WR_JOB_CWD` from the job that added IT, and that value names a different
+directory. Clearing it keeps the invariant true in both directions. Exporting
+`job.Cwd` for a `--cwd_matters` job instead would be wrong for a command that
+`cd`s before adding: `os.Getwd()` is then deliberately somewhere else, and there
+is no wr-created directory to protect it from.
+
+### Precedence in `defaultCwd`
+
+`defaultCwd` now calls `addFromDir()` where it called `os.Getwd()`, and nothing
+else about it changed:
+
+```go
+	if cmdCwd != "" {
+		return "", false
+	}
+
+	wd := addFromDir()
+
+	if isLocal || cmdCwdMatters || remoteSameAsLocal {
+		return wd, false
+	}
+
+	return "/tmp", true
+```
+
+So the order is:
+
+1. **An explicit `--cwd` wins outright**, exactly as before - `defaultCwd`
+   returns before consulting anything. A user who wants a child inside the
+   parent's workspace passes `--cwd` and gets it. (A `cwd` in the commands
+   file's own JSON wins too: `cmd/add.go:1157` only applies the default when
+   the line names none.)
+2. **The remote-manager `/tmp` rule is untouched**: `WR_JOB_CWD` replaces
+   `os.Getwd()` as the answer to "where are we", and the remote branch is
+   reached afterwards, so a remote add still defaults to `/tmp` with its
+   warning. Substituting inside `os.Getwd()`'s slot rather than in front of the
+   whole function is what keeps that true.
+3. `--cwd_matters` does NOT exempt a new job from the correction. It selects
+   which BRANCH is taken (the `wd` branch rather than `/tmp`), as before; it
+   does not change what `wd` is. A `--cwd_matters` child added from inside a job
+   with no `--cwd` would otherwise run directly in the parent's disposable
+   workspace, which is the same data loss. `--cwd` remains the way to ask for
+   that deliberately.
+
+```go
+func addFromDir() string {
+	if jobCwd := os.Getenv(jobqueue.JobCwdEnvVar); filepath.IsAbs(jobCwd) {
+		return jobCwd
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		die("%s", err)
+	}
+
+	return wd
+}
+```
+
+The `IsAbs` check, rather than `!= ""`, is not defensive dressing: a relative
+value would be resolved by everything downstream against the current directory,
+which IS the working directory we are trying to get out of, so it would nest
+silently. `jobqueue/workspace.go:221` refuses a non-absolute dir for the same
+reason. Mutation M5 pins it.
+
+### All generations end up siblings
+
+The mechanism carries: a child added from inside the parent gets
+`Cwd = <parent's Cwd>`; the runner gives that child
+`WR_JOB_CWD = <child's Cwd> = <parent's Cwd>`, not the child's own working
+directory; so a grandchild added from inside the child gets the same original
+`Cwd` again. Every generation's workspace is a sibling under one `*_cwd` base,
+at one depth - which is the shape `relIsJobCreatedCwd` already relies on, and
+the shape the existing sibling-safety reasoning in `jobqueue/utils.go:1254`
+already covers. Pinned by the third Convey of `TestAddDefaultCwdInsideJob`.
+
+### No path-shape fallback
+
+`relIsJobCreatedCwd` is not used as a second, environment-free detector, and no
+shape check was added. Reasons:
+
+- It cannot be reused as-is. It answers "is `rel` the working directory
+  `mkHashedDir` built for a job with THIS KEY, below THIS Cwd" - and `wr add`
+  has neither the key nor the Cwd. Its own doc comment says why the key matters:
+  "every Job of a Cwd works below the same `*_cwd` base at the same depth with
+  the same leaf name, so nothing short of the key distinguishes a sibling's live
+  working directory from this Job's own."
+- What is left without the key is depth + a `_cwd` suffix + a leaf named `cwd`,
+  which a user's own directory can have. Guessing wrong means silently moving a
+  job's Cwd four levels up from where the user asked - a worse failure than the
+  one being fixed, and one with no error message.
+- The only case it would buy is a job whose command sanitises its environment.
+  Such a command has already discarded `TMPDIR` and (with `--change_home`)
+  `HOME`, so wr's other environment contracts are gone too; `--cwd` is the
+  explicit answer for it, and is documented.
+
+One mechanism, authoritative, with an explicit override. Two mechanisms would
+need the shape check to be trustworthy on its own, and it is not.
+
+### `wr bsub` children are unchanged
+
+`cmd/lsf.go:138-147` still gives its children `Cwd: os.Getwd()` with
+`CwdMatters: true`, and `wr bsub` does not go through `defaultCwd` at all, so
+nothing here touches it. That is deliberate: an LSF job submitted from a
+directory runs in that directory, and a submitting program hands its children
+paths relative to it, so moving them would break the emulation's contract. It
+does mean a `wr bsub` child's `Cwd` is still its parent's created working
+directory when the parent is an ordinary job - the parent's cleanup can still
+take it. That is the second commit in this branch, and it is fixed from the
+other end (the parent stops having a created working directory at all).
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -run TestJobRunEnv
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./cmd/ -run TestAddDefaultCwdInsideJob
+
+Both are port-free; neither needs a manager. `jobqueue/job_run_env_test.go`'s
+`TestJobRunEnv` covers the runner's half; `TestAddDefaultCwdInsideJob` in
+`cmd/add_test.go` covers `wr add`'s half through `parseCmdFile`, asserting on
+the resulting `job.Cwd` rather than on `defaultCwd`'s return, so an add's own
+JSON-vs-default precedence is exercised too.
+
+`jobRunEnv` was extracted from `Execute` first, with no behaviour change, so the
+red is on assertions rather than a build failure:
+
+```
+  * jobqueue/job_run_env_test.go
+  Line 49:
+  Expected the container ([]string) to contain: 'WR_JOB_CWD=/some/user/dir' (but it didn't)!
+
+  * jobqueue/job_run_env_test.go
+  Line 84:
+  Expected: []string{"FOO=bar"}
+  Actual:   []string{"FOO=bar", "WR_JOB_CWD=/grandparent"}
+
+--- FAIL: TestJobRunEnv (0.00s)
+```
+
+```
+  * cmd/add_test.go
+  Line 447:
+  Expected: "/tmp/TestAddDefaultCwdInsideJob3484677237/003"
+  Actual:   "/tmp/TestAddDefaultCwdInsideJob3484677237/003/wr_cwd/d/4/1/7364d1/cwd"
+  (Should equal)!
+
+  * cmd/add_test.go
+  Line 505:
+  Expected: "/tmp/TestAddDefaultCwdInsideJob3484677237/009"
+  Actual:   "/tmp/TestAddDefaultCwdInsideJob3484677237/009/wr_cwd/d/4/1/7364d1/cwd"
+  (Should equal)!
+
+--- FAIL: TestAddDefaultCwdInsideJob (0.00s)
+```
+
+Line 447 is the one-generation case, line 505 the two-generation one; both
+report the working directory where the original Cwd was wanted. Green
+afterwards: `18 total assertions` / `--- PASS: TestJobRunEnv`, and
+`53 total assertions` / `--- PASS: TestAddDefaultCwdInsideJob`.
+
+The cases that must pass BEFORE and AFTER, as controls: an explicit `--cwd`
+still wins, a remote manager still defaults to `/tmp` with its warning, and an
+add made outside any job still defaults to the actual current directory.
+
+## Mutation checks
+
+`go vet ./cmd/ ./jobqueue/` was run after every edit and reported clean each
+time (M5's first attempt did not, and was rewritten so it compiled before its
+verdict was taken), so no verdict below is a build failure masquerading as a
+dead guard.
+
+- [x] M1: stop exporting the variable (`over` back to `{"TMPDIR=" + tmpDir}`).
+  Vet OK. **RED** in `jobqueue`: `Line 49: Expected the container ([]string) to
+  contain: 'WR_JOB_CWD=/some/user/dir' (but it didn't)!`, `1 total assertion`.
+  `cmd` stays green, correctly - its test sets the variable itself, which is
+  what makes the two halves independent.
+- [x] M2: make `defaultCwd` ignore it (`addFromDir`'s guard `false &&`-ed).
+  Vet OK. **RED** in `cmd`: lines 447 and 505, with the output quoted above.
+  `jobqueue` stays green.
+- [x] M3: export it for a `--cwd_matters` job too (`tmpDir == ""` branch
+  replaced with `envOverride(env, []string{JobCwdEnvVar + "=" + job.Cwd})`).
+  Vet OK. **RED**: `Line 79: Expected: []string{"FOO=bar"} Actual:
+  []string{"FOO=bar", "WR_JOB_CWD=/some/user/dir"}`, `15 total assertions` - the
+  first 14 still pass, so it is that case alone.
+- [x] M4: leave an inherited value in place for a `--cwd_matters` job
+  (`tmpDir == ""` branch returning `env` unchanged, ie. no clearing). Vet OK.
+  **RED**: `Line 84: Expected: []string{"FOO=bar"} Actual: []string{"FOO=bar",
+  "WR_JOB_CWD=/grandparent"}`. Both directions of the invariant are
+  load-bearing.
+- [x] M5: drop the `IsAbs` guard (`jobCwd != "" || filepath.IsAbs(jobCwd)`, so
+  it compiles). Vet OK. **RED** on exactly the relative-value case:
+  `Line 486: Expected: ".../015/wr_cwd/d/4/1/7364d1/cwd" Actual: ".."`.
+- [x] All reverted from the saved copies; `go build ./...`,
+  `go vet ./cmd/ ./jobqueue/` clean, both tests green again.
+
+## Files touched
+
+- `jobqueue/client.go`: `JobCwdEnvVar`; the `TMPDIR`/`HOME` block extracted from
+  `Execute` into `jobRunEnv` and taught `WR_JOB_CWD`.
+- `cmd/add.go`: `defaultCwd` calls the new `addFromDir`; one paragraph of the
+  `--cwd` long help.
+- `jobqueue/job_run_env_test.go` (new), `cmd/add_test.go`: the tests above.

--- a/.docs/bugfixes/260903-11.md
+++ b/.docs/bugfixes/260903-11.md
@@ -274,24 +274,24 @@ red is on assertions rather than a build failure:
 
 ```
   * cmd/add_test.go
-  Line 447:
-  Expected: "/tmp/TestAddDefaultCwdInsideJob3484677237/003"
-  Actual:   "/tmp/TestAddDefaultCwdInsideJob3484677237/003/wr_cwd/d/4/1/7364d1/cwd"
+  Line 515:
+  Expected: "/tmp/TestAddDefaultCwdInsideJob689924370/003"
+  Actual:   "/tmp/TestAddDefaultCwdInsideJob689924370/003/wr_cwd/d/4/1/7364d1/cwd"
   (Should equal)!
 
   * cmd/add_test.go
-  Line 505:
-  Expected: "/tmp/TestAddDefaultCwdInsideJob3484677237/009"
-  Actual:   "/tmp/TestAddDefaultCwdInsideJob3484677237/009/wr_cwd/d/4/1/7364d1/cwd"
+  Line 574:
+  Expected: "/tmp/TestAddDefaultCwdInsideJob689924370/009"
+  Actual:   "/tmp/TestAddDefaultCwdInsideJob689924370/009/wr_cwd/d/4/1/7364d1/cwd"
   (Should equal)!
 
 --- FAIL: TestAddDefaultCwdInsideJob (0.00s)
 ```
 
-Line 447 is the one-generation case, line 505 the two-generation one; both
+Line 515 is the one-generation case, line 574 the two-generation one; both
 report the working directory where the original Cwd was wanted. Green
 afterwards: `18 total assertions` / `--- PASS: TestJobRunEnv`, and
-`53 total assertions` / `--- PASS: TestAddDefaultCwdInsideJob`.
+`47 total assertions` / `--- PASS: TestAddDefaultCwdInsideJob`.
 
 The cases that must pass BEFORE and AFTER, as controls: an explicit `--cwd`
 still wins, a remote manager still defaults to `/tmp` with its warning, and an
@@ -324,7 +324,7 @@ dead guard.
   load-bearing.
 - [x] M5: drop the `IsAbs` guard (`jobCwd != "" || filepath.IsAbs(jobCwd)`, so
   it compiles). Vet OK. **RED** on exactly the relative-value case:
-  `Line 486: Expected: ".../015/wr_cwd/d/4/1/7364d1/cwd" Actual: ".."`.
+  `Line 554: Expected: ".../015/wr_cwd/d/4/1/7364d1/cwd" Actual: ".."`.
 - [x] All reverted from the saved copies; `go build ./...`,
   `go vet ./cmd/ ./jobqueue/` clean, both tests green again.
 
@@ -335,3 +335,210 @@ dead guard.
 - `cmd/add.go`: `defaultCwd` calls the new `addFromDir`; one paragraph of the
   `--cwd` long help.
 - `jobqueue/job_run_env_test.go` (new), `cmd/add_test.go`: the tests above.
+
+---
+
+# `--bsub` implies `--cwd_matters`
+
+The other half of the same problem, and the second commit on this branch.
+`wr add --bsub 'pipeline ...'` gives the parent a wr-created working directory,
+and `wr bsub` - which the pipeline itself invokes - hands its children
+`Cwd: os.Getwd(), CwdMatters: true` (cmd/lsf.go:138-147). So the children's
+shared submission directory IS the parent's disposable working directory, and
+the parent's default cleanup destroys their live work. Commit 1's change does
+not reach this: `wr bsub` never calls `defaultCwd`.
+
+## Verification of the reasoning
+
+**The parent is the only job in a `--bsub` tree that creates a working
+directory.** The children are `CwdMatters: true` already, so
+`resolveWorkingDir` (jobqueue/client.go:1288) sets `cmd.Dir = job.Cwd` for them
+and calls no `mkHashedDir`. Remove the parent's one created directory and the
+class disappears: there is nothing to sweep, and nothing to strand.
+
+**A `cwd_matters` parent cannot carry a cleanup behaviour at all**, on every
+route in. `Job.dropImpossibleCleanups` (jobqueue/job.go:160) returns early for
+`!CwdMatters` and otherwise applies `Behaviours.withoutCleanups`
+(jobqueue/behaviours.go:462), which deletes every `Cleanup` and `CleanupAll`.
+Its three call sites cover every way a Job reaches the store:
+
+| route | call site | what it covers |
+| --- | --- | --- |
+| a client add | `Server.prepareInputJobs`, jobqueue/server.go:4341 | every add variant, including REST and a hand-built `Job` handed to `Client.Add` |
+| a stored job | `db.decodeJob`, jobqueue/db.go:928 | every read of the database, so a db written by an older wr cannot bring one back |
+| `wr mod` | `JobModifier.applyBehaviours`, jobqueue/job.go:2163 | runs over the MERGED result, and runs even when no behaviours were modified, so `wr mod --cwd_matters` drops a cleanup the job already stored |
+
+So `--bsub` implying `--cwd_matters` does not merely make the parent's cleanup
+harmless; the parent cannot store one.
+
+## What was implemented
+
+`cmd/add.go` gained `cwdMatters()`, and the two places that read
+`cmdCwdMatters` for a new job - the `jd.CwdMatters` default and `defaultCwd`'s
+branch choice - now call it:
+
+```go
+func cwdMatters() bool {
+	given := cmdCwdMattersChanged != nil && *cmdCwdMattersChanged
+
+	if cmdBsubMode && !given {
+		return true
+	}
+
+	return cmdCwdMatters
+}
+```
+
+Precedence: **defaulted, not forced.** `--bsub` supplies the value only when
+`--cwd_matters` was not GIVEN, so `--bsub --cwd_matters=false` still yields
+false and someone who wants the old shape can ask for it. `--bsub
+--cwd_matters` yields true, and `--cwd_matters` unmentioned without `--bsub`
+still yields false.
+
+"Given" is read from the flag's own `Changed`, reached through a
+`*bool` (`cmdCwdMattersChanged`) taken when the flag is registered rather than
+through `addCmd.Flags().Changed(...)`: `addCmd`'s own initialiser refers to
+`parseCmdFile`, so a reference back to `addCmd` from anything `parseCmdFile`
+calls is an initialisation cycle (`go build` says so). The pointer aims at the
+same `pflag.Flag` the command line writes to, so `Changed` is read live.
+
+`cmd/lsf.go` is untouched. The children's hardcoded `CwdMatters: true` is
+correct: an LSF job submitted from a directory runs in that directory, and the
+submitting program hands its children paths relative to it.
+
+Help text: `--bsub`'s one-liner gained "; implies --cwd_matters", and the
+`"bsub_mode"` paragraph of the long help gained three lines saying why and
+naming the `--cwd_matters=false` escape.
+
+## Consequences - visible behaviour changes
+
+- [x] **The parent loses its wr-managed TMPDIR.** Confirmed:
+  `resolveWorkingDir` returns `("", "", nil)` for a `CwdMatters` job, and
+  `jobRunEnv` (this branch's commit 1) applies the `TMPDIR=` override only when
+  `tmpDir != ""`. So the parent inherits the runner's own environment - the
+  system temp directory, not a private one wr deletes after the run. The
+  existing live test at jobqueue/jobqueue_test.go:4551 already pins exactly
+  this: its `CwdMatters: true` job reports `File::Spec->tmpdir` as
+  `os.TempDir()`, while its `CwdMatters: false` twin reports the wr tmp dir
+  beside its working directory. This could put pressure on `/tmp` where it
+  previously did not, for a `--bsub` job whose Cmd writes large temporary
+  files. The children are unaffected: they were already `cwd_matters` and
+  already had no wr TMPDIR.
+- [x] **`--change_home` becomes a no-op for `--bsub` jobs.** Confirmed:
+  `jobRunEnv` applies `HOME=` only inside the same `tmpDir != ""` branch. This
+  is already the documented rule for `--change_home` ("when not --cwd_matters,
+  set $HOME to the actual working directory"), so no help text changes, but a
+  `--bsub --change_home` command line that used to do something now does
+  nothing.
+- [x] **Existing `--bsub` users' outputs move.** Relative-path output from the
+  parent's Cmd, and from every `wr bsub` child, now lands in the user's own
+  `--cwd` (or the directory they ran `wr add` in) rather than in a wr-created
+  directory, and persists rather than being cleaned. That is the point of the
+  change - the children's work stops being deleted - but it is a visible change
+  of location and of lifetime, and it **deserves a changelog line**. I have not
+  added one; that is the repo owner's wording to choose.
+
+Two smaller consequences, from the same `cwd_matters` semantics:
+
+- The parent loses disk-space tracking and learning, which only happen for jobs
+  whose cwd does not matter (`cmd/add.go`'s long help says so).
+- The parent stops getting the relative-paths-in-cmd warning, since
+  `checkForRelativePathsInNonCwdMatters` skips `cwd_matters` jobs. That warning
+  existed because relative paths do not work when cwd does not matter; they now
+  do work, so the warning is correctly gone.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    CGO_ENABLED=1 go test -tags netgo --count 1 ./cmd/ \
+      -run TestAddBsubImpliesCwdMatters -v
+
+Port-free. Run by name because `go test ./cmd/` already fails on develop for an
+unrelated pre-existing reason (a cobra selector flag leaking between tests);
+confirmed still failing that way on this branch, and not chased.
+
+Failing output before the change:
+
+```
+=== RUN   TestAddBsubImpliesCwdMatters
+
+  --bsub defaults cwd_matters to true, so the parent creates no working directory ✔✔✔✘
+
+Failures:
+
+  * cmd/add_test.go
+  Line 629:
+  Expected: true
+  Actual:   false
+
+
+4 total assertions
+
+
+  Without --bsub, cwd_matters is still false unless asked for ✔✔✔✔
+
+
+8 total assertions
+
+--- FAIL: TestAddBsubImpliesCwdMatters (0.00s)
+```
+
+Green afterwards: `--bsub` alone true, `--bsub --cwd_matters=false` false,
+`--bsub --cwd_matters` true, and no `--bsub` false; `18 total assertions`,
+`--- PASS`.
+
+The test resets the flag's `Changed` through `resetCwdMattersGiven`, called from
+`configureAddParserTest`'s setup AND its cleanup. Without the setup call, a
+Convey leaf that says `--cwd_matters` explicitly leaks that into the NEXT run of
+the enclosing block's own body - which is the same class of leak the
+pre-existing `./cmd` failure is.
+
+## Mutation checks
+
+`go vet ./cmd/` after each edit, clean each time.
+
+- [x] MA: remove the implication (`cwdMatters` reduced to
+  `return cmdCwdMatters`). Vet OK. **RED**: `Line 629: Expected: true Actual:
+  false`, `4 total assertions` - the `--bsub` alone case, with the output quoted
+  above. The no-`--bsub` control stays green.
+- [x] MB: force the value instead of defaulting it (`if cmdBsubMode {` without
+  the `!given`). Vet OK. **RED**: `Line 637: Expected: false Actual: true`,
+  `14 total assertions` - the explicit `--cwd_matters=false` case alone; the
+  `--bsub`-alone and `--cwd_matters=true` cases stay green, so the two halves of
+  the precedence are separately load-bearing.
+- [x] Both reverted, `go build ./...` and `go vet ./cmd/` clean, green again.
+
+## Files touched
+
+- `cmd/add.go`: `cwdMatters()`, `cmdCwdMattersChanged`, the two call sites, the
+  `--bsub` flag help and the `"bsub_mode"` long help.
+- `cmd/add_test.go`: `TestAddBsubImpliesCwdMatters`, `bsubModeAdd`,
+  `resetCwdMattersGiven`.
+
+---
+
+# Gates
+
+Run once over both commits, from the repo root with all `OS_*` unset, on the
+committed tree, with the box otherwise idle (`ps` clear, load under 1).
+
+| gate | this branch (`7eec46e1`) | branch point (`902eccf0`) |
+| --- | --- | --- |
+| `go build ./... && go vet ./cmd/ ./jobqueue/` | clean | clean |
+| `make test` | `426 passed · 9 skipped · 29 packages · 3m49s`, PASSED | `423 passed · 9 skipped · 29 packages · 3m50s`, PASSED |
+| `make race` | `426 passed · 9 skipped · 29 packages · 4m47s`, PASSED | not re-measured |
+| `make lint` | `0 issues.` | `0 issues.` |
+
+Both baselines were measured here, not assumed: `902eccf0` was checked out and
+both `make test` and `make lint` run on it, with `golangci-lint cache clean`
+before each lint result. The baseline I measured is **423**, not the 424 I was
+told to expect; the difference is one test somewhere outside these two packages
+and outside this change, so it is reported rather than chased. `cmd` went 59 ->
+61 and `jobqueue` 227 -> 228: exactly the three new test functions
+(`TestAddDefaultCwdInsideJob`, `TestAddBsubImpliesCwdMatters`,
+`TestJobRunEnv`), and nothing else moved.
+
+`go test ./cmd/` fails on this branch and fails identically on `902eccf0`, in
+`cmd/suspend_test.go` (a cobra selector flag leaking between tests), which is
+the known pre-existing failure. Not chased. Both new `cmd` tests pass when run
+by name and inside `make test`, which shards around it.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -184,7 +185,10 @@ output","cwd":"/path/to/cwd","priority":1,"dep_grps":["dg2","dg3"],"deps":
 "cwd" determines the directory to cd to before running the command (the 'command
 working directory'). If none is specified, the default will be your current
 directory right now. (If adding to a remote cloud-deployed manager, then cwd
-will instead default to /tmp.)
+will instead default to /tmp.) If you are adding from inside a running wr
+command, the default is instead that command's own job's cwd, so that the new
+job's working directory is a sibling of the adding job's and not inside it (an
+adding job's cleanup behaviour would otherwise delete the new job's work).
 
 "cwd_matters" by default is false, causing "cwd" to taken as the parent
 directory to create a unique working directory inside. This unique directory can
@@ -903,12 +907,41 @@ func parseDurationOrDie(value, flagName string) time.Duration {
 
 // defaultCwd determines the default command working directory to use when
 // --cwd was not supplied. It returns the empty string (and no warning) when
-// --cwd was supplied. Otherwise it returns the current directory when the
-// manager is local, --cwd_matters is set, or remote adds should behave like
-// local adds, and /tmp (with remoteWarning true) when the manager is remote.
+// --cwd was supplied. Otherwise it returns addFromDir() when the manager is
+// local, --cwd_matters is set, or remote adds should behave like local adds, and
+// /tmp (with remoteWarning true) when the manager is remote.
 func defaultCwd(isLocal, remoteSameAsLocal bool) (pwd string, remoteWarning bool) {
 	if cmdCwd != "" {
 		return "", false
+	}
+
+	wd := addFromDir()
+
+	if isLocal || cmdCwdMatters || remoteSameAsLocal {
+		return wd, false
+	}
+
+	return "/tmp", true
+}
+
+// addFromDir returns the directory this add should be treated as having been
+// made from: the cwd of the job we are running inside, if we are running inside
+// one, and the actual current directory otherwise.
+//
+// A job's command runs in a disposable working directory wr made below the job's
+// cwd, so os.Getwd() inside a job is that working directory. Defaulting a new
+// job to it would put the new job's working directory inside the adding job's,
+// where the adding job's cleanup behaviour deletes the new job's live work, and
+// where a still-running new job stops the adding job's working directory ever
+// being reclaimed. The runner tells us the adding job's own cwd so that we can
+// default to that instead, making the new job's working directory a sibling of
+// the adding job's.
+//
+// A relative value is ignored because it would resolve inside the working
+// directory we are trying to avoid.
+func addFromDir() string {
+	if jobCwd := os.Getenv(jobqueue.JobCwdEnvVar); filepath.IsAbs(jobCwd) {
+		return jobCwd
 	}
 
 	wd, err := os.Getwd()
@@ -916,11 +949,7 @@ func defaultCwd(isLocal, remoteSameAsLocal bool) (pwd string, remoteWarning bool
 		die("%s", err)
 	}
 
-	if isLocal || cmdCwdMatters || remoteSameAsLocal {
-		return wd, false
-	}
-
-	return "/tmp", true
+	return wd
 }
 
 // parseJobViaJSON converts the columns of a single commands-file line into a

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -504,8 +504,8 @@ new job will have this job's mount and cloud_* options.
 
 Because those new jobs are given this job's working directory as their own
 literal one, "bsub_mode" defaults "cwd_matters" to true, so that this job's
-working directory is your own directory and not one wr made and may delete. Say
---cwd_matters=false if you want the old behaviour.
+working directory is your own directory and not one wr made and may delete. An
+explicit --cwd_matters=false overrides that default.
 
 NB: When running with sudo that is configured to not pass through environmental
 variables, you must have a wr config file, accessible from the working
@@ -975,8 +975,7 @@ func addFromDir() string {
 // only job in a --bsub tree that creates a working directory, the children being
 // cwd_matters already, so not creating it removes the whole class.
 //
-// An explicit --cwd_matters=false still wins, for anyone who wants the old
-// shape.
+// An explicit --cwd_matters=false still wins.
 func cwdMatters() bool {
 	given := cmdCwdMattersChanged != nil && *cmdCwdMattersChanged
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -97,6 +97,7 @@ var (
 	cmdFile                 string
 	cmdHead                 int
 	cmdCwdMatters           bool
+	cmdCwdMattersChanged    *bool
 	cmdChangeHome           bool
 	cmdRepGroup             string
 	cmdGroup                string
@@ -501,6 +502,11 @@ this manager session) job id, and turns on bsub emulation, which means that if
 your Cmd calls bsub, it will instead result in a command being added to wr. The
 new job will have this job's mount and cloud_* options.
 
+Because those new jobs are given this job's working directory as their own
+literal one, "bsub_mode" defaults "cwd_matters" to true, so that this job's
+working directory is your own directory and not one wr made and may delete. Say
+--cwd_matters=false if you want the old behaviour.
+
 NB: When running with sudo that is configured to not pass through environmental
 variables, you must have a wr config file, accessible from the working
 directory, with ManagerHost, ManagerPort, and ManagerCertDomain set.`,
@@ -610,6 +616,12 @@ func addCmdCoreFlags() {
 	flags.StringVarP(&cmdDepGroups, "dep_grps", "e", "", "comma-separated list of dependency groups")
 	flags.StringVarP(&cmdCwd, "cwd", "c", "", "base for the command's working dir")
 	flags.BoolVar(&cmdCwdMatters, "cwd_matters", false, "--cwd should be used as the actual working directory")
+
+	// cwdMatters() has to know whether --cwd_matters was GIVEN, not just its
+	// value, and cannot ask addCmd: addCmd's own initialiser refers to
+	// parseCmdFile, so a reference back to addCmd from anything parseCmdFile
+	// calls is an initialisation cycle.
+	cmdCwdMattersChanged = &flags.Lookup("cwd_matters").Changed
 	flags.BoolVar(&cmdChangeHome, "change_home", false,
 		"when not --cwd_matters, set $HOME to the actual working directory")
 	flags.StringVar(&cmdGroup, "group", "", "unix group to start the command as")
@@ -698,7 +710,7 @@ func addCmdMiscFlags() {
 		"make remote-manager adds use the same cwd and environment behaviour as local-manager adds")
 	flags.BoolVar(&cmdReRun, "rerun", false,
 		"re-run any commands that you add that had been previously added and have since completed")
-	flags.BoolVar(&cmdBsubMode, "bsub", false, "enable bsub emulation mode")
+	flags.BoolVar(&cmdBsubMode, "bsub", false, "enable bsub emulation mode; implies --cwd_matters")
 	flags.BoolVar(&cmdDisableRelativeCheck, "disable_relative_check", false,
 		"disable the relative path checking when cwd_matters is false")
 	flags.IntVar(&timeoutint, "timeout", defaultAddTimeout,
@@ -908,8 +920,8 @@ func parseDurationOrDie(value, flagName string) time.Duration {
 // defaultCwd determines the default command working directory to use when
 // --cwd was not supplied. It returns the empty string (and no warning) when
 // --cwd was supplied. Otherwise it returns addFromDir() when the manager is
-// local, --cwd_matters is set, or remote adds should behave like local adds, and
-// /tmp (with remoteWarning true) when the manager is remote.
+// local, cwdMatters(), or remote adds should behave like local adds, and /tmp
+// (with remoteWarning true) when the manager is remote.
 func defaultCwd(isLocal, remoteSameAsLocal bool) (pwd string, remoteWarning bool) {
 	if cmdCwd != "" {
 		return "", false
@@ -917,7 +929,7 @@ func defaultCwd(isLocal, remoteSameAsLocal bool) (pwd string, remoteWarning bool
 
 	wd := addFromDir()
 
-	if isLocal || cmdCwdMatters || remoteSameAsLocal {
+	if isLocal || cwdMatters() || remoteSameAsLocal {
 		return wd, false
 	}
 
@@ -950,6 +962,29 @@ func addFromDir() string {
 	}
 
 	return wd
+}
+
+// cwdMatters reports whether --cwd should be taken as the literal command
+// working directory rather than as the parent to create one below.
+//
+// --bsub defaults it to true. A bsub-mode job's Cmd submits its children with
+// `wr bsub`, which gives them the submitting Cmd's own working directory as
+// their Cwd, with CwdMatters true (cmd/lsf.go) - so a wr-created working
+// directory for the parent becomes the children's shared submission directory,
+// and the parent's cleanup behaviour deletes their live work. The parent is the
+// only job in a --bsub tree that creates a working directory, the children being
+// cwd_matters already, so not creating it removes the whole class.
+//
+// An explicit --cwd_matters=false still wins, for anyone who wants the old
+// shape.
+func cwdMatters() bool {
+	given := cmdCwdMattersChanged != nil && *cmdCwdMattersChanged
+
+	if cmdBsubMode && !given {
+		return true
+	}
+
+	return cmdCwdMatters
 }
 
 // parseJobViaJSON converts the columns of a single commands-file line into a
@@ -1030,7 +1065,7 @@ func parseCmdFile(jq *jobqueue.Client, diskSet bool, remoteSameAsLocal bool) ([]
 		ReqGrp:               reqGroup,
 		Group:                cmdGroup,
 		Cwd:                  cmdCwd,
-		CwdMatters:           cmdCwdMatters,
+		CwdMatters:           cwdMatters(),
 		ChangeHome:           cmdChangeHome,
 		CPUs:                 cmdCPUs,
 		Disk:                 cmdDisk,

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -613,6 +613,70 @@ func insideJobAdd(t *testing.T) (string, string, *jobqueue.Client) {
 	return orig, workSpace, &jobqueue.Client{ServerInfo: &jobqueue.ServerInfo{Addr: remoteManagerAddr}}
 }
 
+// TestAddBsubImpliesCwdMatters covers the working directory of a --bsub job. Its
+// children are submitted by `wr bsub` from the job's own working directory and
+// are cwd_matters themselves, so a wr-created working directory for the parent
+// would be the children's shared submission directory, which the parent's
+// cleanup deletes.
+func TestAddBsubImpliesCwdMatters(t *testing.T) {
+	Convey("--bsub defaults cwd_matters to true, so the parent creates no working directory", t, func() {
+		jq := bsubModeAdd(t)
+
+		jobs, _, _ := parseCmdFile(jq, false, true)
+
+		So(jobs, ShouldHaveLength, 1)
+		So(jobs[0].BsubMode, ShouldNotBeBlank)
+		So(jobs[0].CwdMatters, ShouldBeTrue)
+
+		Convey("An explicit --cwd_matters=false still wins", func() {
+			So(addCmd.Flags().Set("cwd_matters", "false"), ShouldBeNil)
+
+			jobs, _, _ = parseCmdFile(jq, false, true)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].CwdMatters, ShouldBeFalse)
+		})
+
+		Convey("An explicit --cwd_matters is honoured too", func() {
+			So(addCmd.Flags().Set("cwd_matters", "true"), ShouldBeNil)
+
+			jobs, _, _ = parseCmdFile(jq, false, true)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].CwdMatters, ShouldBeTrue)
+		})
+	})
+
+	Convey("Without --bsub, cwd_matters is still false unless asked for", t, func() {
+		jq := bsubModeAdd(t)
+		cmdBsubMode = false
+
+		jobs, _, _ := parseCmdFile(jq, false, true)
+
+		So(jobs, ShouldHaveLength, 1)
+		So(jobs[0].BsubMode, ShouldBeBlank)
+		So(jobs[0].CwdMatters, ShouldBeFalse)
+	})
+}
+
+// bsubModeAdd sets cmd's add globals up for a `wr add --bsub` with --cwd_matters
+// left unmentioned, and returns a client for a remote manager.
+func bsubModeAdd(t *testing.T) *jobqueue.Client {
+	t.Helper()
+
+	cmdPath := filepath.Join(t.TempDir(), "cmds.txt")
+	err := os.WriteFile(cmdPath, []byte("pipeline that bsubs\n"), 0600)
+	So(err, ShouldBeNil)
+
+	configureAddParserTest(t, cmdPath)
+
+	cmdCwd = t.TempDir()
+	cmdCwdMatters = false
+	cmdBsubMode = true
+
+	return &jobqueue.Client{ServerInfo: &jobqueue.ServerInfo{Addr: remoteManagerAddr}}
+}
+
 func TestAddCommandDependenciesDoNotWarnForMissingTargets(t *testing.T) {
 	ctx := context.Background()
 
@@ -922,6 +986,8 @@ func configureAddParserTest(t *testing.T, cmdPath string) {
 				t.Errorf("reset add --head: %s", err)
 			}
 		}
+
+		resetCwdMattersGiven(t)
 	})
 
 	config = &internal.Config{ManagerPort: "4321"}
@@ -932,6 +998,8 @@ func configureAddParserTest(t *testing.T, cmdPath string) {
 	cmdDepGroups = ""
 	cmdCwd = t.TempDir()
 	cmdCwdMatters = true
+
+	resetCwdMattersGiven(t)
 	cmdChangeHome = false
 	reqGroup = ""
 	cmdMem = "1G"
@@ -972,6 +1040,20 @@ func configureAddParserTest(t *testing.T, cmdPath string) {
 	rtimeoutint = 1
 	simpleOutput = false
 	syncMode = false
+}
+
+// resetCwdMattersGiven makes --cwd_matters unmentioned again, so that a test
+// that says it explicitly does not leak that into the next one (or into the next
+// run of a Convey block's own body).
+func resetCwdMattersGiven(t *testing.T) {
+	t.Helper()
+
+	flag := addCmd.Flags().Lookup("cwd_matters")
+	if flag == nil {
+		t.Fatal("add has no cwd_matters flag")
+	}
+
+	flag.Changed = false
 }
 
 func runAddForTest(t *testing.T) string {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -500,6 +500,119 @@ func runSynchronousAddHelper(exitCode int, stdout string, stderr string, exit fu
 	)
 }
 
+// TestAddDefaultCwdInsideJob covers the default working directory of a job added
+// by another job's command. Such a command runs in the disposable working
+// directory wr made for its job below the job's Cwd, so defaulting to
+// os.Getwd() would nest the added job's working directory inside the adding
+// job's, where the adding job's cleanup behaviour destroys it.
+func TestAddDefaultCwdInsideJob(t *testing.T) {
+	Convey("Adding from inside a job defaults the new job's cwd to the adding job's cwd", t, func() {
+		orig, workSpace, jq := insideJobAdd(t)
+
+		jobs, _, _ := parseCmdFile(jq, false, true)
+
+		So(jobs, ShouldHaveLength, 1)
+		So(jobs[0].Cwd, ShouldEqual, orig)
+		So(jobs[0].Cwd, ShouldNotEqual, workSpace)
+
+		Convey("So its working directory becomes a sibling of the adding job's, not a child", func() {
+			So(workSpace, ShouldStartWith, orig)
+			So(jobs[0].Cwd, ShouldNotStartWith, workSpace)
+		})
+
+		Convey("And --cwd_matters does not change that", func() {
+			cmdCwdMatters = true
+
+			jobs, _, _ = parseCmdFile(jq, false, true)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].Cwd, ShouldEqual, orig)
+		})
+
+		Convey("But an explicit --cwd still wins, for someone who wants the nesting", func() {
+			cmdCwd = workSpace
+
+			jobs, _, _ = parseCmdFile(jq, false, true)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].Cwd, ShouldEqual, workSpace)
+		})
+
+		Convey("And a remote manager still defaults to /tmp", func() {
+			jobs, _, _ = parseCmdFile(jq, false, false)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].Cwd, ShouldEqual, "/tmp")
+		})
+
+		Convey("A relative value is ignored, since it would resolve inside the working directory", func() {
+			t.Setenv(jobqueue.JobCwdEnvVar, "..")
+
+			jobs, _, _ = parseCmdFile(jq, false, true)
+
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].Cwd, ShouldEqual, workSpace)
+		})
+	})
+
+	Convey("Adding from outside a job defaults the new job's cwd to the current directory", t, func() {
+		_, workSpace, jq := insideJobAdd(t)
+
+		os.Unsetenv(jobqueue.JobCwdEnvVar)
+
+		jobs, _, _ := parseCmdFile(jq, false, true)
+
+		So(jobs, ShouldHaveLength, 1)
+		So(jobs[0].Cwd, ShouldEqual, workSpace)
+	})
+
+	Convey("Every generation of jobs adding jobs ends up a sibling of the first", t, func() {
+		orig, _, jq := insideJobAdd(t)
+
+		children, _, _ := parseCmdFile(jq, false, true)
+		So(children, ShouldHaveLength, 1)
+		So(children[0].Cwd, ShouldEqual, orig)
+
+		// the runner gives a child the child's own Cwd in JobCwdEnvVar (see
+		// TestJobRunEnv), and runs it in a working directory below that Cwd, so
+		// that is the situation the grandchild gets added from.
+		childWorkSpace := jobCreatedCwd(t, children[0].Cwd)
+		t.Chdir(childWorkSpace)
+		t.Setenv(jobqueue.JobCwdEnvVar, children[0].Cwd)
+
+		grandChildren, _, _ := parseCmdFile(jq, false, true)
+
+		So(grandChildren, ShouldHaveLength, 1)
+		So(grandChildren[0].Cwd, ShouldEqual, orig)
+		So(grandChildren[0].Cwd, ShouldNotEqual, childWorkSpace)
+	})
+}
+
+// insideJobAdd sets cmd's add globals up for an add with no --cwd, made from
+// inside the working directory wr would create for a job with a Cwd of the
+// returned orig, as the runner sets that situation up. It returns orig, that
+// working directory, and a client for a remote manager.
+func insideJobAdd(t *testing.T) (string, string, *jobqueue.Client) {
+	t.Helper()
+
+	cmdPath := filepath.Join(t.TempDir(), "cmds.txt")
+	err := os.WriteFile(cmdPath, []byte("cmd one\n"), 0600)
+	So(err, ShouldBeNil)
+
+	configureAddParserTest(t, cmdPath)
+
+	cmdCwd = ""
+	cmdCwdMatters = false
+
+	orig := t.TempDir()
+	workSpace := jobCreatedCwd(t, orig)
+
+	t.Chdir(workSpace)
+	t.Setenv(jobqueue.JobCwdEnvVar, orig)
+
+	return orig, workSpace, &jobqueue.Client{ServerInfo: &jobqueue.ServerInfo{Addr: remoteManagerAddr}}
+}
+
 func TestAddCommandDependenciesDoNotWarnForMissingTargets(t *testing.T) {
 	ctx := context.Background()
 
@@ -899,6 +1012,17 @@ func runAddCaptureForTest(t *testing.T) (string, string) {
 	So(err, ShouldBeNil)
 
 	return string(stdout), string(stderr)
+}
+
+// jobCreatedCwd creates and returns a directory of the shape wr creates below a
+// job's cwd to be that job's working directory.
+func jobCreatedCwd(t *testing.T, cwd string) string {
+	t.Helper()
+
+	created := filepath.Join(cwd, "wr_cwd", "d", "4", "1", "7364d1", "cwd")
+	So(os.MkdirAll(created, 0700), ShouldBeNil)
+
+	return created
 }
 
 func TestSynchronousAddPrintsStdoutAndExitsZero(t *testing.T) {

--- a/jobqueue/behaviours_env_test.go
+++ b/jobqueue/behaviours_env_test.go
@@ -52,6 +52,7 @@ const testStoredHome = "/nonexistent/stored-home"
 type probedEnv struct {
 	home    string
 	tmpDir  string
+	jobCwd  string
 	testVar string
 }
 
@@ -61,7 +62,8 @@ func envProbeBehaviour(out string) *Behaviour {
 	return &Behaviour{
 		When: OnExit,
 		Do:   Run,
-		Arg:  `printf '%s\n%s\n%s\n' "$HOME" "$TMPDIR" "$` + testEnvVar + `" > ` + out,
+		Arg: `printf '%s\n%s\n%s\n%s\n' "$HOME" "$TMPDIR" "$` + JobCwdEnvVar +
+			`" "$` + testEnvVar + `" > ` + out,
 	}
 }
 
@@ -71,9 +73,9 @@ func readProbedEnv(out string) probedEnv {
 	So(err, ShouldBeNil)
 
 	lines := strings.Split(strings.TrimSuffix(string(reported), "\n"), "\n")
-	So(len(lines), ShouldEqual, 3)
+	So(len(lines), ShouldEqual, 4)
 
-	return probedEnv{home: lines[0], tmpDir: lines[1], testVar: lines[2]}
+	return probedEnv{home: lines[0], tmpDir: lines[1], jobCwd: lines[2], testVar: lines[3]}
 }
 
 // probedEnvIfRun is what a `run` Behaviour's command reported, or the zero
@@ -89,11 +91,12 @@ func probedEnvIfRun(out string) probedEnv {
 }
 
 // storeTestEnv gives job the environment it was added with: the calling process's
-// (so the command has a PATH) with its HOME replaced and a variable of the test's
-// own added, the way wr's own --env override does it.
-func storeTestEnv(job *Job) {
+// (so the command has a PATH) with its HOME replaced, a variable of the test's
+// own added, and any extra variables the caller names, the way wr's own --env
+// override does it.
+func storeTestEnv(job *Job, extra ...string) {
 	env, err := compressEnv(envOverride(os.Environ(),
-		[]string{"HOME=" + testStoredHome, testEnvVar + "=from_job_env"}))
+		append([]string{"HOME=" + testStoredHome, testEnvVar + "=from_job_env"}, extra...)))
 	So(err, ShouldBeNil)
 
 	job.EnvC = env
@@ -172,6 +175,57 @@ func TestBehaviourRunEnv(t *testing.T) {
 			So(got.testVar, ShouldEqual, "from_job_env")
 			So(got.home, ShouldEqual, testStoredHome)
 			So(got.tmpDir, ShouldBeBlank)
+		})
+
+		// a `run` behaviour's command adds jobs as readily as the Cmd does -
+		// `on_success: {"run": "wr add -f followup.txt"}` - and it runs in the
+		// working directory wr made for the Cmd, so os.Getwd() there is that
+		// disposable directory. It needs the Job's own Cwd for the same reason
+		// the Cmd does, or the jobs it adds get their workspaces built inside
+		// this one's; see JobCwdEnvVar.
+		Convey("a run behaviour is told the Job's own Cwd, not the working directory it runs in", func() {
+			job := &Job{Cwd: cwd, Cmd: testWSCmd}
+			storeTestEnv(job)
+			actualCwd, _, _ := realWorkSpace(job)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.jobCwd, ShouldEqual, cwd)
+			So(got.jobCwd, ShouldNotEqual, actualCwd)
+		})
+
+		Convey("a CwdMatters Job's run behaviour is told nothing, not even what it inherited", func() {
+			// wr moved this Job out of nothing, so os.Getwd() is the right answer
+			// for anything its command adds - while the value the Job that added
+			// THIS one was given names a different directory altogether.
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, CwdMatters: true}
+			storeTestEnv(job, JobCwdEnvVar+"="+filepath.Join("/", "grandparent"))
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.jobCwd, ShouldBeBlank)
+			So(got.testVar, ShouldEqual, "from_job_env")
+		})
+
+		Convey("a CwdMatters Job with no environment of its own is told nothing either", func() {
+			// with nothing stored and nothing retrieved the Job names no
+			// environment at all, so the run gets the triggering process's - and
+			// that process is a wr runner or manager, which was itself given a
+			// WR_JOB_CWD naming ITS Job's Cwd. Leaving the run to inherit it
+			// silently would hand this Job's command a directory it was never in.
+			t.Setenv(JobCwdEnvVar, filepath.Join("/", "grandparent"))
+
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, CwdMatters: true}
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.jobCwd, ShouldBeBlank)
+			// the rest of that environment is still what the run has to work
+			// with, so only the one variable goes
+			So(got.home, ShouldEqual, os.Getenv("HOME"))
 		})
 
 		Convey("the behaviours the manager pins carry the Job's environment", func() {

--- a/jobqueue/behaviours_env_test.go
+++ b/jobqueue/behaviours_env_test.go
@@ -228,6 +228,35 @@ func TestBehaviourRunEnv(t *testing.T) {
 			So(got.home, ShouldEqual, os.Getenv("HOME"))
 		})
 
+		Convey("a Job with no environment of its own still gets wr's dirs over the triggering process's", func() {
+			// the other direction of the same fallback: wr DID make directories
+			// here, so they go OVER the triggering process's environment rather
+			// than instead of it. That environment is all the command has to work
+			// with - a PATH included - and the overrides do not name it, so losing
+			// it would leave the command with three variables and nothing to
+			// notice it by.
+			//
+			// os.Setenv and Reset rather than t.Setenv, whose restore waits for
+			// the whole test to end: the enclosing block asserts this variable is
+			// named nowhere but the Job, and every later leaf re-checks that.
+			So(os.Setenv(testEnvVar, "from_triggering_process"), ShouldBeNil)
+
+			Reset(func() { So(os.Unsetenv(testEnvVar), ShouldBeNil) })
+
+			job := &Job{Cwd: cwd, Cmd: testWSCmd, ChangeHome: true}
+			actualCwd, _, tmpDir := realWorkSpace(job)
+
+			So(probe.Trigger(OnExit, job), ShouldBeNil)
+
+			got := readProbedEnv(out)
+			So(got.home, ShouldEqual, actualCwd)
+			So(got.tmpDir, ShouldEqual, tmpDir)
+			So(got.jobCwd, ShouldEqual, cwd)
+			// and the variable only the triggering process named, which is what
+			// makes keeping its environment observable at all
+			So(got.testVar, ShouldEqual, "from_triggering_process")
+		})
+
 		Convey("the behaviours the manager pins carry the Job's environment", func() {
 			job := &Job{Cwd: cwd, Cmd: testWSCmd, ChangeHome: true, Behaviours: Behaviours{probe}}
 			storeTestEnv(job)

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -89,6 +89,13 @@ const (
 	FailReasonKilled   = "killed by user request"
 )
 
+// JobCwdEnvVar is the environment variable a run's command finds its Job's own
+// Cwd in, when wr gave the run a working directory below that Cwd instead of
+// running it in the Cwd itself. `wr add` defaults a new Job's Cwd to it, so that
+// a Job added by a Job gets a working directory beside the adding Job's instead
+// of inside it.
+const JobCwdEnvVar = "WR_JOB_CWD"
+
 // lsfEmulationDir is the name of the directory we store our LSF emulation
 // symlinks in.
 const lsfEmulationDir = ".wr_lsf_emulation"
@@ -556,6 +563,29 @@ func reserveHostAndPid() (string, int) {
 	}
 
 	return host, os.Getpid()
+}
+
+// jobRunEnv returns env with the overrides a run of job needs. A tmpDir is only
+// made for a job whose Cwd does not matter, ie. one wr gave a working directory
+// of its own below its Cwd, so an empty tmpDir means the run is happening in the
+// job's Cwd itself: nothing needs overriding, and any JobCwdEnvVar inherited
+// from the job that added this one has to go, because os.Getwd() is then the
+// right answer for anything this run adds.
+func jobRunEnv(env []string, job *Job, actualCwd, tmpDir string) []string {
+	if tmpDir == "" {
+		return slices.DeleteFunc(env, func(envvar string) bool {
+			return strings.HasPrefix(envvar, JobCwdEnvVar+"=")
+		})
+	}
+
+	// (this works fine even if tmpDir has a space in one of the dir names)
+	over := []string{"TMPDIR=" + tmpDir, JobCwdEnvVar + "=" + job.Cwd}
+
+	if job.ChangeHome {
+		over = append(over, "HOME="+actualCwd)
+	}
+
+	return envOverride(env, over)
 }
 
 func currentProcessTreeCPUtime(pid int) time.Duration {
@@ -1977,14 +2007,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return fmt.Errorf("failed to extract environment variables for job [%s]: %w%s", job.Key(), err, extra)
 	}
 
-	if tmpDir != "" {
-		// (this works fine even if tmpDir has a space in one of the dir names)
-		env = envOverride(env, []string{"TMPDIR=" + tmpDir})
-
-		if job.ChangeHome {
-			env = envOverride(env, []string{"HOME=" + actualCwd})
-		}
-	}
+	env = jobRunEnv(env, job, actualCwd, tmpDir)
 
 	if prependPath != "" {
 		env, err = c.addBsubEnv(env, job, prependPath, host, shell)

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -565,13 +565,14 @@ func reserveHostAndPid() (string, int) {
 	return host, os.Getpid()
 }
 
-// jobRunEnv returns env with the overrides a run of job needs. A tmpDir is only
+// envWithRunDirs returns env with the directories wr gave this run put into it.
+// A tmpDir is only
 // made for a job whose Cwd does not matter, ie. one wr gave a working directory
 // of its own below its Cwd, so an empty tmpDir means the run is happening in the
 // job's Cwd itself: nothing needs overriding, and any JobCwdEnvVar inherited
 // from the job that added this one has to go, because os.Getwd() is then the
 // right answer for anything this run adds.
-func jobRunEnv(env []string, job *Job, actualCwd, tmpDir string) []string {
+func envWithRunDirs(env []string, job *Job, actualCwd, tmpDir string) []string {
 	if tmpDir == "" {
 		return slices.DeleteFunc(env, func(envvar string) bool {
 			return strings.HasPrefix(envvar, JobCwdEnvVar+"=")
@@ -2007,7 +2008,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return fmt.Errorf("failed to extract environment variables for job [%s]: %w%s", job.Key(), err, extra)
 	}
 
-	env = jobRunEnv(env, job, actualCwd, tmpDir)
+	env = envWithRunDirs(env, job, actualCwd, tmpDir)
 
 	if prependPath != "" {
 		env, err = c.addBsubEnv(env, job, prependPath, host, shell)

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -565,30 +565,6 @@ func reserveHostAndPid() (string, int) {
 	return host, os.Getpid()
 }
 
-// envWithRunDirs returns env with the directories wr gave this run put into it.
-// A tmpDir is only
-// made for a job whose Cwd does not matter, ie. one wr gave a working directory
-// of its own below its Cwd, so an empty tmpDir means the run is happening in the
-// job's Cwd itself: nothing needs overriding, and any JobCwdEnvVar inherited
-// from the job that added this one has to go, because os.Getwd() is then the
-// right answer for anything this run adds.
-func envWithRunDirs(env []string, job *Job, actualCwd, tmpDir string) []string {
-	if tmpDir == "" {
-		return slices.DeleteFunc(env, func(envvar string) bool {
-			return strings.HasPrefix(envvar, JobCwdEnvVar+"=")
-		})
-	}
-
-	// (this works fine even if tmpDir has a space in one of the dir names)
-	over := []string{"TMPDIR=" + tmpDir, JobCwdEnvVar + "=" + job.Cwd}
-
-	if job.ChangeHome {
-		over = append(over, "HOME="+actualCwd)
-	}
-
-	return envOverride(env, over)
-}
-
 func currentProcessTreeCPUtime(pid int) time.Duration {
 	pid32, ok := processPID(pid)
 	if !ok {
@@ -2008,7 +1984,7 @@ func (c *Client) Execute(ctx context.Context, job *Job, shell string) error {
 		return fmt.Errorf("failed to extract environment variables for job [%s]: %w%s", job.Key(), err, extra)
 	}
 
-	env = envWithRunDirs(env, job, actualCwd, tmpDir)
+	env = envWithRunDirs(env, jobRunDirs{cwd: job.Cwd, actualCwd: actualCwd, tmp: tmpDir}, job.ChangeHome)
 
 	if prependPath != "" {
 		env, err = c.addBsubEnv(env, job, prependPath, host, shell)

--- a/jobqueue/job_run_env.go
+++ b/jobqueue/job_run_env.go
@@ -42,9 +42,10 @@ import (
 // Cwd the Job was added with, the working directory wr created below it, and the
 // tmp dir wr created beside that.
 //
-// cwd is always the Job's own Cwd. actualCwd and tmp are the two wr makes, and
-// it makes them only for a Job whose Cwd does not matter, so those two arrive
-// together or not at all; see wrMade.
+// cwd is always the Job's own Cwd. tmp is set exactly when wr made a working
+// directory for this run, so it is the one discriminator anything here reads;
+// see wrMade. actualCwd is the field the two callers fill differently where wr
+// made none, and neither of them is wrong, because nothing reads it then.
 type jobRunDirs struct {
 	// cwd is the Job's own Cwd, which is what JobCwdEnvVar names - not the
 	// working directory below it, so that every generation of Jobs added by Jobs
@@ -52,9 +53,11 @@ type jobRunDirs struct {
 	cwd string
 
 	// actualCwd is the directory the commands run in, which --change_home makes
-	// HOME. Where wr made one below cwd that is it; where it made none this is
-	// cwd itself and nothing reads it, since --change_home has no working
-	// directory of wr's to point HOME at.
+	// HOME. Where wr made one below cwd, that is it. Where it made none the two
+	// callers differ - Client.Execute passes the blank resolveWorkingDir handed
+	// it, jobWorkSpaceSnapshot.runEnv the Job's own Cwd the command really runs
+	// in - and neither is wrong, because nothing reads this field when there is
+	// no working directory of wr's for --change_home to point HOME at.
 	actualCwd string
 
 	// tmp is the dir wr made beside actualCwd to be TMPDIR.
@@ -83,10 +86,12 @@ func (d jobRunDirs) wrMade() bool {
 // variable is present exactly when wr moved the run out of its Cwd, in both
 // directions.
 //
-// A nil env comes back nil, since there is neither anything to delete from nor
-// anything to override; that is not the invariant holding, but there being no
-// environment to hold it over. Naming one - this process's, where the Job named
-// none of its own - is the caller's business; see jobWorkSpaceSnapshot.runEnv.
+// A nil env comes back nil where wr made no directories, there being nothing to
+// delete from. Where it made some it comes back as the overrides alone, which is
+// a command with no PATH rather than the invariant holding: envOverride appends
+// to a nil slice. Either way there is no environment to hold the invariant over,
+// and naming one first - this process's, where the Job named none of its own -
+// is the caller's business; see jobWorkSpaceSnapshot.runEnv.
 func envWithRunDirs(env []string, dirs jobRunDirs, changeHome bool) []string {
 	if !dirs.wrMade() {
 		return slices.DeleteFunc(env, func(envvar string) bool {

--- a/jobqueue/job_run_env.go
+++ b/jobqueue/job_run_env.go
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+// This file contains the one account of the directories wr made for a Job's run
+// and of what they mean to the environment its commands get.
+//
+// Both of the commands wr runs for a Job take their environment from
+// envWithRunDirs - Client.Execute the Job's own Cmd, and
+// jobWorkSpaceSnapshot.runEnv a `run` Behaviour's - so a variable put in here
+// cannot reach one of them and miss the other.
+
+import (
+	"slices"
+	"strings"
+)
+
+// jobRunDirs are the directories a Job's commands run in and are told about: the
+// Cwd the Job was added with, the working directory wr created below it, and the
+// tmp dir wr created beside that.
+//
+// cwd is always the Job's own Cwd. actualCwd and tmp are the two wr makes, and
+// it makes them only for a Job whose Cwd does not matter, so those two arrive
+// together or not at all; see wrMade.
+type jobRunDirs struct {
+	// cwd is the Job's own Cwd, which is what JobCwdEnvVar names - not the
+	// working directory below it, so that every generation of Jobs added by Jobs
+	// works in a sibling of this one rather than inside it.
+	cwd string
+
+	// actualCwd is the directory the commands run in, which --change_home makes
+	// HOME. Where wr made one below cwd that is it; where it made none this is
+	// cwd itself and nothing reads it, since --change_home has no working
+	// directory of wr's to point HOME at.
+	actualCwd string
+
+	// tmp is the dir wr made beside actualCwd to be TMPDIR.
+	tmp string
+}
+
+// wrMade says whether wr made these directories, ie. whether it moved the run
+// out of the Job's Cwd.
+//
+// The tmp dir is the condition rather than a flag of its own because
+// Client.resolveWorkingDir makes no directories at all for a Job whose Cwd
+// matters, and mkHashedDir returns the working directory and the tmp dir
+// together, so a tmp dir exists exactly when wr created a workspace.
+func (d jobRunDirs) wrMade() bool {
+	return d.tmp != ""
+}
+
+// envWithRunDirs returns env with the directories wr made for this run put into
+// it: TMPDIR, JobCwdEnvVar, and, when changeHome is set, the working directory
+// as HOME.
+//
+// Where wr made no directories the run happens in the Job's Cwd itself, so there
+// is nothing to override - and any JobCwdEnvVar inherited from the Job that added
+// this one has to go, because os.Getwd() is then the right answer for anything
+// this run adds, while the inherited value names a different directory. So the
+// variable is present exactly when wr moved the run out of its Cwd, in both
+// directions.
+//
+// A nil env comes back nil, since there is neither anything to delete from nor
+// anything to override; that is not the invariant holding, but there being no
+// environment to hold it over. Naming one - this process's, where the Job named
+// none of its own - is the caller's business; see jobWorkSpaceSnapshot.runEnv.
+func envWithRunDirs(env []string, dirs jobRunDirs, changeHome bool) []string {
+	if !dirs.wrMade() {
+		return slices.DeleteFunc(env, func(envvar string) bool {
+			return strings.HasPrefix(envvar, JobCwdEnvVar+"=")
+		})
+	}
+
+	// (this works fine even if a dir has a space in one of its names)
+	over := []string{"TMPDIR=" + dirs.tmp, JobCwdEnvVar + "=" + dirs.cwd}
+
+	if changeHome {
+		over = append(over, "HOME="+dirs.actualCwd)
+	}
+
+	return envOverride(env, over)
+}

--- a/jobqueue/job_run_env_test.go
+++ b/jobqueue/job_run_env_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-// unrelatedEnvVar is an environment variable setting jobRunEnv must leave alone.
+// unrelatedEnvVar is an environment variable setting envWithRunDirs must leave alone.
 const unrelatedEnvVar = "FOO=bar"
 
 // TestJobRunEnv covers the environment Execute gives a run's command. The
@@ -47,7 +47,7 @@ func TestJobRunEnv(t *testing.T) {
 	Convey("A run in a wr-created working directory is told its Job's own Cwd", t, func() {
 		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd}
 
-		env := jobRunEnv([]string{unrelatedEnvVar}, job, workSpace, tmpDir)
+		env := envWithRunDirs([]string{unrelatedEnvVar}, job, workSpace, tmpDir)
 
 		So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 		So(env, ShouldContain, "TMPDIR="+tmpDir)
@@ -60,14 +60,14 @@ func TestJobRunEnv(t *testing.T) {
 		Convey("And --change_home still moves HOME to the working directory", func() {
 			job.ChangeHome = true
 
-			env = jobRunEnv([]string{unrelatedEnvVar, "HOME=/home/user"}, job, workSpace, tmpDir)
+			env = envWithRunDirs([]string{unrelatedEnvVar, "HOME=/home/user"}, job, workSpace, tmpDir)
 
 			So(env, ShouldContain, "HOME="+workSpace)
 			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 		})
 
 		Convey("An existing value is replaced, not duplicated", func() {
-			env = jobRunEnv([]string{JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, workSpace, tmpDir)
+			env = envWithRunDirs([]string{JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, workSpace, tmpDir)
 
 			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 			So(env, ShouldNotContain, JobCwdEnvVar+"="+filepath.Join("/", "grandparent"))
@@ -77,18 +77,18 @@ func TestJobRunEnv(t *testing.T) {
 	Convey("A cwd_matters run, which runs in its Cwd, is told nothing", t, func() {
 		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd, CwdMatters: true}
 
-		env := jobRunEnv([]string{unrelatedEnvVar}, job, "", "")
+		env := envWithRunDirs([]string{unrelatedEnvVar}, job, "", "")
 
 		So(env, ShouldResemble, []string{unrelatedEnvVar})
 
 		Convey("Even if it inherited a value from the Job that added it, since os.Getwd() is right for it", func() {
-			env = jobRunEnv([]string{unrelatedEnvVar, JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, "", "")
+			env = envWithRunDirs([]string{unrelatedEnvVar, JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, "", "")
 
 			So(env, ShouldResemble, []string{unrelatedEnvVar})
 		})
 
 		Convey("And a nil environment stays nil, so the run inherits the runner's", func() {
-			So(jobRunEnv(nil, job, "", ""), ShouldBeNil)
+			So(envWithRunDirs(nil, job, "", ""), ShouldBeNil)
 		})
 	})
 }

--- a/jobqueue/job_run_env_test.go
+++ b/jobqueue/job_run_env_test.go
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// unrelatedEnvVar is an environment variable setting jobRunEnv must leave alone.
+const unrelatedEnvVar = "FOO=bar"
+
+// TestJobRunEnv covers the environment Execute gives a run's command. The
+// interesting part is JobCwdEnvVar: a command that runs `wr add` finds its own
+// Cwd there instead of having to trust os.Getwd(), which is the disposable
+// working directory wr made for it.
+func TestJobRunEnv(t *testing.T) {
+	origCwd := filepath.Join("/", "some", "user", "dir")
+	workSpace := filepath.Join(origCwd, "wr_cwd", "d", "4", "1", "7364d1", "cwd")
+	tmpDir := filepath.Join(origCwd, "wr_cwd", "d", "4", "1", "7364d1", "tmp")
+
+	Convey("A run in a wr-created working directory is told its Job's own Cwd", t, func() {
+		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd}
+
+		env := jobRunEnv([]string{unrelatedEnvVar}, job, workSpace, tmpDir)
+
+		So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
+		So(env, ShouldContain, "TMPDIR="+tmpDir)
+		So(env, ShouldContain, unrelatedEnvVar)
+
+		Convey("Which is the Cwd, not the working directory, so all generations are siblings", func() {
+			So(env, ShouldNotContain, JobCwdEnvVar+"="+workSpace)
+		})
+
+		Convey("And --change_home still moves HOME to the working directory", func() {
+			job.ChangeHome = true
+
+			env = jobRunEnv([]string{unrelatedEnvVar, "HOME=/home/user"}, job, workSpace, tmpDir)
+
+			So(env, ShouldContain, "HOME="+workSpace)
+			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
+		})
+
+		Convey("An existing value is replaced, not duplicated", func() {
+			env = jobRunEnv([]string{JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, workSpace, tmpDir)
+
+			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
+			So(env, ShouldNotContain, JobCwdEnvVar+"="+filepath.Join("/", "grandparent"))
+		})
+	})
+
+	Convey("A cwd_matters run, which runs in its Cwd, is told nothing", t, func() {
+		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd, CwdMatters: true}
+
+		env := jobRunEnv([]string{unrelatedEnvVar}, job, "", "")
+
+		So(env, ShouldResemble, []string{unrelatedEnvVar})
+
+		Convey("Even if it inherited a value from the Job that added it, since os.Getwd() is right for it", func() {
+			env = jobRunEnv([]string{unrelatedEnvVar, JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, "", "")
+
+			So(env, ShouldResemble, []string{unrelatedEnvVar})
+		})
+
+		Convey("And a nil environment stays nil, so the run inherits the runner's", func() {
+			So(jobRunEnv(nil, job, "", ""), ShouldBeNil)
+		})
+	})
+}

--- a/jobqueue/job_run_env_test.go
+++ b/jobqueue/job_run_env_test.go
@@ -35,19 +35,20 @@ import (
 // unrelatedEnvVar is an environment variable setting envWithRunDirs must leave alone.
 const unrelatedEnvVar = "FOO=bar"
 
-// TestJobRunEnv covers the environment Execute gives a run's command. The
-// interesting part is JobCwdEnvVar: a command that runs `wr add` finds its own
-// Cwd there instead of having to trust os.Getwd(), which is the disposable
-// working directory wr made for it.
+// TestJobRunEnv covers the environment wr gives the commands it runs for a Job -
+// the Job's own Cmd and a `run` Behaviour's command alike, since both go through
+// envWithRunDirs. The interesting part is JobCwdEnvVar: a command that runs
+// `wr add` finds its own Cwd there instead of having to trust os.Getwd(), which
+// is the disposable working directory wr made for it.
 func TestJobRunEnv(t *testing.T) {
 	origCwd := filepath.Join("/", "some", "user", "dir")
 	workSpace := filepath.Join(origCwd, "wr_cwd", "d", "4", "1", "7364d1", "cwd")
 	tmpDir := filepath.Join(origCwd, "wr_cwd", "d", "4", "1", "7364d1", "tmp")
 
 	Convey("A run in a wr-created working directory is told its Job's own Cwd", t, func() {
-		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd}
+		dirs := jobRunDirs{cwd: origCwd, actualCwd: workSpace, tmp: tmpDir}
 
-		env := envWithRunDirs([]string{unrelatedEnvVar}, job, workSpace, tmpDir)
+		env := envWithRunDirs([]string{unrelatedEnvVar}, dirs, false)
 
 		So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 		So(env, ShouldContain, "TMPDIR="+tmpDir)
@@ -58,16 +59,14 @@ func TestJobRunEnv(t *testing.T) {
 		})
 
 		Convey("And --change_home still moves HOME to the working directory", func() {
-			job.ChangeHome = true
-
-			env = envWithRunDirs([]string{unrelatedEnvVar, "HOME=/home/user"}, job, workSpace, tmpDir)
+			env = envWithRunDirs([]string{unrelatedEnvVar, "HOME=/home/user"}, dirs, true)
 
 			So(env, ShouldContain, "HOME="+workSpace)
 			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 		})
 
 		Convey("An existing value is replaced, not duplicated", func() {
-			env = envWithRunDirs([]string{JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, workSpace, tmpDir)
+			env = envWithRunDirs([]string{JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, dirs, false)
 
 			So(env, ShouldContain, JobCwdEnvVar+"="+origCwd)
 			So(env, ShouldNotContain, JobCwdEnvVar+"="+filepath.Join("/", "grandparent"))
@@ -75,20 +74,24 @@ func TestJobRunEnv(t *testing.T) {
 	})
 
 	Convey("A cwd_matters run, which runs in its Cwd, is told nothing", t, func() {
-		job := &Job{Cmd: "wr add -f cmds", Cwd: origCwd, CwdMatters: true}
+		// wr makes no directories for such a Job, which is what tells the two
+		// cases apart: there is no tmp dir to be its TMPDIR, and no working
+		// directory for --change_home to make its HOME.
+		dirs := jobRunDirs{cwd: origCwd}
 
-		env := envWithRunDirs([]string{unrelatedEnvVar}, job, "", "")
+		env := envWithRunDirs([]string{unrelatedEnvVar}, dirs, true)
 
 		So(env, ShouldResemble, []string{unrelatedEnvVar})
 
 		Convey("Even if it inherited a value from the Job that added it, since os.Getwd() is right for it", func() {
-			env = envWithRunDirs([]string{unrelatedEnvVar, JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")}, job, "", "")
+			env = envWithRunDirs([]string{unrelatedEnvVar, JobCwdEnvVar + "=" + filepath.Join("/", "grandparent")},
+				dirs, false)
 
 			So(env, ShouldResemble, []string{unrelatedEnvVar})
 		})
 
-		Convey("And a nil environment stays nil, so the run inherits the runner's", func() {
-			So(envWithRunDirs(nil, job, "", ""), ShouldBeNil)
+		Convey("And a nil environment comes back nil, there being nothing to delete from", func() {
+			So(envWithRunDirs(nil, dirs, false), ShouldBeNil)
 		})
 	})
 }

--- a/jobqueue/jobqueue_test.go
+++ b/jobqueue/jobqueue_test.go
@@ -4558,8 +4558,22 @@ func TestJobqueueExecutionAndDependencyScenarios(t *testing.T) {
 					reserveErr = os.Mkdir(tmpDir, os.ModePerm)
 					So(reserveErr, ShouldBeNil)
 
-					jobs = append(jobs, &Job{Cmd: "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; warn File::Spec->tmpdir, qq[\\n]'", Cwd: tmpDir, CwdMatters: true, ChangeHome: true, ReqGroup: "fake_group", Requirements: standardReqs, RepGroup: "should_pass"})
-					jobs = append(jobs, &Job{Cmd: "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; die File::Spec->tmpdir, qq[\\n]'", Cwd: tmpDir, CwdMatters: false, ChangeHome: true, ReqGroup: "fake_group", Requirements: standardReqs, RepGroup: "should_fail"})
+					// each command reports its own cwd, its HOME and the Cwd wr gave it,
+					// so what Execute really put in its environment is read back from its
+					// stdout
+					passCmd := `perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[-], $ENV{` +
+						JobCwdEnvVar + `}, qq[\n]; warn File::Spec->tmpdir, qq[\n]'`
+					failCmd := `perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[-], $ENV{` +
+						JobCwdEnvVar + `}, qq[\n]; die File::Spec->tmpdir, qq[\n]'`
+
+					jobs = append(jobs, &Job{
+						Cmd: passCmd, Cwd: tmpDir, CwdMatters: true, ChangeHome: true,
+						ReqGroup: "fake_group", Requirements: standardReqs, RepGroup: "should_pass",
+					})
+					jobs = append(jobs, &Job{
+						Cmd: failCmd, Cwd: tmpDir, CwdMatters: false, ChangeHome: true,
+						ReqGroup: "fake_group", Requirements: standardReqs, RepGroup: "should_fail",
+					})
 					inserts, _, err := jq.Add(jobs, envVars, true)
 					So(err, ShouldBeNil)
 					So(inserts, ShouldEqual, 2)
@@ -4567,7 +4581,7 @@ func TestJobqueueExecutionAndDependencyScenarios(t *testing.T) {
 					// job that outputs to stdout and stderr but succeeds
 					job, err := jq.Reserve(50 * time.Millisecond)
 					So(err, ShouldBeNil)
-					So(job.Cmd, ShouldEqual, "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; warn File::Spec->tmpdir, qq[\\n]'")
+					So(job.Cmd, ShouldEqual, passCmd)
 					So(job.State, ShouldEqual, JobStateReserved)
 
 					err = jq.Execute(ctx, job, config.RunnerExecShell)
@@ -4580,19 +4594,21 @@ func TestJobqueueExecutionAndDependencyScenarios(t *testing.T) {
 
 					home, herr := os.UserHomeDir()
 					So(herr, ShouldBeNil)
-					So(stdout, ShouldEqual, tmpDir+"-"+home)
+					// wr moved this Job out of nothing, so it is told no Cwd of its own:
+					// os.Getwd() is the right answer for anything it adds
+					So(stdout, ShouldEqual, tmpDir+"-"+home+"-")
 
 					stderr, err := job.StdErr()
 					So(err, ShouldBeNil)
 					So(stderr, ShouldEqual, os.TempDir())
 
-					job2, err := jq2.GetByEssence(&JobEssence{Cmd: "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; warn File::Spec->tmpdir, qq[\\n]'", Cwd: tmpDir}, true, false)
+					job2, err := jq2.GetByEssence(&JobEssence{Cmd: passCmd, Cwd: tmpDir}, true, false)
 					So(err, ShouldBeNil)
 					So(job2, ShouldNotBeNil)
 					So(job2.State, ShouldEqual, JobStateComplete)
 					stdout, err = job2.StdOut()
 					So(err, ShouldBeNil)
-					So(stdout, ShouldEqual, tmpDir+"-"+home)
+					So(stdout, ShouldEqual, tmpDir+"-"+home+"-")
 
 					stderr, err = job2.StdErr()
 					So(err, ShouldBeNil)
@@ -4601,7 +4617,7 @@ func TestJobqueueExecutionAndDependencyScenarios(t *testing.T) {
 					// job that outputs to stdout and stderr and fails
 					job, err = jq.Reserve(50 * time.Millisecond)
 					So(err, ShouldBeNil)
-					So(job.Cmd, ShouldEqual, "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; die File::Spec->tmpdir, qq[\\n]'")
+					So(job.Cmd, ShouldEqual, failCmd)
 					So(job.State, ShouldEqual, JobStateReserved)
 
 					err = jq.Execute(ctx, job, config.RunnerExecShell)
@@ -4614,28 +4630,32 @@ func TestJobqueueExecutionAndDependencyScenarios(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					actualCwd := job.ActualCwd
-					So(actualCwd, ShouldStartWith, filepath.Join(tmpDir, "jobqueue_cwd", "d", "4", "1", "7364d743329da784e74f2d69d438d"))
+					So(actualCwd, ShouldStartWith,
+						filepath.Join(tmpDir, "jobqueue_cwd", "3", "5", "5", "65da5ced642d9c5026565e20149b5"))
 					So(actualCwd, ShouldEndWith, "cwd")
-					So(stdout, ShouldEqual, actualCwd+"-"+actualCwd)
+					// the third field is the Cwd it was added with, not the disposable
+					// directory wr moved it into, so a `wr add` in it gives the new job a
+					// workspace beside this one rather than inside it
+					So(stdout, ShouldEqual, actualCwd+"-"+actualCwd+"-"+tmpDir)
 
 					stderr, err = job.StdErr()
 					So(err, ShouldBeNil)
 
-					tmpDir = actualCwd[:len(actualCwd)-3] + "tmp"
-					So(stderr, ShouldEqual, tmpDir)
+					wrTmpDir := actualCwd[:len(actualCwd)-3] + "tmp"
+					So(stderr, ShouldEqual, wrTmpDir)
 
-					job2, err = jq2.GetByEssence(&JobEssence{Cmd: "perl -MCwd -MFile::Spec -e '$cwd = getcwd(); print $cwd, qq[-], $ENV{HOME}, qq[\\n]; die File::Spec->tmpdir, qq[\\n]'"}, true, false)
+					job2, err = jq2.GetByEssence(&JobEssence{Cmd: failCmd}, true, false)
 					So(err, ShouldBeNil)
 					So(job2, ShouldNotBeNil)
 					So(job2.State, ShouldEqual, JobStateBuried)
 					So(job2.FailReason, ShouldEqual, FailReasonExit)
 					stdout, err = job2.StdOut()
 					So(err, ShouldBeNil)
-					So(stdout, ShouldEqual, actualCwd+"-"+actualCwd)
+					So(stdout, ShouldEqual, actualCwd+"-"+actualCwd+"-"+tmpDir)
 
 					stderr, err = job2.StdErr()
 					So(err, ShouldBeNil)
-					So(stderr, ShouldEqual, tmpDir)
+					So(stderr, ShouldEqual, wrTmpDir)
 				})
 
 				Convey("The stdout/err of jobs is limited in size", func() {

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -185,14 +185,16 @@ func (j *Job) workSpaceSnapshotLocked() jobWorkSpaceSnapshot {
 }
 
 // runEnv is the environment a `run` Behaviour's command executes with: the one
-// Execute gave the Job's own Cmd, with the directories wr made for the Job put in
-// it exactly as Execute puts them (see runDir.dirEnv). The command is part of the
+// Execute gave the Job's own Cmd, with the directories wr made for the Job put
+// into it by the envWithRunDirs Execute itself uses. The command is part of the
 // same job as the Cmd, so the two run in the same environment.
 //
-// A nil result means the Job carried no environment and none was asked for, and
-// leaves exec.Cmd inheriting this process's. An environment that could not be
-// read is an error instead, so the command is refused rather than run with the
-// triggering process's; see jobRunEnv.unread.
+// Where the Job named no environment of its own the command gets this process's,
+// which is what exec.Cmd would have inherited anyway - but NAMED, so that
+// envWithRunDirs decides JobCwdEnvVar over it too, rather than the command
+// inheriting the one the triggering runner or manager was given for its own Job.
+// An environment that could not be read is an error instead, so the command is
+// refused rather than run with the triggering process's; see jobRunEnv.unread.
 func (s jobWorkSpaceSnapshot) runEnv(dir *runDir) ([]string, error) {
 	if s.env.unread != nil {
 		return nil, s.env.unread
@@ -203,20 +205,17 @@ func (s jobWorkSpaceSnapshot) runEnv(dir *runDir) ([]string, error) {
 		return nil, err
 	}
 
-	dirEnv := dir.dirEnv(s.env.changeHome)
-	if len(dirEnv) == 0 {
-		return env, nil
-	}
-
 	if env == nil {
 		// the Job's own environment was never stored and never retrieved, so
-		// this process's is all there is to run with - which is what exec.Cmd
-		// would inherit anyway. Naming it is what lets the Job's own directories
-		// still be put in it.
+		// this process's is all there is to run with. Naming it is what lets the
+		// Job's own directories be put in it - and lets the JobCwdEnvVar of the
+		// runner's or manager's OWN Job be taken back out of it.
 		env = os.Environ()
 	}
 
-	return envOverride(env, dirEnv), nil
+	dirs := jobRunDirs{cwd: s.cwd, actualCwd: dir.path, tmp: dir.tmp}
+
+	return envWithRunDirs(env, dirs, s.env.changeHome), nil
 }
 
 // workSpacePaths is the lexical half of the resolution: the Job's directories,
@@ -474,28 +473,9 @@ type runDir struct {
 	path string
 
 	// tmp is the tmp dir wr made beside the working directory to be the Job's
-	// TMPDIR, or blank when wr made no workspace and so no tmp dir; see dirEnv.
+	// TMPDIR, or blank when wr made no workspace and so no tmp dir; see
+	// jobRunDirs.wrMade.
 	tmp string
-}
-
-// dirEnv is the part of a `run` Behaviour's environment that comes from the
-// directories wr made for the Job: its TMPDIR, and its working directory as HOME
-// when the Job asked for that.
-//
-// Execute sets both on the Job's own Cmd, and only for a Job it made a workspace
-// for: a CwdMatters Job runs in the user's own Cwd with neither, whatever
-// --change_home says, so this answers nothing for one.
-func (r *runDir) dirEnv(changeHome bool) []string {
-	if r.tmp == "" {
-		return nil
-	}
-
-	dirEnv := []string{"TMPDIR=" + r.tmp}
-	if changeHome {
-		dirEnv = append(dirEnv, "HOME="+r.path)
-	}
-
-	return dirEnv
 }
 
 // openRunDir hands back the Job's working directory, held open.


### PR DESCRIPTION
A job's command runs in a disposable working directory wr made below the job's
`Cwd`, so `os.Getwd()` inside a job is that working directory. A job that adds
jobs therefore gave its children a `Cwd` *inside its own workspace*, which
causes two things at once:

- **Deletion.** The adding job's `on_exit cleanup` deletes its whole workspace
  — and the children's live work with it. Driving the production entry point
  (`(&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, parent)`) on the
  nested shape deletes the child's output, workspace and TMPDIR and returns
  `nil`: no error, no warning.
- **The leak users actually report.** If any part of the child's subtree can't
  be removed (a still-running child, a busy mount), `dirChain.removeUpward`
  stops at the dir it can't remove and treats that as expected, so the adding
  job's entire `jobqueue_cwd/…` tree is left behind for ever. This is the
  "my wr tmp directories aren't getting cleaned up" complaint.

Same root cause, and making the children's workspaces *siblings* fixes both.

### 1. Default a job-added job's cwd to the adding job's cwd

A run whose `Cwd` didn't matter now finds `WR_JOB_CWD` in its environment, set
to the job's own `Cwd`; `wr add` defaults `--cwd` to it. So a job added by a
job lands beside the adding job's workspace instead of inside it.

The variable is set exactly when wr moved the run out of its `Cwd` (the
existing `tmpDir != ""` condition — no new flag), and is *removed* when it
didn't, so a stale value can't be inherited down a chain. Explicit `--cwd`
still wins outright, and a relative value is ignored because it would resolve
inside the very directory we're escaping.

No path-shape sniffing: `relIsJobCreatedCwd` needs the job's key, which
`wr add` doesn't have, and guessing from depth + `_cwd` alone would silently
relocate a job whose own directory happened to match.

### 2. `--bsub` implies `--cwd_matters`

`wr bsub` gives its children the submitting command's working directory as
their literal `Cwd` (`cmd/lsf.go`), and offers no flags — so a bsub-mode
parent with a wr-made workspace makes that workspace its children's shared
submission directory, and its cleanup deletes their live work. The parent is
the only job in a `--bsub` tree that creates a workspace at all (the children
being `cwd_matters` already), so not creating one removes the whole class.

Defaulted, not forced: an explicit `--cwd_matters=false` still wins.

A `cwd_matters` job can't carry a cleanup behaviour in the first place —
`dropImpossibleCleanups` strips it on every route in (`prepareInputJobs`,
`db.decodeJob`, `JobModifier.applyBehaviours`), so an older database can't
reintroduce one either.

**Behaviour change worth a changelog line:** existing `--bsub` users' job
outputs now stay in their real working directory instead of a wr-made one, and
the parent loses its wr-managed `TMPDIR` (so `--change_home` becomes a no-op
for it, as already documented for `cwd_matters`).

### Notes

- `#575` keeps the defence-in-depth guards that stop the sweep crossing into a
  nested workspace even when one is still built inside another; this PR removes
  the shape that needs them.
- A `wr bsub` child of an *ordinary* (non-`--bsub`) parent is still exposed by
  commit 1 alone — `wr bsub` never calls `defaultCwd`. Commit 2 closes that
  from the other end, for `--bsub` trees, which is where `wr bsub` is used.

Checklist and evidence: `.docs/bugfixes/260903-11.md`. Gates: 429 passed · 9
skipped on both `make test` and `make race`, `make lint` 0 issues.
