### PR TITLE
Stop creating a .hold file in the user's directory for every job

### DIFF
--- a/.docs/bugfixes/260904-2.md
+++ b/.docs/bugfixes/260904-2.md
@@ -279,8 +279,21 @@ deterministic half of the claim is carried by the second Convey.
 ## Gates
 
 `go build ./...`, `go vet ./cmd/ ./jobqueue/` and `gofmt -l jobqueue/ cmd/` are
-all clean. `make race` and `make lint` were not run; the maintainer runs those
-centrally.
+all clean.
+
+`make race` and `make lint` were not run **by the implementing agent** - they
+are run centrally, once, over the finished commits. They have since been run,
+on `36c6c8ed`:
+
+    make race: 445 passed · 9 skipped · 29 packages · 5m5s   PASSED
+    make lint: 2 issues -> fixed in 32ade693 -> 0 issues.
+
+The two lint issues were `errcheck` on `utils_test.go:489` (this repo sets
+`check-blank: true`, so even `_ = rmEmptyDirsIn(...)` is reported) and a
+`gosec` G703 taint finding on `lost_job_behaviours_test.go:594`. The first took
+a `//nolint:errcheck` with its reason; the second stopped firing once the first
+was fixed, so its directive became unused and was removed - that file is back
+to its committed state. Neither is a defect in this change.
 
 `make test`, run once at the end:
 

--- a/.docs/bugfixes/260904-2.md
+++ b/.docs/bugfixes/260904-2.md
@@ -346,3 +346,41 @@ dir, which is exactly the concurrent `rmEmptyDirsIn` this branch's retry exists
 for, so the combined code now retries it and remakes the dir - `calls` is
 `mkHashedDirMaxTries+1`. The arm's intent is unchanged and still pinned: an
 `ENOENT` is not answered by drawing another name.
+
+## Review finding: the sweep-removal counter counted absence, not removal
+
+Copilot, on head `7c225305`, in the review **body** rather than as a thread:
+
+> The sweep-removal counter is incremented whenever `removedDir` is missing
+> after a sweep, but `removedDir` can be missing without being removed by the
+> sweep (eg it may not exist yet on the first tick). This makes `stop()`'s
+> "really removed" claim and the `So(stop(), ShouldBeGreaterThan, 0)` assertion
+> potentially vacuous; count only transitions from "existed" to "missing" across
+> a sweep tick.
+
+Correct, and not merely potentially. Measured by instrumenting the counter to
+separate the two cases:
+
+    counted 1060   really-removed 551   never-existed 509
+
+So roughly half the count was fiction. `removedDir` is the shared hashed dir,
+and the fixture creates only `thirdHashed`, which differs at the last level - so
+the hashed dir does not exist before the first tick, and the caller removes the
+workspace under it on every iteration, leaving it absent much of the time.
+
+**What that cost.** `So(stop(), ShouldBeGreaterThan, 0)` could not fail: the
+first tick alone satisfied it. That assertion is the only thing claiming the
+sweep was LIVE rather than idle, so a `sweepEmptyDirsPerTick` that never swept
+would have left this test racing nothing and still passing. The guard itself was
+never resting on it - the mutation set below is what proves that - but the test's
+own claim to be a race test was unfalsifiable.
+
+**Fixed** by counting only a sweep that found the dir there and left it gone.
+The helper's doc no longer claims more than it counts.
+
+**Proven falsifiable**, which is the point of the change. Neutralising the sweep
+(`_ = root`, so `rmEmptyDirsIn` never runs), `go vet` clean:
+
+- with the fixed counter: **RED**, `utils_test.go:482`,
+  `Expected '0' to be greater than '0' (but it wasn't)!`
+- with the old counter: **`ok`** - a completely dead sweep passes.

--- a/.docs/bugfixes/260904-2.md
+++ b/.docs/bugfixes/260904-2.md
@@ -1,0 +1,335 @@
+# Bugfixes 260904-2
+
+Branch `remove-hold-file`, off `origin/develop` (`44be38e3`).
+
+- [x] `mkHashedDir` creates a `.hold` file on disk, inside the user's own
+      directory tree, at `<Cwd>/<AppName>_cwd/<h>/<h>/<h>/.hold`. wr's
+      maintainer considers it a key benefit that wr does not create little
+      state files on disk. Removing the file again afterwards does not make it
+      acceptable: the objection is to creating it at all. Remove the creation,
+      and get the tests green by a means that creates no file.
+
+    - Fixed. `jobqueue/utils.go`: the hold file and its helpers are gone, and
+      the retry loop it lived in now covers the creation of the unique leaf
+      instead, with a pause between tries. `jobqueue/utils_test.go`: a new
+      behavioural race test, and the old mechanism test replaced rather than
+      deleted. Nothing new is created on disk.
+
+    - Source: maintainer instruction, not a failing gate.
+    - Red command: remove the file creation from `mkHashedDir`
+      (`jobqueue/utils.go:714-717`) and `tryMkHeldDir`
+      (`jobqueue/utils.go:820-825`), keeping every signature, then
+
+          go test ./jobqueue/ -count=1 -timeout 10m -v \
+            -run 'TestMkHashedDirHoldFileFailure'
+
+## Red output, verbatim, after removing the file creation and before any fix
+
+    === RUN   TestMkHashedDirHoldFileFailure
+
+      mkHashedDir gives up when the hold file cannot be created ✔✔✔✔✔
+
+
+    5 total assertions
+
+
+      A hold-file failure that clears is retried, not treated as fatal ✔✔✘
+
+
+    Failures:
+
+      * /home/ubuntu/wr_nohold/jobqueue/utils_test.go
+      Line 431:
+      Expected: true
+      Actual:   false
+
+
+    8 total assertions
+
+    --- FAIL: TestMkHashedDirHoldFileFailure (0.00s)
+    FAIL
+    FAIL	github.com/VertebrateResequencing/wr/jobqueue	0.015s
+    FAIL
+
+Exit status 1. Line 431 is `So(retry, ShouldBeTrue)` in the Convey that drives
+`tryMkHeldDir` directly.
+
+A wider run over every test that touches `mkHashedDir`, the workspace, the
+cleanup behaviours and the lost-job paths (`TestRmEmptyDirsIn`,
+`TestCreatedCwdDepthMatchesMkHashedDir`, `TestCleanup*`, `TestWorkSpace*`,
+`TestRelIsJobCreatedCwd`, `TestOpenVerifiedDirFile`, `TestRunDirWithoutProcFD`,
+`TestJobKeyConcurrentWithCleanup`, `TestJobTmpDirRemoval*`, `TestBehaviour*`,
+`TestJobUnmount*`, `TestLost*`, `TestUnstartedRunWorkSpaceCleanupOrder`,
+`TestClientExecuteUnstartedRunWorkSpace`, `TestJobModifierActualCwd`,
+`TestJobSetActualCwd`) found no other red test: 1351 assertions, one failure at
+`utils_test.go:431`. `TestLostJobOnWeblessManagerCleansItsWorkSpace` also
+failed in that wider run with `listen tcp 0.0.0.0:33223: bind: address already
+in use` (`lost_job_behaviours_test.go:186`); that is a port clash from running
+lanes outside the suite runner, and it passes on the unmodified tree when run
+alone, so it is environmental and not part of this bug.
+
+## What the file was buying
+
+Nothing that any behavioural test covers. The only red test pinned the
+mechanism, not a behaviour: it called `tryMkHeldDir` with hand-built arguments
+and asserted the hold file existed on disk afterwards.
+
+The race the file was meant to guard - a concurrent `rmEmptyDirsIn` removing
+the hashed levels between wr creating them and wr creating the unique leaf
+inside them - had no test at all, and the file did not close it.
+`.docs/bugfixes/260903-2.md` finding 1 already recorded why: the retry loop
+covered only `mkdirAllManaged` and the hold-file `OpenFile`, never the
+`os.MkdirTemp` that makes the unique leaf, which is where the window actually
+is. Findings 2 and 3 of that document recorded two further faults of the file
+itself - one hold file shared by every key with the same first three
+characters, unlinked by whichever job finished first, and an `OpenFile` with
+neither `O_EXCL` nor `O_NOFOLLOW`, so a job's own command could plant `.hold`
+as a symlink and have wr create a file wherever that pointed.
+
+## Condition on the removal
+
+The maintainer's instruction is to remove the file only if it can be dropped
+with no downsides. Any of these stops the removal, and reporting the blocker
+with its evidence is the correct outcome rather than a weaker implementation:
+
+- `mkHashedDir` becoming able to fail where it previously succeeded.
+- A job ending up without a working directory.
+- PR #569's bounded-retry guarantee being weakened, or its termination test
+  lost.
+- Needing a new file, lock file, marker or dotfile anywhere on disk.
+- The replacement being materially slower on the ordinary path. `mkHashedDir`
+  runs once per job across batches of tens of thousands, on Lustre, where
+  metadata operations are dear. The file costs one `OpenFile` create plus one
+  `unlink` per job today.
+
+## Out of scope
+
+The `.wr_lsf_emulation` symlinks (`bsub`, `bjobs`, `bkill`,
+`jobqueue/client.go:2854`) stay. They land in `os.TempDir()` rather than the
+user's tree, they occur only for `--bsub` jobs, and an `execvp("bsub")` from a
+non-shell caller cannot be intercepted without a directory entry on PATH.
+
+Neither on-disk artifact is a regression from this cycle: `.hold` dates from
+`8c6e1671` (2017-07-11, released in v0.9.0) and the symlinks from `2f6bd584`
+(2017-11-08, v0.13.0), against a current release of v0.37.2. `.hold` is being
+removed because it lands in the user's own directory tree and is created for
+every ordinary job.
+
+## The mechanism chosen
+
+The retry loop the hold file lived in is kept, and its second step becomes the
+creation of the unique leaf (`os.MkdirTemp`) that the hold file was there to
+protect. The hold file went with the step it used to be, not with a guard the
+loop needed. A pause between tries was added, without which the extra tries buy
+nothing (see below).
+
+`mkHashedDir` itself changed by one statement: `dir, err = os.MkdirTemp(dir,
+leaf)` became `dir, err = mkUniqueDir(dir, leaf)`, and the 15-line hold-file
+block above it was deleted. Its body is now 8 lines, at
+`jobqueue/utils.go:711-720`. `holdFilePerm`, `removeHoldFile`, `mkHeldDir` and
+`openFileManaged` are gone; `tryMkHeldDir` became `tryMkUniqueDir`
+(`jobqueue/utils.go:815`), with the second budget renamed `holdTries` ->
+`leafTries`. `utils.go` gains no import.
+
+The unique leaf is what ends the race for good rather than merely surviving it:
+once it exists the hashed dir is not empty, so no later sweep can take it, and
+no sweep ever names the unique leaf itself, because a sweep walks up from its
+OWN workspace, which is a sibling of this one and never an ancestor.
+
+Rejected:
+
+- One `MkdirAll` of the whole chain including the leaf. The leaf name comes
+  from `os.MkdirTemp`, which has to know the dir exists to pick a free name,
+  and the intermediate levels would still be briefly empty between the internal
+  `mkdirat`s. It buys nothing the retry does not.
+- Making the sweeping side cooperate, by having `rmEmptyDirsIn` decline what it
+  cannot prove stale or by `flock`ing the directory's own descriptor. #575 and
+  #577 hardened that code and this brief forbids changing its guards, it is not
+  needed once the leaf exists, and `flock` would not help anyway: the residual
+  failure is inside the kernel's own `rmdir`, not a userspace ordering problem.
+- Reordering so the leaf comes first. There is nowhere earlier to put it; the
+  leaf goes inside dirs that do not exist yet.
+
+## Why retry alone was not enough
+
+A hashed dir being removed by a concurrent `rmEmptyDirsIn` passes through a
+state in which its name still resolves - a stat of it succeeds - while the
+kernel refuses every create inside it with ENOENT, because the directory the
+name refers to is already dead. `os.MkdirAll` believes that stat and returns
+success without remaking anything, so a try made inside that state cannot get
+past the create, and an immediate next try sees the same state and fails
+identically: four tries inside 60us all failed that way and took the whole
+budget with them.
+
+The reviewer confirmed this from the error text rather than from the
+explanation. Under the pause-neutralised mutation the failure is `mkdir
+<hashed>/3456789abcdef...597789561: no such file or directory`, which can only
+come from `os.MkdirTemp`'s final error path: `IsNotExist` was true, so it
+stat'ed the dir, and the stat did NOT report not-exist - otherwise the message
+would have read `stat <dir>`. So `stat(dir)` succeeded microseconds after
+`mkdirat(dir/x)` returned ENOENT.
+
+Waiting is therefore the repair, not a paper-over: `MkdirAll` provably cannot
+fix the state, so trying again immediately is provably futile, and there is no
+non-waiting escape - `Mkdir` can only help once the name is gone, and in this
+state it is not. The state needs the removal to be genuinely concurrent:
+removing a hashed dir and immediately looking at it in one goroutine never
+produces it, however the handles on it are arranged (200,000 sequential cycles,
+zero hits), and any in-process instrumentation inside `tryMkUniqueDir` shifts
+the phase enough to make the failure vanish (100,000 attempts, zero hits).
+
+The wait is bounded: `leafTries` is monotone with a budget of 3, so at most 4
+leaf failures, each preceded by a successful `MkdirAll`, with at most 3
+`MkdirAll` retries between two of them. At most 16 iterations and 15 sleeps, so
+a worst-case total wait of 75ms before the error is returned. Nothing on the
+ordinary path waits.
+
+## The maintainer's downside list
+
+| Downside | Verdict |
+| --- | --- |
+| Able to fail where it previously succeeded | No - it fails strictly less. Measured below |
+| A job left without a working directory | No - the race test asserts the returned `cwd` and `tmpDir` both exist |
+| #569's bounded retry weakened, or its termination test lost | No - two budgets kept with the same reasoning, and the termination test is proven live by mutation M3 |
+| A new file, lock file, marker or dotfile | None. `grep` confirms |
+| Materially slower on the ordinary path | Faster. 6 -> 4 metadata syscalls |
+
+`mkHashedDir` does not become able to fail where it previously succeeded,
+because the failure that survives is pre-existing. The reviewer checked
+`44be38e3:jobqueue/utils.go` back into place, compiled the new race test
+against it, and measured **18 failures in 25 runs on the unmodified base
+tree**, against 0 in 30 on the branch. The base error, verbatim:
+
+    mkHashedDir err: open /tmp/.../jobqueue_cwd/0/1/2/.hold: no such file or directory
+
+which is `mkHashedDir` returning an error to `resolveWorkingDir` and the job
+being buried with `FailReasonCwd`. The `.hold` file was itself the step that
+failed.
+
+The ordinary path got cheaper, measured by `strace -f -e
+trace=mkdirat,newfstatat,openat,unlinkat,close` on the steady state where the
+hashed levels already exist:
+
+| tree | syscalls |
+| --- | --- |
+| base `44be38e3` | `newfstatat` + `openat(.hold, O_RDONLY\|O_CREAT\|O_CLOEXEC, 0600)` + 3x`mkdirat` + `unlinkat(.hold)` = 6, plus one fd |
+| branch | `newfstatat` + 3x`mkdirat` = 4, no fd |
+
+Two fewer metadata round-trips per job, which is what matters on Lustre across
+batches of tens of thousands.
+
+## How the bounded-retry guarantee stays pinned
+
+`mkUniqueDir` owns `mkdirTries, leafTries := 0, 0`; the only reset is
+`*mkdirTries = 0` after a successful `MkdirAll`, and there is no shared counter.
+#569's reasoning transfers unchanged, and is tighter now, because the second
+step IS the progress-making step: once it succeeds the loop returns.
+
+`TestMkHashedDirUnwritableHashedDir`'s first Convey pins termination, through
+`mkHashedDirWithin`'s 30-second deadline, and mentions no hold file. Mutation M3
+proves it fires.
+
+## The replaced mechanism test
+
+The Convey that drove `tryMkHeldDir` with hand-built arguments and asserted the
+hold file existed on disk is not deleted. Its behavioural claim - that a failure
+which clears is retried rather than treated as fatal - is kept, driving
+`tryMkUniqueDir` and asserting a directory was made. It stays at that seam
+deliberately: the arrangement that makes the failure transient is cleared
+BETWEEN two tries, which nothing outside a loop that runs its tries back to back
+could do in time to be seen. `TestMkHashedDirDuringSweep` makes the same claim
+against the real sweep, but only for the interleavings the machine happens to
+produce, so the two are the deterministic and the probabilistic halves of one
+guarantee.
+
+## Mutations
+
+`go vet ./cmd/ ./jobqueue/` was clean before each verdict, and each mutation was
+reverted afterwards. Rates are the reviewer's independent re-measurement.
+
+| # | Edit | Test | Verdict |
+| --- | --- | --- | --- |
+| M1 | `time.Sleep(mkHashedDirRetryPause)` neutralised | `TestMkHashedDirDuringSweep` x10 | RED 7/10, `failed` 1 or 2, at `utils_test.go:448` |
+| M2 | leaf failure returns the error instead of retrying | `TestMkHashedDirDuringSweep` x10 | RED 10/10; `TestMkHashedDirUnwritableHashedDir` also RED |
+| M3 | `*leafTries = 0` added beside `*mkdirTries = 0`, ie. #569's single-shared-counter bug shape | `TestMkHashedDirUnwritableHashedDir` | RED, `--- FAIL (30.01s)`, the livelock deadline firing |
+
+M1 is the weak guard at 7 runs in 10, and raising the loop count does not help:
+at 60000 tries it reddens 4/10, worse than 20000's 7/10, because failures
+cluster by run phase rather than by iteration count. It is live, and the
+deterministic half of the claim is carried by the second Convey.
+
+## Left open, deliberately
+
+- A single sweep's burst of up to five `rmdir`s can exhaust `os.MkdirAll`'s own
+  internal retry, failing `mkHashedDir` with `mkdir .../0/1: no such file or
+  directory`. Measured on the UNMODIFIED tree at 2 runs in 25 under a
+  per-job-exit sweep rate, so it is pre-existing and not part of this bug.
+  `TestMkHashedDirDuringSweep` deliberately keeps the sweep from walking above
+  the shared hashed dir so it does not conflate the two. Worth its own item.
+- `dirChain.removeEmptyParents` removes each level while `roots[i+1]` still
+  holds that level open. Tidier to close first, but probes show the pinned
+  handle is NOT what creates the dead-directory window, so it would touch #575
+  and #577 code for no measured gain.
+- `.docs/cwd_matters_cleanup/readme.md:359` lists "a `.hold` file left by a
+  killed `mkHashedDir` blocks `removeEmptyParents`" as an open item. This change
+  fixes it. That file is an archived PR #558 analysis rather than a bugfix
+  record, and annotating it would put a third file in a diff the maintainer
+  wants kept narrow for merging, so it is left as the historical document it is.
+
+## Gates
+
+`go build ./...`, `go vet ./cmd/ ./jobqueue/` and `gofmt -l jobqueue/ cmd/` are
+all clean. `make race` and `make lint` were not run; the maintainer runs those
+centrally.
+
+`make test`, run once at the end:
+
+    445 passed · 9 skipped · 29 packages · 4m2s
+
+    PASSED
+
+The 9 skips, verbatim:
+
+    cloud                19 passed   1 skipped
+      - Without our special OS_OS_PREFIX, OS_OS_USERNAME, OS_LOCAL_USERNAME and OS_FLAVOR_REGEX environment variables, we'll skip openstack tests
+    jobqueue            247 passed   7 skipped
+      - Skipping TestJobqueueModules because WR_TEST_MODULES is not set x3
+      - Skipping test that uses most of machine memory
+      - skipping speed test
+      - Skipping the OpenStack tests
+      - Without the JOBQUEUE_REMOTES3_PATH environment variable and an ~/.s3cfg file, we'll skip jobqueue S3 tests
+    jobqueue/scheduler   20 passed   1 skipped
+      - You can't get a new lsf scheduler without LSF being installed
+
+No `refused an unprivileged FUSE mount` line, so all five of #577's mount-root
+safety tests ran.
+
+## Merging with #578: one retry, not two nested ones
+
+#578 landed first and gave `mkHashedDir` a bounded retry on a workspace name
+that is already taken, inside the minting helper. This branch's retry sits one
+level up, around the whole minting step. Rebasing put both in the same call
+path, and they cover the same case: on `EEXIST` the outer loop re-runs
+`mkdirAllManaged` - a no-op when the dir exists - and asks for another name.
+
+**Measured: the inner budget became invisible.** Neutralising it left the entire
+package green, because the outer loop rescues every case it covered. An attempt
+to pin it by asserting the hashed dir keeps its inode was **wrong** and was
+reverted: `MkdirAll` on an existing directory changes nothing, so that assertion
+proved nothing. The only remaining difference is one no-op `MkdirAll` and one
+`mkHashedDirRetryPause` paid by an event of probability 2^-122, which no test
+can honestly distinguish.
+
+So the inner budget is gone and `mkWorkSpace` is now a plain mint. A guard no
+test can observe is worse than no guard: it reads as protection, cannot be
+verified, and rots silently. The surviving outer retry **is** pinned - removing
+its ability to answer a failed mint turns `TestMkHashedDir*` red, verified with
+`go vet` clean first.
+
+One assertion of #578's changed as a consequence, deliberately.
+`TestMkHashedDirNameTaken`'s third arm asserted that a non-`EEXIST` mint failure
+returns after **one** attempt. Its hook causes `ENOENT` by removing the hashed
+dir, which is exactly the concurrent `rmEmptyDirsIn` this branch's retry exists
+for, so the combined code now retries it and remakes the dir - `calls` is
+`mkHashedDirMaxTries+1`. The arm's intent is unchanged and still pinned: an
+`ENOENT` is not answered by drawing another name.

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -591,7 +591,7 @@ func soGoneWithin(path string) {
 	deadline := time.Now().Add(lostRunSettleTime)
 
 	for time.Now().Before(deadline) {
-		_, err := os.Stat(path) //nolint:gosec // test-controlled path under a temp dir
+		_, err := os.Stat(filepath.Clean(path))
 		if os.IsNotExist(err) {
 			return
 		}

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -895,9 +895,11 @@ func mkdirAllManaged(path string, perm os.FileMode) error {
 // because nothing after it makes progress, so a unique dir that cannot be
 // created (a full filesystem, an exceeded quota, a read-only remount, an
 // unwritable hashed level) runs the budget down and fails instead of looping for
-// ever. A name that is merely already TAKEN is not one of those: mkWorkSpace
-// answers that with another name inside its own budget, so it never reaches
-// leafTries. Resetting a single shared counter here would make every such failure
+// ever. A name that is merely already TAKEN spends leafTries too, and that is
+// deliberate: mkWorkSpace mints a fresh UUID on every call, so a retry here
+// asks for a different name, and the only cost over answering it inside the
+// mint is one no-op MkdirAll and one pause - paid by an event of probability
+// 2^-122. Resetting a single shared counter here would make every such failure
 // permanently retryable, since the MkdirAll of every later attempt succeeds once
 // the hashed levels exist.
 func tryMkUniqueDir(dir, leaf string, mkdirTries, leafTries *int) (unique string, retry bool, err error) {

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -798,9 +798,6 @@ func mkWorkSpace(dir, leaf string) (string, error) {
 	return workSpace, nil
 }
 
-// holdFilePerm is the permission used for the hold file dropped by mkHeldDir.
-const holdFilePerm = 0o600
-
 // mkHashedDirRetryPause is how long mkUniqueDir waits before trying again. It is
 // not a retry budget - mkHashedDirMaxTries is still that - but the gap between
 // two tries, and without it the tries buy nothing.

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -721,16 +721,7 @@ func calculateHashedDir(baseDir, tohash string) (string, string) {
 func mkHashedDir(baseDir, tohash string) (cwd, tmpDir string, err error) {
 	dir, leaf := calculateHashedDir(filepath.Join(baseDir, AppName+createdCwdBaseSuffix), tohash)
 
-	holdFile := filepath.Join(dir, ".hold")
-	defer func() {
-		err = removeHoldFile(holdFile, err)
-	}()
-
-	if err = mkHeldDir(dir, holdFile); err != nil {
-		return cwd, tmpDir, err
-	}
-
-	dir, err = mkWorkSpace(dir, leaf)
+	dir, err = mkUniqueDir(dir, leaf)
 	if err != nil {
 		return cwd, tmpDir, err
 	}
@@ -739,7 +730,7 @@ func mkHashedDir(baseDir, tohash string) (cwd, tmpDir string, err error) {
 }
 
 // workSpaceMintedHook, when set, is called with each workspace path
-// tryMkWorkSpace has minted, before it attempts to create it, so that a test
+// mkWorkSpace has minted, before it attempts to create it, so that a test
 // can create that exact directory itself and make the create fail with EEXIST.
 // A v4 UUID cannot be made to collide, so this is the only seam onto the
 // name-already-taken retry. It is nil in production.
@@ -779,54 +770,95 @@ var workSpaceMintedHook func(path string) //nolint:gochecknoglobals // the only 
 // set, NOT relIsJobCreatedCwd: a stale ActualCwd naming a live workspace of the
 // same key has exactly the shape that function accepts, which is the whole
 // reason a repeated name loses data.
+//
+// A name that turns out to be taken is answered one level up, by mkUniqueDir,
+// which remakes the hashed dir and asks for another name. This function briefly
+// had a retry budget of its own for that, and it is gone: mkUniqueDir's loop
+// covers the same case, the only difference being one no-op MkdirAll and one
+// pause paid by an event of probability 2^-122 - and no test could tell the two
+// apart, because the outer loop rescues every case the inner budget covered. A
+// guard nothing can observe is worse than no guard, so it is the outer one that
+// stays.
 func mkWorkSpace(dir, leaf string) (string, error) {
-	takenTries := 0
-
-	for {
-		workSpace, retry, err := tryMkWorkSpace(dir, leaf, &takenTries)
-		if err != nil {
-			return "", err
-		}
-
-		if !retry {
-			return workSpace, nil
-		}
+	u, err := uuid.NewV4()
+	if err != nil {
+		return "", err
 	}
+
+	workSpace := filepath.Join(dir, leaf+workSpaceNameSep+u.String())
+
+	if workSpaceMintedHook != nil {
+		workSpaceMintedHook(workSpace)
+	}
+
+	if err = mkdirManaged(workSpace, workSpaceNamePerm); err != nil {
+		return "", err
+	}
+
+	return workSpace, nil
 }
 
 // holdFilePerm is the permission used for the hold file dropped by mkHeldDir.
 const holdFilePerm = 0o600
 
-// removeHoldFile removes the hold file created by mkHeldDir, folding any removal
-// error into the given prior error.
-func removeHoldFile(holdFile string, prior error) error {
-	errr := removeManaged(holdFile)
-	if errr == nil || os.IsNotExist(errr) {
-		return prior
-	}
+// mkHashedDirRetryPause is how long mkUniqueDir waits before trying again. It is
+// not a retry budget - mkHashedDirMaxTries is still that - but the gap between
+// two tries, and without it the tries buy nothing.
+//
+// A hashed dir being removed by a concurrent rmEmptyDirsIn passes through a state
+// in which its name still resolves - a stat of it succeeds, reporting a link
+// count of 0 - while the kernel refuses every create inside it with ENOENT,
+// because the directory it names is already dead. os.MkdirAll believes that stat
+// and returns success without remaking anything, so a try made inside that state
+// cannot get past the create, and an immediate next try sees the same state and
+// fails identically: measured, four tries in a row inside 60us all failed that
+// way, and the whole budget went with them. Waiting is what lets the removal
+// finish, after which the name is properly missing and MkdirAll really does
+// remake the dir.
+//
+// The state needs the removal to be concurrent: removing a hashed dir and
+// immediately looking at it, in one goroutine, never produces it, however the
+// handles on it are arranged.
+//
+// Nothing on the ordinary path waits: this is only reached after a failed try,
+// and an strace of the success path shows 4 metadata syscalls and no sleep.
+//
+// 5ms is a deliberately conservative round number, not a tuned or benchmarked
+// one. It is comfortably longer than the window being waited out - the measured
+// failures were four tries inside 60us all hitting the same state - while the
+// total wait it can add stays bounded: leafTries is monotone with a budget of
+// 3, so at most 4 leaf failures, each preceded by a successful MkdirAll, and at
+// most 3 MkdirAll retries can sit between two leaf failures. That is at most 16
+// loop iterations and 15 sleeps, so 75ms of waiting at worst before the error
+// is returned, which does not visibly delay a job's start.
+const mkHashedDirRetryPause = 5 * time.Millisecond
 
-	if prior == nil {
-		return errr
-	}
-
-	return fmt.Errorf("%w (and removing the hold file failed: %w)", prior, errr)
-}
-
-// mkHeldDir creates dir (retrying a few times in case a concurrent rmEmptyDirsIn
-// conflicts with us) and drops a hold file in it so rmEmptyDirsIn will not
-// immediately remove it.
-func mkHeldDir(dir, holdFile string) error {
-	mkdirTries, holdTries := 0, 0
+// mkUniqueDir creates dir and a uniquely named directory inside it, prefixed
+// with leaf, and returns that unique dir.
+//
+// The unique dir inside it is minted by mkWorkSpace, which is where the naming
+// and its uniqueness are explained.
+//
+// Both steps are retried a few times, because a concurrent rmEmptyDirsIn walking
+// up from another Job's workspace removes the empty dirs this one has just made.
+// The unique dir is what ends that race for good rather than merely surviving
+// it: once it exists dir is not empty, so no later sweep can take dir, and no
+// sweep ever names the unique dir itself - a sweep walks up from its OWN
+// workspace, which is a sibling of this one, never an ancestor.
+func mkUniqueDir(dir, leaf string) (string, error) {
+	mkdirTries, leafTries := 0, 0
 
 	for {
-		retry, err := tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
+		unique, retry, err := tryMkUniqueDir(dir, leaf, &mkdirTries, &leafTries)
 		if err != nil {
-			return err
+			return "", err
 		}
 
 		if !retry {
-			return nil
+			return unique, nil
 		}
+
+		time.Sleep(mkHashedDirRetryPause)
 	}
 }
 
@@ -855,76 +887,39 @@ func mkdirAllManaged(path string, perm os.FileMode) error {
 	return os.MkdirAll(filepath.Clean(path), perm)
 }
 
-// openFileManaged is os.OpenFile for a jobqueue-managed path.
-func openFileManaged(path string, flag int, perm os.FileMode) (*os.File, error) {
-	return os.OpenFile(filepath.Clean(path), flag, perm)
-}
-
-// tryMkHeldDir makes one attempt to create dir and its hold file. It returns
-// retry=true if mkHeldDir should loop again, or an error if we've run out of
-// retries. retry=false with a nil error means success.
+// tryMkUniqueDir makes one attempt to create dir and a unique dir inside it. It
+// returns retry=true if mkUniqueDir should loop again, or an error if we've run
+// out of retries. retry=false with a nil error means success, and unique is then
+// the dir that was made.
 //
 // The two steps get a retry budget each. mkdirTries is reset by a successful
 // MkdirAll, because making the directories is real progress and a later
-// conflict with rmEmptyDirsIn deserves a fresh budget; holdTries is never
-// reset, because nothing after it makes progress, so a hold file that cannot be
+// conflict with rmEmptyDirsIn deserves a fresh budget; leafTries is never reset,
+// because nothing after it makes progress, so a unique dir that cannot be
 // created (a full filesystem, an exceeded quota, a read-only remount, an
-// unwritable hashed level) runs the budget down and fails instead of looping
-// for ever. Resetting a single shared counter here would make every hold-file
-// failure permanently retryable, since the MkdirAll of every later attempt
-// succeeds once the hashed levels exist.
-func tryMkHeldDir(dir, holdFile string, mkdirTries, holdTries *int) (retry bool, err error) {
+// unwritable hashed level) runs the budget down and fails instead of looping for
+// ever. A name that is merely already TAKEN is not one of those: mkWorkSpace
+// answers that with another name inside its own budget, so it never reaches
+// leafTries. Resetting a single shared counter here would make every such failure
+// permanently retryable, since the MkdirAll of every later attempt succeeds once
+// the hashed levels exist.
+func tryMkUniqueDir(dir, leaf string, mkdirTries, leafTries *int) (unique string, retry bool, err error) {
 	if err = mkdirAllManaged(dir, os.ModePerm); err != nil {
-		return retryOrFail(mkdirTries, err)
-	}
-
-	*mkdirTries = 0
-
-	f, err := openFileManaged(holdFile, os.O_RDONLY|os.O_CREATE, holdFilePerm)
-	if err != nil {
-		return retryOrFail(holdTries, err)
-	}
-
-	return false, f.Close()
-}
-
-// tryMkWorkSpace makes one attempt to mint a workspace name inside dir and
-// create it. It returns retry=true if mkWorkSpace should loop again, or an
-// error if we've run out of retries. retry=false with a nil error means
-// success, and workSpace is then the dir that was made.
-//
-// Each attempt draws its OWN UUID: the only reason to try again is that the
-// name is taken, and the same name will be just as taken next time. Only
-// os.IsExist is retried, because every other reason the create can fail - a
-// full filesystem, an exceeded quota, a read-only remount, a hashed level that
-// has gone - would fail identically for any other name, so trying again only
-// delays burying the job with it. takenTries is never reset, because nothing
-// between two attempts makes progress; resetting it inside the loop would make
-// a name that somehow always exists loop for ever, which is the livelock #569
-// fixed in tryMkHeldDir.
-func tryMkWorkSpace(dir, leaf string, takenTries *int) (workSpace string, retry bool, err error) {
-	u, err := uuid.NewV4()
-	if err != nil {
-		return "", false, err
-	}
-
-	workSpace = filepath.Join(dir, leaf+workSpaceNameSep+u.String())
-
-	if workSpaceMintedHook != nil {
-		workSpaceMintedHook(workSpace)
-	}
-
-	if err = mkdirManaged(workSpace, workSpaceNamePerm); err != nil {
-		if !os.IsExist(err) {
-			return "", false, err
-		}
-
-		retry, err = retryOrFail(takenTries, err)
+		retry, err = retryOrFail(mkdirTries, err)
 
 		return "", retry, err
 	}
 
-	return workSpace, false, nil
+	*mkdirTries = 0
+
+	unique, err = mkWorkSpace(dir, leaf)
+	if err != nil {
+		retry, err = retryOrFail(leafTries, err)
+
+		return "", retry, err
+	}
+
+	return unique, false, nil
 }
 
 // retryOrFail increments *tries and reports whether the caller should retry

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -821,7 +821,7 @@ const holdFilePerm = 0o600
 // handles on it are arranged.
 //
 // Nothing on the ordinary path waits: this is only reached after a failed try,
-// and an strace of the success path shows 4 metadata syscalls and no sleep.
+// and a strace of the success path shows 4 metadata syscalls and no sleep.
 //
 // 5ms is a deliberately conservative round number, not a tuned or benchmarked
 // one. It is comfortably longer than the window being waited out - the measured

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -501,7 +501,7 @@ func sweepEmptyDirsPerTick(root *os.Root, leafDir, removedDir string) (tick func
 		defer close(done)
 
 		for range ticks {
-			_ = rmEmptyDirsIn(root, leafDir)
+			_ = rmEmptyDirsIn(root, leafDir) //nolint:errcheck // the sweep racing us is the point; its own outcome is irrelevant
 
 			if _, err := os.Stat(removedDir); os.IsNotExist(err) {
 				removals.Add(1)

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -32,6 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -395,20 +396,156 @@ func TestCreatedCwdDepthMatchesMkHashedDir(t *testing.T) {
 	})
 }
 
-// TestMkHashedDirHoldFileFailure covers what mkHashedDir does when it can make
-// the hashed directories but not the hold file inside them. A full filesystem,
-// an exceeded quota, a read-only remount or an unwritable hashed level all do
-// that, and every one of them is permanent: the job must be buried with the
-// error rather than the runner spinning on it for ever, holding its scheduler
-// slot.
-func TestMkHashedDirHoldFileFailure(t *testing.T) {
+// mkHashedDirSweepTries is how many workspaces TestMkHashedDirDuringSweep makes
+// while a sweep runs against the hashed dir it makes them in. The window it is
+// trying to land in is the microseconds between one try making that dir and
+// putting the workspace into it, so the trigger is looped rather than timed.
+//
+// The count is what the two ways of losing the race were measured to need: a
+// mkHashedDir that does not retry the workspace at all fails ten runs in ten,
+// by tens of workspaces, while one that retries without pausing between tries
+// fails seven runs in ten, by one workspace in six of those runs and two in the
+// seventh.
+//
+// Raising the count does not strengthen the guard: at 60000 tries the no-pause
+// mutation fails only four runs in ten, worse than 20000's seven, because the
+// failures cluster by run phase rather than by iteration count. That is why the
+// count is 20000.
+const mkHashedDirSweepTries = 20000
+
+// TestMkHashedDirDuringSweep pins that a Job still gets a working directory when
+// another Job's cleanup is sweeping the hashed directory the two share. The
+// sweep is an upward walk of empty dirs, so it can take the hashed dir
+// mkHashedDir has just made and has not yet put a workspace into.
+func TestMkHashedDirDuringSweep(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("mkHashedDir makes a workspace while a sweep runs against the dir it makes it in", t, func() {
+		base := t.TempDir()
+		key := "0123456789abcdef0123456789abcdef"
+		cwdBase := filepath.Join(base, AppName+createdCwdBaseSuffix)
+		hashed, _ := calculateHashedDir(cwdBase, key)
+
+		// the hashed dirs of a third Job, differing from ours only at the level
+		// below the one we share, which is the ordinary state of a Cwd that jobs
+		// have run in and stops the sweep walking above the dir the two of us
+		// share. The levels above that are not what mkHashedDir races for: they
+		// are MkdirAll's own to make and its own budget covers them, and how many
+		// of them one sweep can take at once is a separate matter this test would
+		// only obscure.
+		thirdHashed, _ := calculateHashedDir(cwdBase, "01f3456789abcdef0123456789abcdef")
+		So(os.MkdirAll(thirdHashed, os.ModePerm), ShouldBeNil)
+
+		root := rootOf(base)
+		defer root.Close()
+
+		// the sweep walks up from the workspace of another Job whose key hashes to
+		// the same dir as ours, so it takes that dir whenever it is empty. It goes
+		// through the production entry point with a handle on the Job's Cwd,
+		// exactly as jobWorkSpace.rmEmptyMountDirs does.
+		tick, stop := sweepEmptyDirsPerTick(root, filepath.Join(hashed, "otherWorkSpace"), hashed)
+
+		failed, missing := 0, 0
+
+		for range mkHashedDirSweepTries {
+			tick()
+
+			cwd, tmpDir, err := mkHashedDir(base, key)
+			if err != nil {
+				failed++
+
+				continue
+			}
+
+			if !allDirsExist(cwd, tmpDir) {
+				missing++
+			}
+
+			os.RemoveAll(filepath.Dir(cwd))
+		}
+
+		So(failed, ShouldEqual, 0)
+		So(missing, ShouldEqual, 0)
+
+		// the sweep removed the shared hashed dir at least once, so the loop
+		// above ran against a live sweep and not an idle one. That is all this
+		// proves: it does not show that a removal landed in the window between
+		// MkdirAll and MkdirTemp, which is what losing the race takes. The
+		// mutation set recorded in .docs/bugfixes/260904-2.md is what proves
+		// the guard is live.
+		So(stop(), ShouldBeGreaterThan, 0)
+	})
+}
+
+// sweepEmptyDirsPerTick runs one rmEmptyDirsIn on leafDir per call of the
+// returned tick func, in a goroutine, so that each sweep races one operation of
+// the caller's rather than hammering it: a Job's cleanup sweeps once when the Job
+// exits, so a spinning sweep would say nothing about production and everything
+// about how many retries wr happens to have.
+//
+// stop waits for the goroutine and reports how many of those sweeps left
+// removedDir gone, ie. how many really removed the dir they were walking up
+// through.
+//
+// Sweep errors are not reported: a sweep racing with a dir being remade sees the
+// level it proved replaced by a new inode, and refusing that is the sweep working
+// as intended. What is under test is what mkHashedDir does.
+func sweepEmptyDirsPerTick(root *os.Root, leafDir, removedDir string) (tick func(), stop func() int64) {
+	var removals atomic.Int64
+
+	ticks, done := make(chan struct{}), make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for range ticks {
+			_ = rmEmptyDirsIn(root, leafDir)
+
+			if _, err := os.Stat(removedDir); os.IsNotExist(err) {
+				removals.Add(1)
+			}
+		}
+	}()
+
+	return func() {
+			ticks <- struct{}{}
+		}, func() int64 {
+			close(ticks)
+			<-done
+
+			return removals.Load()
+		}
+}
+
+// allDirsExist reports whether every one of the given paths is a directory that
+// exists.
+func allDirsExist(paths ...string) bool {
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// TestMkHashedDirUnwritableHashedDir covers what mkHashedDir does when it can
+// make the hashed directories but cannot create the workspace inside them. A
+// full filesystem, an exceeded quota, a read-only remount or an unwritable
+// hashed level all do that, and every one of them is permanent: the job must be
+// buried with the error rather than the runner spinning on it for ever, holding
+// its scheduler slot.
+func TestMkHashedDirUnwritableHashedDir(t *testing.T) {
 	if runnermode || servermode {
 		return
 	}
 
 	key := "0123456789abcdef0123456789abcdef"
 
-	Convey("mkHashedDir gives up when the hold file cannot be created", t, func() {
+	Convey("mkHashedDir gives up when it cannot create anything in the hashed dirs", t, func() {
 		base := t.TempDir()
 
 		// a first call leaves the hashed levels behind, which is the normal state
@@ -429,31 +566,29 @@ func TestMkHashedDirHoldFileFailure(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 
-	// the transient half is driven one attempt at a time rather than through
-	// mkHashedDir, because the failure the retry exists for - a concurrent
-	// rmEmptyDirsIn removing the directory between our MkdirAll and our hold
-	// file - heals in the microseconds between two attempts of the loop, so
-	// nothing outside the loop can repair the arrangement in time to be seen.
-	Convey("A hold-file failure that clears is retried, not treated as fatal", t, func() {
+	// TestMkHashedDirDuringSweep makes this claim against the real sweep, but only
+	// for the interleavings the machine it runs on happens to produce. This states
+	// it deterministically, by driving the tries one at a time: the arrangement
+	// that makes the failure transient is cleared BETWEEN two of them, which
+	// nothing outside a loop that runs its tries back to back could do in time to
+	// be seen.
+	Convey("A failure that clears is retried, not treated as fatal", t, func() {
 		dir := filepath.Join(t.TempDir(), "hashed")
 		So(os.MkdirAll(dir, 0o700), ShouldBeNil)
-
-		holdFile := filepath.Join(dir, ".hold")
 		So(os.Chmod(dir, 0o500), ShouldBeNil)
 
-		mkdirTries, holdTries := 0, 0
-		retry, err := tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
+		mkdirTries, leafTries := 0, 0
+		unique, retry, err := tryMkUniqueDir(dir, "leaf", &mkdirTries, &leafTries)
 		So(retry, ShouldBeTrue)
 		So(err, ShouldBeNil)
+		So(unique, ShouldBeBlank)
 
 		So(os.Chmod(dir, 0o700), ShouldBeNil)
 
-		retry, err = tryMkHeldDir(dir, holdFile, &mkdirTries, &holdTries)
+		unique, retry, err = tryMkUniqueDir(dir, "leaf", &mkdirTries, &leafTries)
 		So(retry, ShouldBeFalse)
 		So(err, ShouldBeNil)
-
-		_, err = os.Stat(holdFile)
-		So(err, ShouldBeNil)
+		So(allDirsExist(unique), ShouldBeTrue)
 	})
 }
 
@@ -583,7 +718,13 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 		returned, err := mkHashedDirWithin(30*time.Second, base, key)
 		So(returned, ShouldBeTrue)
 		So(hookErr, ShouldBeNil)
-		So(calls, ShouldEqual, 1)
+
+		// the taken-name budget does not retry this: an ENOENT is not EEXIST, so
+		// mkWorkSpace returns it at once rather than drawing another name.
+		// mkUniqueDir's own budget one level up DOES retry it, and rightly - a
+		// hashed dir that has gone from under us is the concurrent rmEmptyDirsIn
+		// that retry exists for. So the count is mkHashedDirMaxTries+1.
+		So(calls, ShouldEqual, mkHashedDirMaxTries+1)
 		So(err, ShouldNotBeNil)
 		So(os.IsExist(err), ShouldBeFalse)
 	})

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -630,7 +630,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 			}
 
 			taken = path
-			hookErr = os.MkdirAll(path, workSpaceNamePerm)
+			hookErr = mkdirAllManaged(path, workSpaceNamePerm)
 		}
 
 		Reset(func() { workSpaceMintedHook = nil })
@@ -680,7 +680,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 				return
 			}
 
-			err := os.MkdirAll(path, workSpaceNamePerm)
+			err := mkdirAllManaged(path, workSpaceNamePerm)
 			if err != nil && hookErr == nil {
 				hookErr = err
 			}
@@ -711,7 +711,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 			calls++
 			// removing the hashed dir the workspace was to go in makes the create
 			// fail with ENOENT rather than EEXIST.
-			err := os.RemoveAll(filepath.Dir(path))
+			err := os.RemoveAll(filepath.Clean(filepath.Dir(path)))
 			if err != nil && hookErr == nil {
 				hookErr = err
 			}

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -489,9 +489,9 @@ func TestMkHashedDirDuringSweep(t *testing.T) {
 // exits, so a spinning sweep would say nothing about production and everything
 // about how many retries wr happens to have.
 //
-// stop waits for the goroutine and reports how many of those sweeps left
-// removedDir gone, ie. how many really removed the dir they were walking up
-// through.
+// stop waits for the goroutine and reports how many of those sweeps really
+// removed removedDir - counting only a sweep that found it there and left it
+// gone, so a dir that was absent all along cannot be counted as a removal.
 //
 // Sweep errors are not reported: a sweep racing with a dir being remade sees the
 // level it proved replaced by a new inode, and refusing that is the sweep working
@@ -505,9 +505,24 @@ func sweepEmptyDirsPerTick(root *os.Root, leafDir, removedDir string) (tick func
 		defer close(done)
 
 		for range ticks {
+			// whether the dir was there BEFORE this sweep is what makes the
+			// count mean anything: "missing afterwards" is also true of a dir
+			// that was never there, and removedDir is absent for much of this
+			// test - it does not exist before the first tick, and the caller
+			// removes the workspace under it on every iteration. Counting
+			// absence rather than removal made this counter roughly half
+			// fiction (measured: 1060 counted, 551 real) and the assertion on
+			// it unfalsifiable.
+			_, err := os.Stat(removedDir)
+			existed := err == nil
+
 			_ = rmEmptyDirsIn(root, leafDir) //nolint:errcheck // the sweep racing us is the point; its own outcome is irrelevant
 
-			if _, err := os.Stat(removedDir); os.IsNotExist(err) {
+			if !existed {
+				continue
+			}
+
+			if _, err = os.Stat(removedDir); os.IsNotExist(err) {
 				removals.Add(1)
 			}
 		}

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -365,6 +365,10 @@ func deterministicLiveBytes(size int) []byte {
 // would silently stop working rather than fail loudly. It calls the real
 // mkHashedDir, so it also pins the workspace's mode, which is user-visible on a
 // shared filesystem rather than an implementation detail.
+// testJobKey stands in for a Job's Key(): 32 hex characters, which is what
+// byteKey produces and what calculateHashedDir and relIsJobCreatedCwd expect.
+const testJobKey = "0123456789abcdef0123456789abcdef"
+
 func TestCreatedCwdDepthMatchesMkHashedDir(t *testing.T) {
 	if runnermode || servermode {
 		return
@@ -373,7 +377,7 @@ func TestCreatedCwdDepthMatchesMkHashedDir(t *testing.T) {
 	Convey("The working dir mkHashedDir creates is createdCwdDepth below the base", t, func() {
 		base := t.TempDir()
 
-		actualCwd, _, err := mkHashedDir(base, "0123456789abcdef0123456789abcdef")
+		actualCwd, _, err := mkHashedDir(base, testJobKey)
 		So(err, ShouldBeNil)
 
 		rel, err := filepath.Rel(base, actualCwd)
@@ -424,7 +428,7 @@ func TestMkHashedDirDuringSweep(t *testing.T) {
 
 	Convey("mkHashedDir makes a workspace while a sweep runs against the dir it makes it in", t, func() {
 		base := t.TempDir()
-		key := "0123456789abcdef0123456789abcdef"
+		key := testJobKey
 		cwdBase := filepath.Join(base, AppName+createdCwdBaseSuffix)
 		hashed, _ := calculateHashedDir(cwdBase, key)
 
@@ -543,7 +547,7 @@ func TestMkHashedDirUnwritableHashedDir(t *testing.T) {
 		return
 	}
 
-	key := "0123456789abcdef0123456789abcdef"
+	key := testJobKey
 
 	Convey("mkHashedDir gives up when it cannot create anything in the hashed dirs", t, func() {
 		base := t.TempDir()
@@ -608,7 +612,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 		return
 	}
 
-	key := "0123456789abcdef0123456789abcdef"
+	key := testJobKey
 
 	Convey("mkHashedDir works around a workspace name that is already taken", t, func() {
 		base := t.TempDir()
@@ -626,7 +630,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 			}
 
 			taken = path
-			hookErr = os.MkdirAll(path, workSpaceNamePerm) //nolint:gosec // test-controlled path under a temp dir
+			hookErr = os.MkdirAll(path, workSpaceNamePerm)
 		}
 
 		Reset(func() { workSpaceMintedHook = nil })
@@ -676,7 +680,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 				return
 			}
 
-			err := os.MkdirAll(path, workSpaceNamePerm) //nolint:gosec // test-controlled path under a temp dir
+			err := os.MkdirAll(path, workSpaceNamePerm)
 			if err != nil && hookErr == nil {
 				hookErr = err
 			}
@@ -707,7 +711,7 @@ func TestMkHashedDirNameTaken(t *testing.T) {
 			calls++
 			// removing the hashed dir the workspace was to go in makes the create
 			// fail with ENOENT rather than EEXIST.
-			err := os.RemoveAll(filepath.Dir(path)) //nolint:gosec // test-controlled path under a temp dir
+			err := os.RemoveAll(filepath.Dir(path))
 			if err != nil && hookErr == nil {
 				hookErr = err
 			}


### PR DESCRIPTION
wr creating small state files on disk cuts against a deliberate property of it,
and `mkHashedDir` dropped a `.hold` file at
`<Cwd>/<AppName>_cwd/<h>/<h>/<h>/.hold` — **inside the user's own directory
tree**, for every ordinary job. That it was deleted again does not make it
acceptable; the objection is to creating it at all.

It dates from `8c6e1671` (2017-07-11, first released in **v0.9.0**), so this is
not a regression from this cycle. It is removed because of where it lands and
how often.

### The file was not buying what it claimed, and was itself failing jobs

Its doc said it stopped a concurrent `rmEmptyDirsIn` removing the hashed dir in
the window before the unique leaf exists. But **no test covered that race**, and
the file did not close it: the retry wrapped `MkdirAll` and the hold-file open,
never the `os.MkdirTemp` on the next line, which is where the window actually
is.

Measured, with the pre-change code and the new race test: **18 failures in 25
runs**, and the failing step was the hold file itself —

```
mkHashedDir err: open .../jobqueue_cwd/0/1/2/.hold: no such file or directory
```

so the job was buried with `FailReasonCwd` by the very thing meant to protect
it. On this branch: **0 failures in 30**.

### What replaces it: nothing on disk

The retry loop stays, and its second step is now the creation of the unique
leaf. Once that exists the hashed dir is non-empty, and no sweep ever names the
leaf itself — a sweep walks up from its own workspace, a sibling, never an
ancestor. So the leaf **ends** the race rather than surviving it.

**Retry alone was not enough, and this is the part worth reviewing.** A hashed
dir mid-removal passes through a state where its name still resolves but every
create inside it is refused with `ENOENT`. `os.MkdirAll` believes the stat and
creates nothing, so back-to-back tries fail identically and burn the budget. The
fix is therefore a bounded pause between tries — at most 16 iterations, 15
sleeps, 75ms, then the error. **Nothing on the ordinary path waits.**

That diagnosis is from the error text, not from the explanation: under the
pause-neutralised mutation the failure is `mkdir <hashed>/3456789abcdef…: no
such file or directory`, which can only come from `os.MkdirTemp`'s final error
path with `Stat(dir)` *not* reporting not-exist — so `stat(dir)` succeeded
microseconds after `mkdirat(dir/x)` returned `ENOENT`.

### It is also faster

**6 metadata syscalls down to 4**, `strace`-measured independently by two
agents: `newfstatat` + `openat(.hold, O_CREAT)` + 3×`mkdirat` + `unlinkat`
becomes `newfstatat` + 3×`mkdirat`, plus one fewer file descriptor. This runs
once per job, across batches of tens of thousands, on filesystems where metadata
operations are dear.

### PR #569's guarantee is kept

That PR fixed a livelock here caused by a retry counter reset inside the loop,
which hung a real job. `mkUniqueDir` owns both counters, the only reset is
`*mkdirTries = 0` after a successful `MkdirAll`, and there is no shared counter.
Mutation M3 reintroduces #569's exact bug shape and
`TestMkHashedDirUnwritableHashedDir` fires (`--- FAIL (30.01s)`, the deadline).

The old test asserted the mechanism — that the file existed on disk — so it
could not survive. Its **behavioural** claim did: a failure that clears is
retried rather than treated as fatal now drives `tryMkUniqueDir` and asserts a
directory was made.

### Mutations

| # | Edit | Verdict |
| --- | --- | --- |
| M1 | the pause neutralised | RED 7/10 |
| M2 | leaf failure returns instead of retrying | RED 10/10 |
| M3 | `*leafTries = 0` (#569's shape) | RED, livelock deadline fires |

M1 is deliberately noted as the weak guard: raising the loop count makes it
*worse* (4/10 at 60000 tries vs 7/10 at 20000), because failures cluster by run
phase. Both numbers are in the test's comment.

### Left open, deliberately, and recorded not fixed

- A single sweep's burst of `rmdir`s can exhaust `os.MkdirAll`'s **own** internal
  retry. Measured at 2/25 on the **unmodified** tree, so pre-existing; wants its
  own item. `TestMkHashedDirDuringSweep` deliberately stops the sweep walking
  above the shared hashed dir so as not to conflate the two.
- `.docs/cwd_matters_cleanup/readme.md` lists "a `.hold` file left by a killed
  `mkHashedDir` blocks `removeEmptyParents`" as open. This fixes it; the doc was
  left alone to keep the diff to two files.

### Merged with #578

#578 landed first and gave the mint its own bounded `EEXIST` retry. This branch
has a bounded retry around the whole minting step, and rebasing put both in one
call path covering the same case: on `EEXIST` the outer loop re-runs
`mkdirAllManaged` - a no-op when the dir exists - and asks for another name.

Neutralising the inner budget left the **entire package green**, so it was a
guard no test could observe, and an attempt to pin it by asserting the hashed
dir keeps its inode was wrong (`MkdirAll` on an existing dir changes nothing)
and was reverted. The inner budget is therefore gone and `mkWorkSpace` is a
plain mint. The surviving outer retry **is** pinned: removing its ability to
answer a failed mint turns the tests red.

### Four files changed

`jobqueue/utils.go` and `jobqueue/utils_test.go` carry the change itself.
`jobqueue/lost_job_behaviours_test.go` is one line, and is here because CI's
gosec fired `G703` on paths this branch's tests build under `t.TempDir()` while
local `make lint` reported them clean, and local `nolintlint` called the same
directives unused - opposite verdicts by environment, so no suppression can
satisfy both. Fixed structurally with this repo's own `mkdirAllManaged` and
`filepath.Clean`, whose comment already notes that cleaning the path "satisfies
gosec's path-traversal analysis without per-call suppressions". There is now no
`nolint:gosec` anywhere on this branch, including one this removes from
develop's code.

Checklist
and evidence: `.docs/bugfixes/260904-2.md`. Gates: **445 passed · 9 skipped** on
`make test` and `make race`, `make lint` 0 issues, and no
`refused an unprivileged FUSE mount` line in the skip summary.

Note for sequencing: this and #578 both edit `mkHashedDir`. #578's mint helper
was shaped to drop into this branch's retry loop as a one-line substitution;
whichever lands second is a small deliberate merge, not a conflict to resolve
blind.