### PR TITLE
Stop a job's cleanup sweeping into a mount rooted at the directory it is clearing

### DIFF
--- a/.docs/bugfixes/260903-13.md
+++ b/.docs/bugfixes/260903-13.md
@@ -1,0 +1,198 @@
+# Bugfixes 260903-13
+
+Branch `fix-sweep-crosses-mount-root`, stacked on PR #575
+(`fix-cleanup-sweeps-nested-jobs`, base `e3fe2288`). It fixes the hole #575's
+own checklist recorded and deliberately left open
+(`.docs/bugfixes/260903-10.md`, "Not fixed here, deliberately"):
+`crossesMountBoundary` is blind when the SWEPT directory is itself a mount
+root.
+
+## The bug
+
+`crossesMountBoundary` compares an entry's device number against the device of
+the directory it is an entry of. Every entry of a mount root is on the mount's
+own device, so where the swept directory IS the mount root no boundary is ever
+seen, and the sweep walks straight into the user's mounted filesystem and
+unlinks what is behind it.
+
+Three sweep entry points took that device from their own `Lstat(".")`, and all
+three were blind for the same reason:
+
+| entry point | device from | reached by | needs a keep set? |
+| --- | --- | --- | --- |
+| `removeAllExcept` | the working directory's own `Lstat(".")` | `removeActualCwd` | yes |
+| `removeAllGuarded` | the workspace's own `Lstat(".")` | `removeWorkSpaceEntries`, `removeActualCwd` | no |
+| `removeAllGuarded` | the workspace's own `Lstat(".")` | `removeTmp`, from `removeJobTmpDir` (`jobqueue/client.go:1540`), which `Execute` defers at `client.go:1651` | no |
+
+The second wipes the mounted remote's top level with no keep set at all, and
+the third reclaims whatever the mounted filesystem happens to call `tmp`.
+`removeTmp` is reached from `Execute` rather than from a cleanup Behaviour, so
+it is a separate production path and not merely another caller.
+
+The production shape is a job whose own Cmd raises a mount over the working
+directory (or the workspace) wr gave it. wr's keep set is built only from the
+Job's own `MountConfigs` (`keptDirs`), so a mount the command raised itself
+appears in no config wr has ever seen, and the device check could not see it
+either. Cleanup runs BEFORE wr takes its own mounts down
+(`jobqueue/client.go:2203` `TriggerBehaviours` vs `:2208` `Unmount`), so a live
+mount at cleanup time is the normal case. Nothing earlier in the path catches
+it: `jobWorkSpace.prove` lstats the working directory at cleanup time, so
+`actualCwdInfo` already describes the mount and `proveSameDir` agrees with it.
+
+## Red command
+
+    unset $(compgen -v | grep '^OS_')
+    go test ./jobqueue/ -count=1 -timeout 15m -v \
+      -run 'TestCleanupCrossesNoMountBoundary|TestJobTmpDirRemoval'
+
+Measured on this branch's base `e3fe2288`, with the three cleanup tests present
+and nothing else changed (log: `<scratchpad>/red-base.log`):
+
+    --- FAIL: TestCleanupCrossesNoMountBoundaryAtTheWorkingDir (0.02s)
+      Actual: 'stat .../004/REMOTE_OBJECT: no such file or directory'
+    --- FAIL: TestCleanupCrossesNoMountBoundaryOverAPopulatedWorkingDir (0.01s)
+      Actual: 'stat .../002/REMOTE_OBJECT: no such file or directory'
+    --- FAIL: TestCleanupCrossesNoMountBoundaryAtTheWorkSpace (0.01s)
+      Actual: 'stat .../002/REMOTE_OBJECT: no such file or directory'
+      Actual: 'stat .../004/cwd/remote_output.txt: no such file or directory'
+    --- PASS: TestCleanupCrossesNoMountBoundary (0.01s)
+
+`REMOTE_OBJECT` is the loopback's BACKING file, outside the Job's `Cwd`
+entirely, so each failure is a deletion that escaped the job's tree. All three
+ran in 0.059s total, unprivileged, over real `hanwen/go-fuse` loopback mounts.
+The existing `TestCleanupCrossesNoMountBoundary` passes beside them and still
+does: `crossesMountBoundary` still has a job to do for an entry that is itself
+a mount.
+
+`TestJobTmpDirRemovalCrossesNoMountBoundary` was written in the second round,
+after the review found the `removeTmp` path unclaimed by any test, so it has no
+pre-fix measurement of its own. Its equivalent proof is mutation B below, which
+reddens it with `stat .../002/tmp/remote_output.txt: no such file or
+directory` - the mutated code really deletes the mounted remote's file.
+
+## The fix
+
+The question has to be asked of the swept directory itself, and it is asked by
+judging that directory against the directory ABOVE it - the one level where the
+device does change - reusing the existing predicate rather than adding a second
+mechanism.
+
+`sweptDir` (`jobqueue/utils.go`) pairs the `*os.Root` on the directory being
+swept with the `os.FileInfo` of the directory that handle is itself an entry of.
+`sweptDir.sweepable() (os.FileInfo, bool, error)` returns the device every entry
+is judged against and says whether the sweep may happen at all: not sweepable,
+with a nil error rather than a failure, when `crossesMountBoundary(above, own)`.
+`dirChain.sweptWorkSpace()` builds the pair from `c.deepest()`, the pinned
+handle `openLeaf` opens the leaf against, so the info above comes from an
+`fstatat` on a descriptor the descent already holds.
+
+### Why not statx or /proc/self/mountinfo
+
+Both were probed rather than assumed. `statx(STATX_ATTR_MOUNT_ROOT)` works here
+(kernel 6.8.0-60-generic reports the attribute in `stx_attributes_mask`, and
+answers correctly for `/`, `/proc`, a go-fuse loopback root and a non-mount,
+through a descriptor from `root.Open(".")` - Go 1.26.3's `os.Root` has no
+`FD()`). It was rejected on design grounds:
+
+- it needs Linux 5.8, while `golang.org/x/sys` is only an indirect dependency
+  (`go.mod:112`) and `jobqueue` builds for darwin too, so a statx-only guard
+  leaves darwin and older kernels exactly as broken - and forces an
+  unanswerable third state: refuse, and cleanup dies on those hosts, or
+  proceed, and the bug is unfixed there;
+- `/proc/self/mountinfo` needs the descriptor's path back out of
+  `/proc/self/fd/N` to key on, which is the string re-derivation the `os.Root`
+  exists to avoid, and re-reading it per swept directory is the cost the device
+  comparison does not pay.
+
+The device comparison has no unanswerable state, needs no new dependency, works
+on every GOOS, and adds no syscall: `sweepable`'s `Lstat(".")` is the one
+`removeAllGuarded`/`removeAllExcept` already made, and the info above is taken
+once per sweep in `sweptWorkSpace`, never per entry. A refusal returns before
+any readdir below the directory.
+
+What it cannot see, and statx could, is a mount root on the SAME device as the
+directory above it: a bind mount, or a second mount of the same filesystem.
+Raising either needs `CAP_SYS_ADMIN` or a user namespace, which the shape being
+defended against - an unprivileged Job Cmd running sshfs, s3fs or a nested wr,
+all of which get a device of their own - does not have. That residual is stated
+on `sweepable`, beside the one `crossesMountBoundary` already documents for a
+host that hands back no `*syscall.Stat_t`.
+
+### The second gap the tests exposed
+
+`rmdir` on a live mount point gives EBUSY, not ENOTEMPTY (measured). So once the
+sweep correctly refuses a workspace that is a mount root, `dirChain.removeUpward`
+still tried to remove it and reported an error for a cleanup that had done
+exactly the right thing. `errIsDirInUse` adds `syscall.EBUSY` to what a
+DIRECTORY removal tolerates, which on Linux means the directory is a mount point
+(or the process's own root, which no workspace of wr's is). The non-dir removal
+site still reports EBUSY, so a mounted-on file is left alone by the boundary
+check rather than tried and forgiven.
+
+### Mutation testing
+
+Each mutation had `go build ./... && go vet ./cmd/ ./jobqueue/` confirmed clean
+BEFORE its test run, and was reverted after. A and B were run twice, by
+independent agents, with matching verdicts (logs
+`<scratchpad>/rev2-mut{A,B,C}.log`). D and E were run before
+`TestJobTmpDirRemovalCrossesNoMountBoundary` existed, so that column is not run
+for them rather than green.
+
+| mutation | AtTheWorkingDir | OverAPopulated | AtTheWorkSpace | TmpDir | existing |
+| --- | --- | --- | --- | --- | --- |
+| A: `removeActualCwd` pairs the working dir with its OWN `Lstat(".")` | 1-mount RED | RED | green x4 | green | green |
+| B: `sweptWorkSpace` pairs the workspace with its OWN `Lstat(".")` | green x2 | green | RED x4 | RED | green |
+| C: `syscall.EBUSY` dropped from `errIsDirInUse` | green | green | RED x4 | green | green |
+| D: `sweepable`'s refusal neutralised | RED (1-mount) | RED | RED x4 | not run | green |
+| E: `crossesMountBoundary` forced to return false | RED | RED | RED | not run | RED |
+
+A and B are the site-independence proof: each sweep site has a test that dies
+when only that site is defeated and survives when only the other is. E confirms
+the pre-existing guard was not weakened - it is the only mutation that reddens
+`TestCleanupCrossesNoMountBoundary`.
+
+`AtTheWorkingDir`'s 0-mount subcase stays green under A because with an empty
+keep set `removeActualCwd` hands the whole directory to `removeAllGuarded`,
+judged against the WORKSPACE's device, from which the mount is a device change
+and was always caught. That is what the test's own comment says.
+
+## Items
+
+- [x] The sweep was blind when the swept directory is itself a mount root, so a
+      mount the Job's own Cmd raised over its working directory or over its
+      workspace was swept through, unlinking the user's remote objects from
+      outside the Job's `Cwd`.
+  - `jobqueue/utils.go`: new `sweptDir` with `sweepable()`; `removeAllExcept`
+    and `removeAllGuarded` take a `sweptDir` and refuse a swept directory that
+    is across a boundary from the directory above it; new
+    `dirChain.sweptWorkSpace()`; `errIsDirInUse` adds `syscall.EBUSY` for the
+    two directory removals.
+  - `jobqueue/workspace.go`: `empty`, `removeWorkSpaceEntries`, `removeTmp` and
+    `removeActualCwd` thread the pair from the pinned parent handle.
+  - `jobqueue/workspace_test.go`: four regression tests over real unprivileged
+    go-fuse loopback mounts -
+    `TestCleanupCrossesNoMountBoundaryAtTheWorkingDir`,
+    `...OverAPopulatedWorkingDir`, `...AtTheWorkSpace` and
+    `TestJobTmpDirRemovalCrossesNoMountBoundary`; the three near-identical mount
+    helpers reconciled into one `mountLoopback`.
+
+## Observed during this round, NOT fixed here
+
+- [ ] `errIsDirInUse`'s EBUSY tolerance is unpinned at its `removeSweptDir`
+      call site. Mutation C reddens only the `removeUpward` site, because
+      `removeEntryWithExceptions` catches a mount-root entry before
+      `removeSweptDir` can ever rmdir one, so that site's EBUSY is reachable
+      only through a TOCTOU between the boundary check and the removal.
+      Symmetry between the two directory removals is the reason it is there, and
+      a test would have to win a race to pin it. Left as an observation rather
+      than removed: an unreachable tolerance deletes nothing, while removing it
+      would make the two sites disagree about the same errno, which is the shape
+      of bug this file has had before.
+- [ ] `os.Root.Remove` is `unlinkat(0)` then `unlinkat(AT_REMOVEDIR)` and
+      returns the unlink errno when rmdir gives ENOTDIR
+      (`$(go env GOROOT)/src/os/root_unix.go`), so if a proven directory has
+      become a mounted-on FILE by the moment either site removes it,
+      `errIsDirInUse` forgives that EBUSY too. The outcome is benign - leave it,
+      report success - and the genuine non-dir removal site still reports EBUSY,
+      but `errIsDirInUse`'s "asked only of the removal of a directory" is true
+      of intent rather than of the syscall pair.

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -591,7 +591,8 @@ func soGoneWithin(path string) {
 	deadline := time.Now().Add(lostRunSettleTime)
 
 	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); os.IsNotExist(err) {
+		_, err := os.Stat(path)
+		if os.IsNotExist(err) {
 			return
 		}
 

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1056,10 +1056,37 @@ func (c dirChain) openLeaf() (*os.Root, error) {
 	return openVerifiedDir(c.roots[last], c.names[last], c.info)
 }
 
+// sweptWorkSpace opens the proven dir as a root of its own - see openLeaf - and
+// pairs it with the lstat of the directory that dir is an entry of, which is the
+// deepest handle the descent opened. The pair is what lets a sweep refuse a
+// workspace that is itself the root of a mount the Job's own Cmd raised; see
+// sweptDir.
+//
+// The lstat goes through that pinned handle, so no part of the path above the
+// workspace is resolved from a string a second time, and it is taken once for
+// the whole sweep rather than once per entry. The caller closes the root.
+func (c dirChain) sweptWorkSpace() (sweptDir, error) {
+	wsRoot, err := c.openLeaf()
+	if err != nil {
+		return sweptDir{}, err
+	}
+
+	aboveInfo, err := c.deepest().Lstat(".")
+	if err != nil {
+		wsRoot.Close()
+
+		return sweptDir{}, err
+	}
+
+	return sweptDir{root: wsRoot, above: aboveInfo}, nil
+}
+
 // removeUpward removes the proven dir and then each of its parents in turn,
 // stopping before it reaches the base (leaving that, and everything above it,
 // undeleted) and stopping early at a dir it cannot remove - which is expected
-// when another Job is running from the same base, so that is not an error.
+// when another Job is running from the same base, or when the workspace is
+// itself the mount point of a mount the Job's own Cmd raised, so that is not an
+// error; see errIsDirInUse.
 //
 // Each removal names a single entry of the pinned handle on the directory that
 // entry lives in, so no part of the path is left to be resolved again, and like
@@ -1077,7 +1104,7 @@ func (c dirChain) removeUpward() error {
 
 	err := c.roots[last].Remove(c.names[last])
 	if err != nil && !os.IsNotExist(err) {
-		if errIsDirNotEmpty(err) {
+		if errIsDirInUse(err) {
 			return nil
 		}
 
@@ -1183,6 +1210,27 @@ func openVerifiedDir(parent *os.Root, name string, info os.FileInfo) (*os.Root, 
 // any contract.
 func errIsDirNotEmpty(err error) bool {
 	return errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST)
+}
+
+// errIsDirInUse says if err is a directory removal that failed because the
+// directory is still in use, which every removal of a DIRECTORY that a Job's
+// cleanup makes can tolerate: there is nothing of ours left to delete there, and
+// nothing to retry.
+//
+// Beyond the directory still having entries in it, that covers EBUSY, which
+// rmdir gives for a directory that is a mount point. Cleanup runs before wr
+// takes its own mounts down, and a mount raised over the workspace by the Job's
+// own Cmd is refused by the sweep rather than swept through (see sweptDir), so
+// the mount point being left standing is the ordinary outcome of protecting it,
+// not a failure of the Job's cleanup. The one other thing Linux reports EBUSY
+// for here is the calling process's own root directory, which no workspace of
+// wr's ever is.
+//
+// It is asked only of the removal of a directory, so a mounted-on FILE - which
+// unlink also refuses with EBUSY - is still reported: the sweep leaves that
+// entry alone via the mount boundary rather than trying and forgiving it.
+func errIsDirInUse(err error) bool {
+	return errIsDirNotEmpty(err) || errors.Is(err, syscall.EBUSY)
 }
 
 // realDirBelow proves that dir is a proper descendant of baseRoot's dir, ie.
@@ -1343,7 +1391,60 @@ func readDirIn(dirRoot *os.Root) ([]os.DirEntry, error) {
 	return f.ReadDir(-1)
 }
 
-// removeAllExcept deletes the contents of dirRoot's own directory, except for
+// sweptDir pairs a handle on a directory a Job's cleanup is about to sweep with
+// the lstat of the directory that handle is itself an entry of.
+//
+// The pair exists because crossesMountBoundary can only see a mount that is
+// INSIDE the swept directory: every entry of a mount root is on the mount's own
+// device, so where the swept directory IS the mount root no entry of it ever
+// looks like a boundary, and the sweep walks straight into the user's mounted
+// filesystem. The device does change one level up, so the swept directory has to
+// be judged against the directory above it as well as its entries against it.
+//
+// Holding the two together also names them, so a transposition of the two
+// os.FileInfos a sweep of the working directory needs - the directory above it,
+// and the identity its own handle is opened against - reads wrong at a call
+// site, where a pair of bare arguments would swap silently and answer the
+// boundary question about the wrong directory.
+type sweptDir struct {
+	// root is the handle on the directory whose contents are being swept.
+	root *os.Root
+
+	// above is the lstat of the directory root is an entry of, read through the
+	// pinned handle on that directory so that no path is resolved from a string.
+	above os.FileInfo
+}
+
+// sweepable lstats the swept directory itself, giving the device every entry's
+// mount boundary is judged against - what removeWithExceptions documents as its
+// dirInfo - and says whether the sweep may happen at all.
+//
+// The directory is not sweepable, with a nil error rather than a failure, where
+// it is across a mount boundary from the directory above it, ie. it is itself a
+// mount root and nothing inside it is wr's. Refusing costs one comparison and
+// happens before any readdir below the directory.
+//
+// What this cannot see, and statx(STATX_ATTR_MOUNT_ROOT) could, is a mount root
+// on the SAME device as the directory above it: a bind mount, or a second mount
+// of the same filesystem. Raising either needs CAP_SYS_ADMIN or a user
+// namespace, which the shape being defended against - a Job's own unprivileged
+// Cmd running sshfs, s3fs or a nested wr, all of which get a device of their own
+// - does not have. It is the same kind of residual crossesMountBoundary already
+// documents for a host that hands back no *syscall.Stat_t.
+func (d sweptDir) sweepable() (os.FileInfo, bool, error) {
+	info, err := d.root.Lstat(".")
+	if err != nil {
+		return nil, false, err
+	}
+
+	if crossesMountBoundary(d.above, info) {
+		return nil, false, nil
+	}
+
+	return info, true, nil
+}
+
+// removeAllExcept deletes the contents of dir's own directory, except for
 // the given folders (paths relative to it), and except for whatever
 // removeEntryWithExceptions refuses to touch at all.
 //
@@ -1353,19 +1454,19 @@ func readDirIn(dirRoot *os.Root) ([]os.DirEntry, error) {
 // because only descendants of the directory are ever deleted here, so an
 // exception outside it was protecting nothing, whereas erroring would abandon the
 // job's workspace for no gain.
-func removeAllExcept(dirRoot *os.Root, exceptions []string) error {
-	info, err := dirRoot.Lstat(".")
-	if err != nil {
+func removeAllExcept(dir sweptDir, exceptions []string) error {
+	info, ok, err := dir.sweepable()
+	if !ok {
 		return err
 	}
 
-	return removeWithExceptions(dirRoot, ".", info, exceptionDirs(exceptions))
+	return removeWithExceptions(dir.root, ".", info, exceptionDirs(exceptions))
 }
 
-// removeAllGuarded deletes the entry of dirRoot called name, and everything
-// below it. It stands in for os.Root.RemoveAll everywhere a Job's cleanup
-// deletes inside the workspace wr made for it, and differs from it only in what
-// it refuses to touch; see removeEntryWithExceptions.
+// removeAllGuarded deletes the entry of dir's own directory called name, and
+// everything below it. It stands in for os.Root.RemoveAll everywhere a Job's
+// cleanup deletes inside the workspace wr made for it, and differs from it only
+// in what it refuses to touch; see removeEntryWithExceptions and sweptDir.
 //
 // Whether name is the Job's to delete at all is decided long before this, by
 // jobWorkSpace; all this bounds is how far a deletion already licensed goes.
@@ -1374,13 +1475,13 @@ func removeAllExcept(dirRoot *os.Root, exceptions []string) error {
 // on as its own keep-set spelling, which nothing then reads. Every caller passes
 // a single component anyway - an entry of the workspace, its tmp or its working
 // directory - so the two spellings are the same string.
-func removeAllGuarded(dirRoot *os.Root, name string) error {
-	info, err := dirRoot.Lstat(".")
-	if err != nil {
+func removeAllGuarded(dir sweptDir, name string) error {
+	info, ok, err := dir.sweepable()
+	if !ok {
 		return err
 	}
 
-	return removeEntryWithExceptions(dirRoot, name, name, info, nil)
+	return removeEntryWithExceptions(dir.root, name, name, info, nil)
 }
 
 // exceptionDirs turns removeAllExcept's exceptions into the set of dirs to keep,
@@ -1548,7 +1649,7 @@ func removeSweptDir(dirRoot *os.Root, name, keepRel string, dirInfo os.FileInfo,
 	}
 
 	err = dirRoot.Remove(name)
-	if err == nil || os.IsNotExist(err) || errIsDirNotEmpty(err) {
+	if err == nil || os.IsNotExist(err) || errIsDirInUse(err) {
 		return nil
 	}
 

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -910,8 +910,12 @@ func (ws *jobWorkSpace) cleanup() error {
 //
 // A Job with no mounts gets no fast path around the keep set: that set is
 // already empty for such a Job, so the sweep below deletes everything anyway.
+//
+// What the workspace handle is paired with is the lstat of the directory above
+// it, without which a mount the Job's own Cmd raised over the workspace is
+// indistinguishable from the workspace itself; see sweptWorkSpace.
 func (ws *jobWorkSpace) empty(chain dirChain) error {
-	wsRoot, err := chain.openLeaf()
+	workSpace, err := chain.sweptWorkSpace()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -919,20 +923,20 @@ func (ws *jobWorkSpace) empty(chain dirChain) error {
 
 		return err
 	}
-	defer wsRoot.Close()
+	defer workSpace.root.Close()
 
-	actualCwd, err := ws.actualCwdNow(wsRoot)
+	actualCwd, err := ws.actualCwdNow(workSpace.root)
 	if err != nil {
 		return err
 	}
 
 	if !ws.keep.wholeActualCwd && actualCwd != nil {
-		if err = removeActualCwd(wsRoot, ws.paths.actualCwdName, actualCwd, ws.keep.inActualCwd); err != nil {
+		if err = removeActualCwd(workSpace, ws.paths.actualCwdName, actualCwd, ws.keep.inActualCwd); err != nil {
 			return err
 		}
 	}
 
-	return ws.removeWorkSpaceEntries(wsRoot)
+	return ws.removeWorkSpaceEntries(workSpace)
 }
 
 // actualCwdNow lstats the working directory again, as a single named entry of the
@@ -1003,9 +1007,11 @@ func (ws *jobWorkSpace) keptEntry(name string) bool {
 //
 // The keep set is not the whole of what survives, because it can only describe
 // what the Job itself configured: removeAllGuarded is what stops the deletion
-// crossing into another Job's workspace or through a live mount deeper down.
-func (ws *jobWorkSpace) removeWorkSpaceEntries(wsRoot *os.Root) error {
-	entries, err := readDirIn(wsRoot)
+// crossing into another Job's workspace, through a live mount deeper down, or -
+// via the info sweptWorkSpace paired with the handle - into a mount raised over
+// the workspace itself, whose entries all look like ordinary entries of it.
+func (ws *jobWorkSpace) removeWorkSpaceEntries(workSpace sweptDir) error {
+	entries, err := readDirIn(workSpace.root)
 	if err != nil {
 		return err
 	}
@@ -1015,7 +1021,7 @@ func (ws *jobWorkSpace) removeWorkSpaceEntries(wsRoot *os.Root) error {
 			continue
 		}
 
-		if err = removeAllGuarded(wsRoot, entry.Name()); err != nil {
+		if err = removeAllGuarded(workSpace, entry.Name()); err != nil {
 			return err
 		}
 	}
@@ -1041,7 +1047,7 @@ func (ws *jobWorkSpace) removeTmp() error {
 	}
 	defer chain.closeAll()
 
-	wsRoot, err := chain.openLeaf()
+	workSpace, err := chain.sweptWorkSpace()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -1049,9 +1055,9 @@ func (ws *jobWorkSpace) removeTmp() error {
 
 		return err
 	}
-	defer wsRoot.Close()
+	defer workSpace.root.Close()
 
-	return removeAllGuarded(wsRoot, createdTmpName)
+	return removeAllGuarded(workSpace, createdTmpName)
 }
 
 // removeActualCwd deletes the Job's working directory, keeping the given relative
@@ -1061,12 +1067,24 @@ func (ws *jobWorkSpace) removeTmp() error {
 // os.Root.RemoveAll: the working directory is where a Job that adds jobs leaves
 // its children's workspaces, and where a mount the Job raised itself is
 // mounted, and the Job's keep set knows about neither.
-func removeActualCwd(wsRoot *os.Root, actualCwdName string, actualCwdInfo os.FileInfo, keepDirs []string) error {
+//
+// Sweeping around a keep set means sweeping the working directory itself, so the
+// device its own mount boundary is judged against is the workspace's, that being
+// the directory it is an entry of. That info comes from workSpace.sweepable
+// rather than a bare lstat so that a workspace which is itself a mount root
+// refuses the sweep of everything inside it, exactly as it refuses the
+// whole-directory deletion above.
+func removeActualCwd(workSpace sweptDir, actualCwdName string, actualCwdInfo os.FileInfo, keepDirs []string) error {
 	if len(keepDirs) == 0 {
-		return removeAllGuarded(wsRoot, actualCwdName)
+		return removeAllGuarded(workSpace, actualCwdName)
 	}
 
-	actualCwdRoot, err := openVerifiedDir(wsRoot, actualCwdName, actualCwdInfo)
+	wsInfo, ok, err := workSpace.sweepable()
+	if !ok {
+		return err
+	}
+
+	actualCwdRoot, err := openVerifiedDir(workSpace.root, actualCwdName, actualCwdInfo)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -1076,7 +1094,7 @@ func removeActualCwd(wsRoot *os.Root, actualCwdName string, actualCwdInfo os.Fil
 	}
 	defer actualCwdRoot.Close()
 
-	return removeAllExcept(actualCwdRoot, keepDirs)
+	return removeAllExcept(sweptDir{root: actualCwdRoot, above: wsInfo}, keepDirs)
 }
 
 // rmEmptyMountDirs deletes any empty directories between the Job's mount points

--- a/jobqueue/workspace_test.go
+++ b/jobqueue/workspace_test.go
@@ -26,6 +26,7 @@
 package jobqueue
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -40,6 +41,7 @@ import (
 
 	"github.com/VertebrateResequencing/wr/clog"
 	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -58,6 +60,244 @@ const (
 // keyGrindMax bounds jobWithKeyPrefix's search, which is expected to take about
 // 16^len(prefix) tries.
 const keyGrindMax = 1 << 20
+
+// TestCleanupCrossesNoMountBoundaryAtTheWorkingDir drives the sweep whose device
+// number comes from the working directory itself: removeAllExcept, reached by
+// removeActualCwd when the Job's keep set is non-empty.
+//
+// The SWEPT directory is where the boundary question is blind, because every
+// entry of a mount root is on the mount's own device: judged against the
+// directory they are entries of, nothing inside a mount root ever looks like a
+// crossing, and the sweep walks the user's mounted filesystem believing it is
+// walking the workspace wr made. So the swept directory has to be judged against
+// the directory ABOVE it, which is the one level where the device does change.
+func TestCleanupCrossesNoMountBoundaryAtTheWorkingDir(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// the mount the Job's own Cmd raised is AT the working directory rather than
+	// an entry of it, and the working directory is where removeAllExcept takes
+	// the device it judges every entry against.
+	//
+	// Both sweeps are driven, because only one of them takes its device from the
+	// working directory: with no mounts the keep set is empty, removeActualCwd
+	// hands the whole directory to removeAllGuarded, and the device that judges
+	// it is the WORKSPACE's - from which the mount is a device change and IS
+	// caught, even before this fix.
+	for _, mounts := range nestedSweepCases() {
+		Convey("Given a Job whose Cmd raised a live mount over the working directory wr gave it", t, func() {
+			if !canMountFuse() {
+				SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+				return
+			}
+
+			cwd := t.TempDir()
+
+			job := &Job{
+				Cwd:          cwd,
+				Cmd:          "sshfs remote:/data . && analyse",
+				MountConfigs: mounts,
+			}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+			scratch := writeFileIn(tmpDir, "scratch.txt")
+
+			// the Job's keep set is built from its MountConfigs LEXICALLY and kept
+			// unconditionally (keptDirs), so the mount point inside the working
+			// directory does not have to be there for the keep set to name it -
+			// which is what sends the sweep down the removeAllExcept branch. It
+			// being absent is also what lets fusermount 2 mount over the working
+			// directory at all; see mountLoopback on the "nonempty" option.
+			remote, mounted := mountLoopbackOver(t, actualCwd)
+			if !mounted {
+				SkipConvey("this host refused an unprivileged FUSE mount", func() {})
+
+				return
+			}
+
+			Convey(fmt.Sprintf("cleanup with %d mounts deletes nothing through it, and still deletes what it made",
+				len(mounts)), func() {
+				err := (&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, job)
+
+				soPathsExist(remote, filepath.Join(actualCwd, testWSRemote), actualCwd, workSpace)
+				soPathsGone(scratch, tmpDir)
+
+				So(err, ShouldBeNil)
+			})
+		})
+	}
+}
+
+// TestCleanupCrossesNoMountBoundaryOverAPopulatedWorkingDir is the test above
+// with the ordering wr really produces: wr raises its own configured mount
+// INSIDE the working directory before the Job's Cmd runs, so that directory is
+// not empty when the Cmd mounts over it.
+func TestCleanupCrossesNoMountBoundaryOverAPopulatedWorkingDir(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a working dir that held wr's own mount point when the Cmd mounted over it", t, func() {
+		if !canMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		cwd := t.TempDir()
+		job := &Job{
+			Cwd:          cwd,
+			Cmd:          "sshfs remote:/data . && analyse",
+			MountConfigs: MountConfigs{{Mount: testWSMount}},
+		}
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+		scratch := writeFileIn(tmpDir, "scratch.txt")
+
+		So(os.MkdirAll(filepath.Join(actualCwd, testWSMount), os.ModePerm), ShouldBeNil)
+
+		backing := t.TempDir()
+		remote := writeFileIn(backing, testWSRemote)
+
+		if !mountLoopback(t, actualCwd, backing, "nonempty") {
+			SkipConvey("this host refused an unprivileged FUSE mount over a non-empty dir", func() {})
+
+			return
+		}
+
+		Convey("cleanup deletes nothing through it, and still deletes what it made", func() {
+			err := (&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, job)
+
+			soPathsExist(remote, filepath.Join(actualCwd, testWSRemote), actualCwd, workSpace)
+			soPathsGone(scratch, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+// TestCleanupCrossesNoMountBoundaryAtTheWorkSpace drives the sweep of the
+// workspace's own entries - removeWorkSpaceEntries - by making the WORKSPACE the
+// mount root. It takes its device from the workspace's own Lstat("."), so it is
+// blind there for the same reason, and it needs no keep set at all to be
+// reached. Reclaiming the TMPDIR is blind in the same place, and is reached from
+// Execute rather than from a cleanup Behaviour; see
+// TestJobTmpDirRemovalCrossesNoMountBoundary.
+func TestCleanupCrossesNoMountBoundaryAtTheWorkSpace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// withCwdEntry says whether the mounted remote happens to hold an entry
+	// called cwd, which is what the working directory resolves to through the
+	// mount. With one, the working-directory sweep runs against it as well; with
+	// none, proveActualCwd's tolerated absence leaves actualCwdInfo nil and only
+	// removeWorkSpaceEntries runs - and that alone is enough to wipe the remote's
+	// top level.
+	//
+	// The mounts decide which sweep that working directory then gets, and only
+	// the keep-set one reaches inside it: from the working directory's own device
+	// - the mount's - nothing below is a crossing, so what refuses it is the
+	// workspace being a mount root, asked one level higher up.
+	for _, withCwdEntry := range []bool{false, true} {
+		for _, mounts := range nestedSweepCases() {
+			Convey("Given a Job whose Cmd raised a live mount over the workspace wr gave it", t, func() {
+				if !canMountFuse() {
+					SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+					return
+				}
+
+				cwd := t.TempDir()
+				job := &Job{Cwd: cwd, Cmd: "sshfs remote:/data .. && analyse", MountConfigs: mounts}
+				actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+				backing := t.TempDir()
+				remote := writeFileIn(backing, testWSRemote)
+				remoteDeep := remote
+
+				if withCwdEntry {
+					remoteDeep = writeFileIn(filepath.Join(backing, createdCwdName), "remote_output.txt")
+				}
+
+				// fusermount 2 refuses a non-empty mount point, which libfuse 3
+				// permits by default, so what wr made in the workspace goes first.
+				So(os.RemoveAll(actualCwd), ShouldBeNil)
+				So(os.RemoveAll(tmpDir), ShouldBeNil)
+
+				if !mountLoopback(t, workSpace, backing) {
+					SkipConvey("this host refused an unprivileged FUSE mount", func() {})
+
+					return
+				}
+
+				Convey(fmt.Sprintf("cleanup with a cwd entry present=%v and %d mounts deletes nothing through it",
+					withCwdEntry, len(mounts)), func() {
+					err := (&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, job)
+
+					soPathsExist(remoteDeep, remote, workSpace)
+
+					So(err, ShouldBeNil)
+				})
+			})
+		}
+	}
+}
+
+// TestJobTmpDirRemovalCrossesNoMountBoundary drives the sweep no cleanup
+// Behaviour reaches: removeTmp, which Execute asks for on every exit through
+// removeJobTmpDir, including for the great majority of Jobs that have no cleanup
+// Behaviour at all and so never sweep anything else.
+//
+// It takes its device from the workspace's own Lstat("."), so with a mount the
+// Job's own Cmd raised over the workspace, the tmp it deletes is whatever the
+// mounted filesystem happens to call tmp.
+func TestJobTmpDirRemovalCrossesNoMountBoundary(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a Job whose Cmd raised a live mount over the workspace holding its TMPDIR", t, func() {
+		if !canMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		cwd := t.TempDir()
+		job := &Job{Cwd: cwd, Cmd: "sshfs remote:/data .. && analyse"}
+		actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+		backing := t.TempDir()
+		remote := writeFileIn(backing, testWSRemote)
+
+		// what the TMPDIR wr made resolves to through the mount is the mounted
+		// filesystem's own tmp, so that is what removeTmp deletes.
+		remoteTmp := writeFileIn(filepath.Join(backing, createdTmpName), "remote_output.txt")
+
+		// fusermount 2 refuses a non-empty mount point, which libfuse 3 permits
+		// by default, so what wr made in the workspace goes first.
+		So(os.RemoveAll(actualCwd), ShouldBeNil)
+		So(os.RemoveAll(tmpDir), ShouldBeNil)
+
+		if !mountLoopback(t, workSpace, backing) {
+			SkipConvey("this host refused an unprivileged FUSE mount", func() {})
+
+			return
+		}
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		Reset(clog.ToDefault)
+
+		Convey("reclaiming the TMPDIR deletes nothing through the mount", func() {
+			removeJobTmpDir(context.Background(), job)
+
+			soPathsExist(remoteTmp, remote, filepath.Join(workSpace, createdTmpName), workSpace)
+			So(buff.String(), ShouldBeEmpty)
+		})
+	})
+}
 
 // realWorkSpace gives job the working directory mkHashedDir really creates for it
 // below job.Cwd, and returns that dir, the workspace holding it, and the tmp dir
@@ -538,6 +778,45 @@ func TestCleanupKeepsCacheAtWorkSpace(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+}
+
+// mountLoopback really FUSE mounts backing over mountPoint, with the given mount
+// options, and takes the mount down when the test ends. ok is false where the
+// host refused the mount, for the reason mountLoopbackOver gives.
+//
+// go-fuse's loopback filesystem is what makes the mount real, and it is the
+// cheapest one an unprivileged process can raise. What is behind it is an
+// ordinary directory, so what survived can be asserted about directly; muxfys
+// would need an object store to talk to, and the deletion under test does not
+// care which filesystem is mounted, only that a mount gets crossed.
+//
+// The one option any of this needs is "nonempty", for a mount point that is not
+// empty: fusermount 2 refuses that without it, while libfuse 3 dropped the check
+// and permits it by default. It decides only whether the mount is PERMITTED,
+// never what the sweep does once it is up.
+func mountLoopback(t *testing.T, mountPoint, backing string, options ...string) bool {
+	t.Helper()
+
+	root, err := gofuse.NewLoopbackRoot(backing)
+	So(err, ShouldBeNil)
+	So(os.MkdirAll(mountPoint, os.ModePerm), ShouldBeNil)
+
+	server, err := gofuse.Mount(mountPoint, root, &gofuse.Options{
+		MountOptions: fuse.MountOptions{Options: options},
+	})
+	if err != nil {
+		t.Logf("this host refused a loopback FUSE mount at %s: %s", mountPoint, err)
+
+		return false
+	}
+
+	t.Cleanup(func() {
+		if uerr := server.Unmount(); uerr != nil {
+			t.Logf("could not unmount the loopback at %s: %s", mountPoint, uerr)
+		}
+	})
+
+	return true
 }
 
 // jobKeptDirs is the keep set the real resolution classifies for job: everything
@@ -1451,33 +1730,17 @@ func canMountFuse() bool {
 // and a fusermount binary and still deny an unprivileged mount, so a failed
 // mount is a skip and never a test failure.
 //
-// go-fuse's loopback filesystem is what makes the mount real, and it is the
-// cheapest one an unprivileged process can raise. What is behind it is an
-// ordinary directory, so what survived can be asserted about directly; muxfys
-// would need an object store to talk to, and the deletion under test does not
-// care which filesystem is mounted, only that a mount gets crossed.
+// A test that needs to choose the NAMES behind the mount plants its own backing
+// directory and calls mountLoopback itself.
 func mountLoopbackOver(t *testing.T, mountPoint string) (string, bool) {
 	t.Helper()
 
 	backing := t.TempDir()
 	remote := writeFileIn(backing, testWSRemote)
 
-	root, err := gofuse.NewLoopbackRoot(backing)
-	So(err, ShouldBeNil)
-	So(os.MkdirAll(mountPoint, os.ModePerm), ShouldBeNil)
-
-	server, err := gofuse.Mount(mountPoint, root, &gofuse.Options{})
-	if err != nil {
-		t.Logf("this host refused a loopback FUSE mount at %s: %s", mountPoint, err)
-
+	if !mountLoopback(t, mountPoint, backing) {
 		return "", false
 	}
-
-	t.Cleanup(func() {
-		if uerr := server.Unmount(); uerr != nil {
-			t.Logf("could not unmount the loopback at %s: %s", mountPoint, uerr)
-		}
-	})
 
 	return remote, true
 }


### PR DESCRIPTION
#575 is merged, so this now targets `develop` directly. It also carries one
unrelated one-line test change, explained at the end.

`crossesMountBoundary`, added in #575, compares an entry's device against the
device of the directory it is an entry of. That is blind in exactly one place:
when the **swept directory is itself a mount root**, every entry of it is on the
mount's own device, so no boundary is ever seen and the sweep walks straight into
the user's mounted filesystem.

This is not theoretical. Over real unprivileged go-fuse loopback mounts, three
shapes each delete data and return `nil`:

| shape | what goes |
| --- | --- |
| a mount at the working directory | the loopback's **backing** file, outside the Job's `Cwd` |
| a mount over a *populated* working directory | same |
| a mount at the workspace | the remote's top level, including output the run had written |

The last is the worst: `removeWorkSpaceEntries` reaches it with **no keep set
involved at all**, so nothing else is standing in the way. And the reachable
production shape is ordinary — a Job's own Cmd mounting sshfs/s3fs/a nested wr
over its working directory. wr's keep set only knows about wr's *own*
`MountConfig`s, and cleanup behaviours run *before* wr unmounts, so live mounts
at cleanup time are the normal case.

### The fix: the same predicate, asked one level up

`sweptDir` pairs the `*os.Root` on the swept directory with the `os.FileInfo` of
the directory that handle is itself an entry of; `sweptDir.sweepable()` refuses
the sweep when those two are across a boundary. The device *does* change one
level up, which is the level all four call sites already hold as a pinned root —
so the existing predicate answers the question and no second mechanism is needed.

**Why not `statx(STATX_ATTR_MOUNT_ROOT)`.** It was probed, not assumed: it works
correctly on this kernel. It was rejected on design. `jobqueue` builds for darwin
(`GOOS=darwin go build ./jobqueue/` exits 0; `client.go` branches on it) and
statx needs Linux 5.8 with `golang.org/x/sys` currently only an indirect
dependency — so it would leave darwin and older hosts exactly as broken as today,
*and* force an unanswerable third state: refuse and cleanup dies there, or
proceed and the bug is unfixed there. Taking the device from one level up has no
unsupported-host branch at all. `/proc/self/mountinfo` was rejected because it
needs the descriptor's path back out of `/proc/self/fd/N`, which is the string
re-derivation the `os.Root` exists to avoid.

**Cost:** zero added syscalls. `sweepable`'s `Lstat(".")` is the one the sweep
already made; the info above is taken once per sweep, never per entry; a refusal
returns before any readdir.

**Residual, documented on `sweepable`:** a mount root on the *same* device as the
directory above it — a bind mount, or a second mount of the same filesystem.
Raising either needs `CAP_SYS_ADMIN` or a user namespace, which the unprivileged
Cmd this defends against does not have.

### Also here

- **A third sweep site**, covered by the fix but claimed by no test: `removeTmp`
  → `removeAllGuarded`, reached from `removeJobTmpDir` which `Execute` defers —
  never from a cleanup Behaviour. Proven distinct by `panic()` in `removeTmp`,
  and now pinned by `TestJobTmpDirRemovalCrossesNoMountBoundary`.
- **`rmdir` on a live mount point returns EBUSY, not ENOTEMPTY** (measured), so
  once the sweep correctly refuses, `removeUpward` was reporting an error for a
  cleanup that had done the right thing. `errIsDirInUse` now accepts `EBUSY` for
  the two directory removals; the non-dir site still reports it.

### Verification

Site-independence is proven in both directions: a mutation that defeats only the
working-directory pairing reddens only the working-directory tests, and one that
defeats only the workspace pairing reddens only the workspace and tmp-dir tests.
Neutralising `sweepable`'s refusal reddens all four new tests while
`TestCleanupCrossesNoMountBoundary` stays green — so the new guard is
load-bearing and does not overlap the old one. Every mutation was confirmed
`go vet`-clean before its verdict counted.

Gates: **438 passed · 9 skipped** on `make test` and `make race`, `make lint`
0 issues. Checklist and evidence: `.docs/bugfixes/260903-13.md`.


### One unrelated change, and why it is here

`jobqueue/lost_job_behaviours_test.go` splits a stat out of its `if`:

```go
_, err := os.Stat(path)
if os.IsNotExist(err) {
```

That file is nothing to do with mount roots. It is here because `make lint`
fails without it: gosec's taint analysis is inter-procedural, and this change
plus #575's per-directory descent together make it trace a path into that test
helper and report `G703: Path traversal via taint analysis`. Neither change
does so alone — #575 lints clean, and this PR linted clean against #575's
pre-perf head — so the finding appears only in combination and only became
visible once both were in one tree.

It is a false positive: the helper stats a path the test itself built under
`t.TempDir()`. The split settles it with no suppression at all, which is
preferable to a `//nolint`. Verified not to be a cache artifact — it reproduces
on a pristine tree after `golangci-lint cache clean` — and the lost-job tests
that use the helper all still pass.