### PR TITLE
Lock the client while tests read its socket

### DIFF
--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -1,0 +1,71 @@
+# 260905-1: Data race on Client.sock in TestSubscriptionReconnectDuringManagerShutdown
+
+Branch `fix-subscription-sock-race`, based on `origin/develop` at `4e5739fc`.
+Recorded finding: `.docs/bugfixes/260904-3.md` on
+`origin/record-subscription-shutdown-race`.
+
+- [ ] `go test -race` intermittently reports a data race on a `*Client`'s
+      `sock` field during `TestSubscriptionReconnectDuringManagerShutdown`. The
+      write is production code and is correct: `(*Client).reconnect` replaces
+      `c.sock` and `c.ServerInfo` under `c.Lock()`
+      (`jobqueue/subscription.go:925-931`), reached from the subscription's
+      poll goroutine via `poll` -> `reconnectAfterPollError` -> `reconnect` ->
+      `reconnectOnce` (`jobqueue/subscription.go:259, 349, 371, 394`). The
+      unsynchronised side is the test, which reads `jq.sock` with no lock held
+      at `jobqueue/subscription_test.go:1776`, `:1784` and `:1911`.
+
+  - Red command (repeat runs of the one test under `-race`, 4 at a time; the
+    test binary is built once so each iteration is a bare run):
+
+    ```
+    go test -race -c -o /tmp/jq.race.test ./jobqueue/
+    cd jobqueue
+    for i in $(seq 1 20); do
+      /tmp/jq.race.test -test.run '^TestSubscriptionReconnectDuringManagerShutdown$' \
+        -test.count=1 > /tmp/logs/run$i.log 2>&1 &
+      while [ "$(jobs -r | wc -l)" -ge 4 ]; do wait -n; done
+    done
+    wait
+    grep -l 'DATA RACE' /tmp/logs/*.log | wc -l
+    ```
+
+  - Measured reproduction rate on this box (4 cores, otherwise idle):
+    **N=20 runs, M=1 failure (5%)** at 4 concurrent runs, and **N=24, M=1
+    (4.2%)** at 8 concurrent runs, so extra load buys nothing. A passing run of
+    this test takes ~18s; the run that reddens takes ~75s, matching the 74.79s
+    in the recorded finding, so the race only fires on the runs whose reconnect
+    actually happens. Logs kept under
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs/`
+    (`baseline20/`, `load24/`); the failing ones are `baseline20/run14.log`
+    and `load24/run7.log`. Two further `load24` runs failed at 8-way
+    concurrency for an unrelated reason of my harness's making: two test
+    processes picked the same free port
+    (`bind: address already in use`, `load24/run9.log`, `run14.log`).
+
+  - Failing excerpt, `baseline20/run14.log`:
+
+    ```
+    WARNING: DATA RACE
+    Write at 0x00c00056c118 by goroutine 477:
+      jobqueue.(*Client).reconnect()
+          jobqueue/subscription.go:928 +0x25e
+      jobqueue.(*Subscription).reconnectOnce()
+          jobqueue/subscription.go:394 +0xce
+      jobqueue.(*Subscription).reconnect()
+          jobqueue/subscription.go:371 +0x104
+      jobqueue.(*Subscription).reconnectAfterPollError()
+          jobqueue/subscription.go:349 +0x76
+      jobqueue.(*Subscription).poll()
+          jobqueue/subscription.go:259 +0xb8
+      jobqueue.(*Client).subscribe.gowrap1()
+          jobqueue/subscription.go:667 +0x70
+
+    Previous read at 0x00c00056c118 by goroutine 9:
+      jobqueue.TestSubscriptionReconnectDuringManagerShutdown.func6()
+          jobqueue/subscription_test.go:1911 +0x68e
+      [... goconvey frames ...]
+
+    --- FAIL: TestSubscriptionReconnectDuringManagerShutdown (75.00s)
+        testing.go:1712: race detected during execution of test
+    FAIL
+    ```

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -4,7 +4,7 @@ Branch `fix-subscription-sock-race`, based on `origin/develop` at `4e5739fc`.
 Recorded finding: `.docs/bugfixes/260904-3.md` on
 `origin/record-subscription-shutdown-race`.
 
-- [ ] `go test -race` intermittently reports a data race on a `*Client`'s
+- [x] `go test -race` intermittently reports a data race on a `*Client`'s
       `sock` field during `TestSubscriptionReconnectDuringManagerShutdown`. The
       write is production code and is correct: `(*Client).reconnect` replaces
       `c.sock` and `c.ServerInfo` under `c.Lock()`
@@ -111,3 +111,38 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
       = 84 runs) 9 runs had that profile and 3 of them reported the race, so
       the race fires in roughly a third of the runs that reach a reconnect and
       in ~3.6% of runs overall.
+
+## Found while fixing this, not fixed
+
+- [ ] `unsubscribeRejectedWithin` closes the client's socket with no lock held:
+      `_ = sub.client.sock.Close()` at `jobqueue/subscription_test.go:3340`.
+      It is the same class as the bug above and it is called from the same
+      Convey block (`:1926`), whose poll goroutine is the `reconnect` writer,
+      so if that branch ever runs during a reconnect the race is back.
+
+  - Left unchecked deliberately: I have no red command for it. The branch only
+    runs when `unsubscribeRejectedReplacement` fails to return within
+    `unreadPingWait`, which is the case `So(returned, ShouldBeTrue)` at
+    `:1927` asserts does not happen, and it did not run in any of the 46
+    post-fix runs.
+  - Taking the client's lock there is NOT the fix and must not be attempted
+    blind: the goroutine this `Close` exists to unblock is inside
+    `requestWithin`, which holds `c.Lock()` while it waits on the socket
+    (`jobqueue/client.go:501-503`), so the closer would block behind the very
+    request it is trying to interrupt. The workable shape is to capture the
+    socket under the lock before the goroutine is started and close that
+    captured value, accepting that a reconnect may have swapped it.
+
+- [ ] `So(returned, ShouldBeTrue)` at `jobqueue/subscription_test.go:1927`
+      failed once in 40 runs of the M1 mutation tree
+      (`logs/M1/run6.log`: `Line 1927: Expected: true Actual: false`, whole
+      test 17.36s, no DATA RACE in that log).
+
+  - Left unchecked: one occurrence, and I cannot attribute it. It is either an
+    independent flake in the existing test, or the second harm of the unlocked
+    read that M1 restores - a deadline set on a socket `reconnect` had already
+    replaced leaves the unsubscribe request on the wide `ClientMinRequestTimeout`
+    floor instead of the narrowed one, which is exactly what makes it miss
+    `unreadPingWait`. It did not occur in the 40 post-fix runs, nor in the 44
+    pre-fix runs of the unmutated tree, so it is at most a ~1-in-40 event and
+    needs its own reproduction before anyone changes that test.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -91,3 +91,23 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     `(*Client).reconnect` 20 times while another sets and reads the receive
     deadline through the helpers. Both goroutines count failures; the test
     asserts the counts once, so no `So()` sits in a loop.
+  - Mutation testing, both mutants `go vet ./cmd/ ./jobqueue/` clean before
+    their verdict was taken (`logs/M1.vet`, `logs/M2.vet`, both empty, exit 0):
+    - **M1, the fix reverted**: the three call sites put back to the unlocked
+      `jq.sock.SetOption`/`GetOption`, helpers and new test left in place.
+      **N=40 runs, M=1 DATA RACE** (`logs/M1/run32.log`, read at
+      `subscription_test.go:1922`, write at `subscription.go:928`), i.e. the
+      recorded race returns at the pre-fix rate.
+    - **M2, the helper locks removed**: `Lock`/`defer Unlock` deleted from both
+      helpers, everything else untouched. `TestSubscriptionReconnectSocketSwap`
+      **N=10 runs, M=10 DATA RACE** (`logs/M2/`), same
+      `(*Client).reconnect` write line, so the new test is a real guard and not
+      a dead one.
+    - **Fixed tree**: the same 40-run command, **N=40, M=0**, no race and no
+      other failure (`logs/FIX40/`), and `TestSubscriptionReconnectSocketSwap`
+      N=5, M=0 (`logs/FIXSWAP/`). The green is not vacuous: 6 of those 40 runs
+      took over 60s, which is the profile of a run whose subscription reconnect
+      actually fires. Across the three unfixed batches (baseline20, load24, M1
+      = 84 runs) 9 runs had that profile and 3 of them reported the race, so
+      the race fires in roughly a third of the runs that reach a reconnect and
+      in ~3.6% of runs overall.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -69,3 +69,25 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
         testing.go:1712: race detected during execution of test
     FAIL
     ```
+
+  - Fixed in `jobqueue/subscription_test.go` (132 insertions, 4 deletions) plus
+    a doc-comment-only line in `jobqueue/client.go:526-527`. Two test-side
+    helpers, `setRecvDeadlineUnderLock` and `recvDeadlineUnderLock`
+    (`jobqueue/subscription_test.go:2068-2085`), take the client's lock and do
+    the option call inside it; the three sites now call them
+    (`:1787`, `:1795`, `:1922`). No socket pointer is returned to the caller,
+    so none can escape the lock: `reconnect` closes the old socket after it
+    unlocks (`jobqueue/subscription.go:933-935`), so a stale-but-valid socket
+    is NOT acceptable here - `SetOption` on it would return "closed" and, worse,
+    would set the deadline on a socket the client has already discarded, which
+    is not what the assertions at those sites mean. The getter helper reuses the
+    production `(*Client).recvDeadline` (`jobqueue/client.go:527`) under the
+    lock rather than duplicating its `GetOption` and type assertion; that is
+    what the comment line documents. Production gained no locks: every
+    production read of `c.sock` is already under `c.Lock()`.
+  - Regression test `TestSubscriptionReconnectSocketSwap`
+    (`jobqueue/subscription_test.go:1970`) encodes the minimal repro
+    deterministically in ~1s: one goroutine runs the production writer
+    `(*Client).reconnect` 20 times while another sets and reads the receive
+    deadline through the helpers. Both goroutines count failures; the test
+    asserts the counts once, so no `So()` sits in a loop.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -146,3 +146,57 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     `unreadPingWait`. It did not occur in the 40 post-fix runs, nor in the 44
     pre-fix runs of the unmutated tree, so it is at most a ~1-in-40 event and
     needs its own reproduction before anyone changes that test.
+
+## PR #581 review findings on this PR's own test code
+
+- [ ] The comment says `socketSwapDeadlineOps` is a backstop against a reconnect
+      loop that never finishes, but limiting the deadline goroutine's iterations
+      does not end the test if reconnect stalls; `wg.Wait()` still waits for the
+      reconnect goroutine. Reword to avoid implying this bound prevents the test
+      from hanging.
+
+  - Source: Copilot on PR #581, thread `PRRT_kwDOAKD33M6fmTUQ`, comment
+    `3941825155`, on `jobqueue/subscription_test.go:92`.
+  - Red command (throwaway harness, no repo changes; it reproduces the
+    two-goroutine/one-`wg.Wait()` shape of `reconnectWhileUsingRecvDeadline`
+    with a reconnect goroutine that never finishes):
+    `cd /tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/f1 && go run .` -> exit 3, output kept at
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs2/f1-timeafter.log`:
+
+    ```
+    deadline goroutine hit its ops bound after 21.423547119s
+    still inside wg.Wait() after 30s: the ops bound did not end the test
+    ```
+
+    So the claim is false as written: the ops bound ends one goroutine, not the
+    test. It also shows the bound's real wall-clock size on this box: 20000
+    iterations of `time.After(100us)` on an otherwise idle process take ~21s,
+    not the ~2s the constants suggest, because a parked Go process wakes on a
+    ~1ms granularity.
+
+- [ ] Using `time.After` inside the loop allocates a new timer every iteration
+      (even if `<-done` is already ready), which is avoidable overhead in a
+      concurrency stress test. Use a ticker (or reusable timer) created once and
+      stop it on exit.
+
+  - Source: Copilot on PR #581, thread `PRRT_kwDOAKD33M6fmTUX`, comment
+    `3941825167`, on `jobqueue/subscription_test.go:2050`.
+  - Red command (throwaway benchmark of the three loop shapes at the loop's own
+    100us wait): `cd /tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/f2 && go test -bench . -benchtime=2s ./...`,
+    output kept at `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs2/f2-bench.log`:
+
+    ```
+    BenchmarkTimeAfter-4      2287    1069669 ns/op    248 B/op    3 allocs/op
+    BenchmarkReusedTimer-4    2260    1069292 ns/op      0 B/op    0 allocs/op
+    BenchmarkTicker-4         2978     899668 ns/op      0 B/op    0 allocs/op
+    ```
+
+    Three allocations per iteration confirmed. It also decides ticker vs timer:
+    the reused timer keeps the pacing `time.After` gives (1069292 vs 1069669
+    ns/op, indistinguishable) because both measure the wait from the top of each
+    iteration, whereas the ticker's fixed period fires early once an iteration
+    outlasts it and runs ~16% more iterations in the same time. The loop needs
+    the former, so the timer is the replacement, not the ticker.
+  - Baseline runtime of `TestSubscriptionReconnectSocketSwap` under `-race`,
+    5 runs before any change: 0.78s, 1.03s, 0.88s, 0.93s, 0.60s (mean 0.84s).
+    Logs `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs2/before-run1..5.log`.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -193,7 +193,7 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     test runner passes `-timeout 40m` (`internal/testsuite/planner.go:40`,
     `runner.go:762,776`), which is go test's own timeout.
 
-- [ ] Using `time.After` inside the loop allocates a new timer every iteration
+- [x] Using `time.After` inside the loop allocates a new timer every iteration
       (even if `<-done` is already ready), which is avoidable overhead in a
       concurrency stress test. Use a ticker (or reusable timer) created once and
       stop it on exit.
@@ -219,3 +219,40 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
   - Baseline runtime of `TestSubscriptionReconnectSocketSwap` under `-race`,
     5 runs before any change: 0.78s, 1.03s, 0.88s, 0.93s, 0.60s (mean 0.84s).
     Logs `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs2/before-run1..5.log`.
+  - Fixed in `countRecvDeadlineErrors` (`jobqueue/subscription_test.go:2043`):
+    one `time.NewTimer(socketSwapDeadlineWait)` before the loop with
+    `defer timer.Stop()`, `<-timer.C` in the select, and
+    `timer.Reset(socketSwapDeadlineWait)` as the last statement of the loop
+    body. The reset is at the END of the body on purpose: that starts each wait
+    when the previous iteration's work finished, which is what `time.After`
+    evaluated at the top of the select did. A ticker was rejected - its fixed
+    period leaves a tick buffered whenever an iteration outlasts it, so the next
+    receive returns at once instead of granting the intended gap, which would
+    change how often the deadline operations meet a socket swap.
+  - The old `errs++; continue` had to go, because a `continue` past an
+    end-of-body reset leaves the timer unarmed. The two-step deadline check
+    moved into a new bool-returning helper `recvDeadlineRoundTripped`, so the
+    loop body now has exactly two paths and every path that loops round hits the
+    reset. The implementor proved it by injection rather than by reading: with
+    the check forced to fail every iteration the new shape still ran 344
+    iterations, while the naive `continue`-plus-end-reset shape ran 1 and then
+    sat on a drained timer. That shape does not hang (the `<-done` case still
+    wakes it), which corrects my briefing - the damage would have been silent,
+    the goroutine quietly ceasing to exercise the race while the test passed.
+  - Pacing unmoved. Deadline ops per run, instrumented then reverted: before
+    317/349/331/354 and 289/311/318/308/289, after 351/350/332/339 and
+    305/336/324/305/331. Still ~1.6% of the 20000 cap, so the `7ee5668a`
+    comment stays true.
+  - Runtime under `-race`, 5 runs after: 0.69/0.67/0.58/0.70/0.91s
+    (implementor) and 0.97/0.74/0.59/0.84/0.82s (reviewer), against the
+    0.78/1.03/0.88/0.93/0.60s baseline. No regression.
+  - Mutation (locks deleted from both `setRecvDeadlineUnderLock` and
+    `recvDeadlineUnderLock`), `go vet ./cmd/ ./jobqueue/` clean and silent on
+    the mutated tree before the verdict was taken: 3/3 runs FAIL, **17
+    `WARNING: DATA RACE` reports across 3 runs** (6/6/5), naming the write in
+    `(*Client).reconnect` (`jobqueue/subscription.go:928`) against the read in
+    `(*Client).recvDeadline` (`jobqueue/client.go:529`). The same mutation
+    rebuilt from committed HEAD gave **15 across 3 runs** (5/5/5), so the change
+    left the test at least as sharp. Logs
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/review_mutated_run{1,2,3}.log` and
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/review_prechange_mutated_run{1,2,3}.log`.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -225,10 +225,18 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     `timer.Reset(socketSwapDeadlineWait)` as the last statement of the loop
     body. The reset is at the END of the body on purpose: that starts each wait
     when the previous iteration's work finished, which is what `time.After`
-    evaluated at the top of the select did. A ticker was rejected - its fixed
-    period leaves a tick buffered whenever an iteration outlasts it, so the next
-    receive returns at once instead of granting the intended gap, which would
-    change how often the deadline operations meet a socket swap.
+    evaluated at the top of the select did. A ticker was rejected: it keeps its
+    own schedule, so an iteration that outlasts the period leaves a tick already
+    due and the next receive returns at once instead of granting the intended
+    gap, which would change how often the deadline operations meet a socket
+    swap. Measured on this toolchain (`/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/f3/main.go`, log
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/logs2/f3-ticker.log`): after a 350ms overrun on a 100ms ticker
+    the next receive returned in 4.263us and the one after that in 49.18ms,
+    while a timer reset after the same overrun returned in 100.28ms. Note
+    `cap(ticker.C)` is 0, not 1 - Go 1.23 made timer and ticker channels
+    unbuffered, so the usual "the tick sits in the channel's one-slot buffer"
+    explanation is out of date. An earlier draft of the code comment said
+    exactly that and was corrected before it was committed.
   - The old `errs++; continue` had to go, because a `continue` past an
     end-of-body reset leaves the timer unarmed. The two-step deadline check
     moved into a new bool-returning helper `recvDeadlineRoundTripped`, so the

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -149,7 +149,7 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
 
 ## PR #581 review findings on this PR's own test code
 
-- [ ] The comment says `socketSwapDeadlineOps` is a backstop against a reconnect
+- [x] The comment says `socketSwapDeadlineOps` is a backstop against a reconnect
       loop that never finishes, but limiting the deadline goroutine's iterations
       does not end the test if reconnect stalls; `wg.Wait()` still waits for the
       reconnect goroutine. Reword to avoid implying this bound prevents the test
@@ -173,6 +173,25 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     iterations of `time.After(100us)` on an otherwise idle process take ~21s,
     not the ~2s the constants suggest, because a parked Go process wakes on a
     ~1ms granularity.
+  - Fixed by rewording the comment at `jobqueue/subscription_test.go:87-99`.
+    It now says `socketSwapDeadlineOps` caps only that goroutine's iterations
+    and that reaching the cap does not end the test, names the bound that does
+    exist (`socketSwapReconnects` reconnects, each calling `Connect()` with the
+    connect timeout it was given), and says plainly that a reconnect stalling
+    past that leaves only `go test`'s own timeout to end the run. The constant
+    is kept: instrumenting `countRecvDeadlineErrors` to count its iterations
+    gave 350/358/359/378 ops (implementor) and 342/350/347/339 (reviewer, four
+    more `-race` runs), i.e. ~1.8% of the 20000 budget, so the cap is nowhere
+    near cutting the deadline goroutine short. Instrumentation reverted; the
+    diff is the comment hunk only.
+  - Reviewer PASS. It confirmed the deliberate gap in the wording: the TCP/TLS
+    dial and mangos handshake inside `dialClientSocket`'s `sock.DialOptions`
+    (`jobqueue/client.go:948`) are NOT bounded by the connect deadlines, so
+    "capped by the connect timeout" would have overclaimed and the comment does
+    not say it. It also confirmed there is no earlier backstop: `TestMain`
+    (`jobqueue/testtempdir_test.go:123-142`) has no watchdog, and the project's
+    test runner passes `-timeout 40m` (`internal/testsuite/planner.go:40`,
+    `runner.go:762,776`), which is go test's own timeout.
 
 - [ ] Using `time.After` inside the loop allocates a new timer every iteration
       (even if `<-done` is already ready), which is avoidable overhead in a

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -296,3 +296,97 @@ Run by the orchestrator, not taken from a subagent's summary.
   comment: `git diff --stat origin/develop..HEAD -- . ':(exclude).docs'
   ':(exclude)*_test.go'` shows only `jobqueue/client.go`, 2 insertions and 1
   deletion, all inside `recvDeadline`'s doc comment.
+
+- [x] `recvDeadlineRoundTripped` (and its doc comment) implies the deadline set
+      is read back from the same socket, but the current check only validates
+      `deadline > 0`. That can let the test pass even if the SetOption didn't
+      actually take effect (or if a reconnect swapped sockets between the set
+      and the get), which weakens this regression guard. Consider doing the
+      set+get in one critical section and checking equality to the value you
+      set.
+
+  - Source: Copilot on PR #581, thread `PRRT_kwDOAKD33M6fn_eh`, on
+    `jobqueue/subscription_test.go:2088`.
+  - Red command is a MUTATION, because the symptom is "the guard passes when it
+    should not". Script `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/red/mutate.sh` (self-restoring; it
+    backs the file up, mutates, vets, runs, and restores on exit). The mutation
+    makes the round trip untrue while leaving the value positive: the SetOption
+    writes `ClientMinRequestTimeout+time.Second` instead of the
+    `ClientMinRequestTimeout` the guard means to prove came back. It is written
+    to match both trees, the pre-fix `setRecvDeadlineUnderLock(jq, ...)` call
+    and a post-fix inline `SetOption(mangos.OptionRecvDeadline, ...)`.
+
+    ```
+    go vet ./jobqueue/                                                    # must be clean
+    go test -race -run 'TestSubscriptionReconnectSocketSwap' -count=3 ./jobqueue
+    ```
+
+  - Verdict on the CURRENT tree (`af9d1491`), log
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/red/mutate-current-tree.log`: vet clean, then
+
+    ```
+    ok  	github.com/VertebrateResequencing/wr/jobqueue	3.711s
+    TEST EXIT 0
+    ```
+
+    GREEN under the mutation, which is the defect: three runs of the guard saw
+    a deadline that was never the one it set and reported no error.
+
+  - Verdict on the FIXED tree, log
+    `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/red/mutate-fixed-tree.log`: vet clean, then all
+    three runs fail at `jobqueue/subscription_test.go:1998`, the
+    `So(deadlineErrs, ShouldEqual, 0)` assertion:
+
+    ```
+    Line 1998:  Expected: 0  Actual: 369  (Should equal)!
+    Line 1998:  Expected: 0  Actual: 359  (Should equal)!
+    FAIL	github.com/VertebrateResequencing/wr/jobqueue	2.099s
+    ```
+
+    The reviewer reproduced both verdicts independently, including swapping
+    `af9d1491`'s copy of the file back in for the GREEN one, and got 337/376/398
+    failures on the fixed tree and `TEST EXIT 0` on the unfixed one.
+  - Fixed in `recvDeadlineRoundTripped` (`jobqueue/subscription_test.go:2085`).
+    It now takes `jq.Lock()`/`defer jq.Unlock()` ONCE and does both the
+    `sock.SetOption(mangos.OptionRecvDeadline, ClientMinRequestTimeout)` and the
+    read inside that one hold, then returns
+    `err == nil && deadline == ClientMinRequestTimeout`. The read is the
+    production `(*Client).recvDeadline`, which requires its caller to hold the
+    lock; calling `recvDeadlineUnderLock` here would self-deadlock, which is why
+    the helper is inlined rather than reused at this one site. Both existing
+    helpers stay: `setRecvDeadlineUnderLock` still has callers at `:1793` and
+    `:1928`, `recvDeadlineUnderLock` at `:1801`. Non-positive still fails,
+    because `ClientMinRequestTimeout` is 60s and equality against a positive
+    constant excludes 0 and negatives; the doc comment now says that, and says
+    why one lock hold is what makes the equality mean anything.
+  - What the equality does NOT prove, measured rather than assumed. Mutation A,
+    equality kept but set and get split back into the two lock-taking helpers:
+    `go vet ./jobqueue/` clean, then `ok ... 3.385s`, GREEN over 3 runs
+    (orchestrator's own run; the reviewer got the same). A swap landing between
+    the two holds is therefore invisible to this assertion, because
+    `reconnect()` builds its replacement through `Connect`, which sets the new
+    socket's deadline to `requestTimeout(timeout)`
+    (`jobqueue/client.go:854, 3864`) - and for this test's connect time that IS
+    `ClientMinRequestTimeout`, so the swapped-in socket answers with the same
+    value. The single critical section is still the right discipline and is what
+    the finding asked for; it is just guarded by `-race`, not by this equality.
+    Mutation B, equality kept but the lock dropped entirely, shows that half is
+    live: vet clean, then RED with `WARNING: DATA RACE` on `jq.sock` between
+    `recvDeadlineRoundTripped` and `(*Client).reconnect`
+    (`jobqueue/subscription.go:928`). The two halves of the guard are enforced
+    by two different mechanisms, both of them biting.
+  - Test-only change. `git diff -- jobqueue/client.go jobqueue/subscription.go`
+    is empty; no non-test `.go` file is touched.
+  - Gates on the fixed tree, run by the orchestrator and again by the reviewer:
+    `make test` -> `615 passed · 13 skipped · 29 packages · 7m22s` / `PASSED`
+    (reviewer: 7m10s); `make lint` -> `0 issues.` with
+    `git rev-parse --verify master` resolving to `b2f0ff97`;
+    `go test -race -run 'TestSubscriptionReconnectSocketSwap' -count=3
+    ./jobqueue` -> `ok ... 3.225s`, zero `DATA RACE` (reviewer: 3.466s).
+    `TestSubscriptionReconnectDuringManagerShutdown` PASS in 18.09s.
+  - Reviewer PASS. It noted one wart in the mutation script rather than in the
+    fix: the script's `MUTATION DID NOT APPLY` guard is
+    `git diff --quiet -- jobqueue/subscription_test.go`, which is already
+    non-quiet on an uncommitted fix, so that guard is vacuous on the fixed tree.
+    Both verdicts were confirmed by the vet status and by the failure being at
+    line 1998 for the right reason, so they stand.

--- a/.docs/bugfixes/260905-1.md
+++ b/.docs/bugfixes/260905-1.md
@@ -264,3 +264,35 @@ Recorded finding: `.docs/bugfixes/260904-3.md` on
     left the test at least as sharp. Logs
     `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/review_mutated_run{1,2,3}.log` and
     `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/review_prechange_mutated_run{1,2,3}.log`.
+
+### Verification of both findings on the final tree (`3a5bca38`)
+
+Run by the orchestrator, not taken from a subagent's summary.
+
+- Mutation, locks deleted from both `setRecvDeadlineUnderLock` and
+  `recvDeadlineUnderLock` (script `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/mutate.sh`, logs `/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/mutFINAL/`):
+  `go vet ./cmd/ ./jobqueue/` silent and exit 0 on the mutated tree
+  (`/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/mutFINAL/vet.log`, empty), `gofmt -l` listed nothing, then
+  `TestSubscriptionReconnectSocketSwap` **FAILED 3/3 runs with 16
+  `WARNING: DATA RACE` reports** (5/6/5). An earlier identical run on
+  `b4fd43db` gave 15 (`/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/mutM2after/`). The file is restored from a byte copy
+  at the end of the script and `git status` was clean after each run.
+- The brief's pre-change figure of "6 DATA RACE reports across 3 runs" does not
+  reproduce here as a count of `WARNING: DATA RACE`: the same mutation rebuilt
+  from the pre-change test gave 15 across 3 runs (5/5/5), measured by the
+  reviewer. The counting method must have differed; what matters is that the
+  same method gives 15 before and 15-17 after, so the change did not blunt the
+  test.
+- `TestSubscriptionReconnectSocketSwap` on the final tree, 5 runs under
+  `-race`: 0.67/0.63/0.60/0.66/0.68s, all PASS, no race
+  (`/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/final/swap1..5.log`), against the 0.78/1.03/0.88/0.93/0.60s baseline.
+- `TestSubscriptionReconnectDuringManagerShutdown` under `-race`, 2 runs:
+  PASS in 17.87s and 17.33s, no race (`/tmp/claude-1000/-home-ubuntu-wr-clone2/5d7020f8-4042-4274-8df6-eefdd9469e3c/scratchpad/shutdown/run1.log`, `run2.log`).
+  Both took the ~18s path, so neither exercised the reconnect that makes this
+  test run ~75s; nothing in these two commits touches it, as
+  `countRecvDeadlineErrors` has a single caller in
+  `reconnectWhileUsingRecvDeadline`, itself used only by the socket-swap test.
+- Production is still untouched by this PR apart from the one pre-existing doc
+  comment: `git diff --stat origin/develop..HEAD -- . ':(exclude).docs'
+  ':(exclude)*_test.go'` shows only `jobqueue/client.go`, 2 insertions and 1
+  deletion, all inside `recvDeadline`'s doc comment.

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -523,7 +523,8 @@ func (c *Client) requestWithin(cr *clientRequest, timeout time.Duration) (sr *se
 	return c.requestLocked(cr)
 }
 
-// recvDeadline returns the receive deadline the client's socket currently has.
+// recvDeadline returns the receive deadline the client's socket currently
+// has. It reads c.sock, so callers must hold the client's lock.
 func (c *Client) recvDeadline() (time.Duration, error) {
 	val, err := c.sock.GetOption(mangos.OptionRecvDeadline)
 	if err != nil {

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -39,6 +39,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -82,6 +83,16 @@ const (
 	// what makes a resubscribe cap recomputed from it a widening rather than a
 	// narrowing.
 	wrAddWaitConnectTimeout = 120 * time.Second
+
+	// socketSwapReconnects, socketSwapDeadlineOps and socketSwapDeadlineWait
+	// bound TestSubscriptionReconnectSocketSwap: the reconnecting goroutine
+	// decides when the test ends, and the deadline goroutine paces itself so it
+	// is still running when each socket swap lands without spinning a core to do
+	// it. Its own bound is only a backstop against a reconnect loop that never
+	// finishes.
+	socketSwapReconnects   = 20
+	socketSwapDeadlineOps  = 20000
+	socketSwapDeadlineWait = 100 * time.Microsecond
 )
 
 var (
@@ -1773,7 +1784,7 @@ func TestSubscriptionReconnectDuringManagerShutdown(t *testing.T) {
 		// connect timeout
 		reconnected := requestTimeout(subscriptionReconnectTimeout)
 		So(reconnected, ShouldEqual, ClientMinRequestTimeout)
-		So(jq.sock.SetOption(mangos.OptionRecvDeadline, reconnected), ShouldBeNil)
+		So(setRecvDeadlineUnderLock(jq, reconnected), ShouldBeNil)
 
 		// the production reconnect budget is ClientRetryTime, far wider than that
 		// floor, so capping the resubscribe by it must change nothing
@@ -1781,7 +1792,7 @@ func TestSubscriptionReconnectDuringManagerShutdown(t *testing.T) {
 
 		resp, reqErr := jq.requestWithin(&clientRequest{Method: requestMethodPing}, ClientRetryTime)
 
-		deadline, optErr := jq.sock.GetOption(mangos.OptionRecvDeadline)
+		deadline, optErr := recvDeadlineUnderLock(jq)
 		So(optErr, ShouldBeNil)
 		So(deadline, ShouldEqual, reconnected)
 
@@ -1908,7 +1919,7 @@ func TestSubscriptionReconnectDuringManagerShutdown(t *testing.T) {
 		// a reconnect re-Connect()s, which leaves the client on the
 		// ClientMinRequestTimeout floor, so that is the deadline this step has
 		// to narrow to stay inside its budget
-		So(jq.sock.SetOption(mangos.OptionRecvDeadline, requestTimeout(subscriptionReconnectTimeout)), ShouldBeNil)
+		So(setRecvDeadlineUnderLock(jq, requestTimeout(subscriptionReconnectTimeout)), ShouldBeNil)
 
 		took, returned, unsubErr := unsubscribeRejectedWithin(sub, unboundedRequestBudget, unreadPingWait)
 
@@ -1954,6 +1965,122 @@ func TestSubscriptionReconnectDuringManagerShutdown(t *testing.T) {
 		So(serverClientSubscriptionCount(server), ShouldEqual, 1)
 		So(errors.Is(unsubErr, ErrSubscriptionClosed), ShouldBeTrue)
 	})
+}
+
+func TestSubscriptionReconnectSocketSwap(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A reconnect can replace a client's socket while its receive deadline is set and read", t, func() {
+		ctx := context.Background()
+		serverConfig, addr, _, clientConnectTime := subscriptionTestConfig(t)
+
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, serverConfig.CAFile, serverConfig.CertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		reconnectErrs, deadlineErrs := reconnectWhileUsingRecvDeadline(jq, clientConnectTime)
+
+		So(reconnectErrs, ShouldEqual, 0)
+		So(deadlineErrs, ShouldEqual, 0)
+	})
+}
+
+// reconnectWhileUsingRecvDeadline reconnects jq socketSwapReconnects times on
+// one goroutine while another sets and reads jq's receive deadline, and returns
+// how many reconnects and how many deadline operations failed.
+//
+// This is the minimal form of what a subscription's poll goroutine does to a
+// client its test is also touching: reconnect() swaps c.sock and closes the old
+// socket, so both goroutines must go through the client's lock.
+func reconnectWhileUsingRecvDeadline(jq *Client, timeout time.Duration) (int, int) {
+	var (
+		wg                          sync.WaitGroup
+		reconnectErrs, deadlineErrs int
+	)
+
+	reconnected := make(chan struct{})
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer close(reconnected)
+
+		for range socketSwapReconnects {
+			if err := jq.reconnect(timeout); err != nil {
+				reconnectErrs++
+			}
+		}
+	}()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		deadlineErrs = countRecvDeadlineErrors(jq, reconnected)
+	}()
+
+	wg.Wait()
+
+	return reconnectErrs, deadlineErrs
+}
+
+// countRecvDeadlineErrors sets and reads jq's receive deadline until done is
+// closed, or until socketSwapDeadlineOps operations have been done, and returns
+// how many of those failed. A deadline read back as non-positive counts as a
+// failure too: mangos reads that as "wait forever", which no live client socket
+// is set to.
+func countRecvDeadlineErrors(jq *Client, done <-chan struct{}) int {
+	errs := 0
+
+	for range socketSwapDeadlineOps {
+		select {
+		case <-done:
+			return errs
+		case <-time.After(socketSwapDeadlineWait):
+		}
+
+		if err := setRecvDeadlineUnderLock(jq, ClientMinRequestTimeout); err != nil {
+			errs++
+
+			continue
+		}
+
+		if deadline, err := recvDeadlineUnderLock(jq); err != nil || deadline <= 0 {
+			errs++
+		}
+	}
+
+	return errs
+}
+
+// setRecvDeadlineUnderLock sets the receive deadline of jq's socket while
+// holding jq's lock, so that a concurrent reconnect() can neither swap the
+// socket out from under the call nor close the socket it is setting the option
+// on.
+func setRecvDeadlineUnderLock(jq *Client, deadline time.Duration) error {
+	jq.Lock()
+	defer jq.Unlock()
+
+	return jq.sock.SetOption(mangos.OptionRecvDeadline, deadline)
+}
+
+// recvDeadlineUnderLock returns the receive deadline of jq's socket, taking the
+// lock that recvDeadline() requires its caller to hold.
+func recvDeadlineUnderLock(jq *Client) (time.Duration, error) {
+	jq.Lock()
+	defer jq.Unlock()
+
+	return jq.recvDeadline()
 }
 
 // applySubscriptionReconnectTimings sets the reconnect backoff/total-retry-time

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -2060,11 +2060,13 @@ func countRecvDeadlineErrors(jq *Client, done <-chan struct{}) int {
 			errs++
 		}
 
-		// Resetting here, after the deadline operations rather than as soon as
-		// the timer fires, keeps each wait starting when the previous iteration
-		// finished, which is what time.After at the top of the select did. A
-		// ticker would instead fire early whenever an iteration outlasts the
-		// period, changing how often these operations meet a socket swap.
+		// Resetting after the deadline operations, rather than as soon as the
+		// timer fires, means each wait starts when the previous iteration's
+		// deadline work finished. Do not simplify this to a ticker: a ticker
+		// keeps its own schedule, so an iteration that outlasts the period
+		// leaves a tick already due and the next receive returns immediately
+		// instead of waiting a full period. That collapses the pacing and
+		// changes how often these operations meet a socket swap.
 		timer.Reset(socketSwapDeadlineWait)
 	}
 

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -88,8 +88,14 @@ const (
 	// bound TestSubscriptionReconnectSocketSwap: the reconnecting goroutine
 	// decides when the test ends, and the deadline goroutine paces itself so it
 	// is still running when each socket swap lands without spinning a core to do
-	// it. Its own bound is only a backstop against a reconnect loop that never
-	// finishes.
+	// it. socketSwapDeadlineOps caps that goroutine's own iterations and nothing
+	// else; reconnectWhileUsingRecvDeadline waits on both goroutines, so
+	// reaching the cap does not end the test. Runtime is bounded by the
+	// reconnect loop instead: socketSwapReconnects reconnects, each of which
+	// only calls Connect() with the connect timeout it was given. If a reconnect
+	// ever stalled past that, only go test's own timeout would end the run.
+	// Observed runs use under 400 deadline ops, so the cap sits well above what
+	// pacing at socketSwapDeadlineWait needs.
 	socketSwapReconnects   = 20
 	socketSwapDeadlineOps  = 20000
 	socketSwapDeadlineWait = 100 * time.Microsecond

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -2042,31 +2042,47 @@ func reconnectWhileUsingRecvDeadline(jq *Client, timeout time.Duration) (int, in
 
 // countRecvDeadlineErrors sets and reads jq's receive deadline until done is
 // closed, or until socketSwapDeadlineOps operations have been done, and returns
-// how many of those failed. A deadline read back as non-positive counts as a
-// failure too: mangos reads that as "wait forever", which no live client socket
-// is set to.
+// how many of those failed.
 func countRecvDeadlineErrors(jq *Client, done <-chan struct{}) int {
 	errs := 0
+
+	timer := time.NewTimer(socketSwapDeadlineWait)
+	defer timer.Stop()
 
 	for range socketSwapDeadlineOps {
 		select {
 		case <-done:
 			return errs
-		case <-time.After(socketSwapDeadlineWait):
+		case <-timer.C:
 		}
 
-		if err := setRecvDeadlineUnderLock(jq, ClientMinRequestTimeout); err != nil {
-			errs++
-
-			continue
-		}
-
-		if deadline, err := recvDeadlineUnderLock(jq); err != nil || deadline <= 0 {
+		if !recvDeadlineRoundTripped(jq) {
 			errs++
 		}
+
+		// Resetting here, after the deadline operations rather than as soon as
+		// the timer fires, keeps each wait starting when the previous iteration
+		// finished, which is what time.After at the top of the select did. A
+		// ticker would instead fire early whenever an iteration outlasts the
+		// period, changing how often these operations meet a socket swap.
+		timer.Reset(socketSwapDeadlineWait)
 	}
 
 	return errs
+}
+
+// recvDeadlineRoundTripped sets jq's receive deadline and reads it back, and
+// says if both succeeded. A deadline read back as non-positive counts as a
+// failure too: mangos reads that as "wait forever", which no live client socket
+// is set to.
+func recvDeadlineRoundTripped(jq *Client) bool {
+	if err := setRecvDeadlineUnderLock(jq, ClientMinRequestTimeout); err != nil {
+		return false
+	}
+
+	deadline, err := recvDeadlineUnderLock(jq)
+
+	return err == nil && deadline > 0
 }
 
 // setRecvDeadlineUnderLock sets the receive deadline of jq's socket while

--- a/jobqueue/subscription_test.go
+++ b/jobqueue/subscription_test.go
@@ -2073,18 +2073,26 @@ func countRecvDeadlineErrors(jq *Client, done <-chan struct{}) int {
 	return errs
 }
 
-// recvDeadlineRoundTripped sets jq's receive deadline and reads it back, and
-// says if both succeeded. A deadline read back as non-positive counts as a
-// failure too: mangos reads that as "wait forever", which no live client socket
-// is set to.
+// recvDeadlineRoundTripped sets jq's receive deadline to
+// ClientMinRequestTimeout, reads it straight back, and says whether the value
+// that came back is the value that went in. Both operations share one hold of
+// jq's lock, so no concurrent reconnect() can swap jq.sock or close it between
+// them: the value read is from the socket just written, which is what makes the
+// equality both deterministic and evidence that the option took effect. The
+// value compared against is positive, so a socket left non-positive - which
+// mangos reads as "wait forever", and no live client socket is set to - fails
+// here too.
 func recvDeadlineRoundTripped(jq *Client) bool {
-	if err := setRecvDeadlineUnderLock(jq, ClientMinRequestTimeout); err != nil {
+	jq.Lock()
+	defer jq.Unlock()
+
+	if err := jq.sock.SetOption(mangos.OptionRecvDeadline, ClientMinRequestTimeout); err != nil {
 		return false
 	}
 
-	deadline, err := recvDeadlineUnderLock(jq)
+	deadline, err := jq.recvDeadline()
 
-	return err == nil && deadline > 0
+	return err == nil && deadline == ClientMinRequestTimeout
 }
 
 // setRecvDeadlineUnderLock sets the receive deadline of jq's socket while


### PR DESCRIPTION
`make race` intermittently failed `TestSubscriptionReconnectDuringManagerShutdown`
with a genuine data race on a `*Client`'s `sock` field. **Measured at 1 in 20 in
isolation** — no special load needed, contrary to what the original record
guessed.

The reproduction has a sharper signal than the raw rate suggests: a run that
reddens takes ~75s, a run whose reconnect never fires takes ~18s. Of 84 unfixed
runs, 9 had the ~75s profile and **3 of those 9 raced** — so about a third of the
runs that actually reach a reconnect.

### Production is correct; the test was not

`(*Client).reconnect` replaces `c.sock` and `c.ServerInfo` while holding the
client's lock. The test read `jq.sock` with **no lock**, while the subscription's
poll goroutine could be inside `reconnect` replacing it.

**Production gained no locks.** The only non-test change is one doc comment, on
`(*Client).recvDeadline`, noting that it reads `c.sock` so callers must hold the
lock.

### Why not the obvious accessor

An accessor returning the socket under the lock lets the pointer **escape** the
lock, and that is not safe here: `reconnect` closes the old socket *after* it
unlocks, so an escaped pointer can be used after close — `SetOption` then returns
an error and the assertion fails spuriously. Worse for the test's meaning, all
three sites set or read the deadline the client's *next request* will use, so
applying it to a discarded socket makes the assertion vacuous.

So the two test helpers do the option call **inside** the lock. A concurrent
`reconnect` simply waits at `c.Lock()`, then swaps and closes; nothing is used
after close. The `GetOption` helper calls the existing production
`(*Client).recvDeadline` under the lock rather than duplicating it.

### The regression test is deterministic

`TestSubscriptionReconnectSocketSwap` drives the production writer
`(*Client).reconnect` 20 times on one goroutine while another sets and reads the
deadline through the helpers. ~1s, and it does not depend on the 1-in-20 window.

**Mutations**, each `go vet`-clean before its verdict counted:

| mutation | verdict |
| --- | --- |
| the fix reverted (three sites back to unlocked `jq.sock`) | **N=40, M=1 DATA RACE** — the recorded race at its pre-fix rate |
| the helper locks removed | new test **10/10 red** |

On the fixed tree the shutdown test is **N=40, M=0**, and 6 of those runs hit the
>60s reconnect profile — so the green is not vacuous.

### Recorded, not fixed

- `subscription_test.go` closes `sub.client.sock` unlocked on a timeout branch.
  No red command (that branch is what an existing assertion says does not
  happen), and a naive lock there would **deadlock** behind `requestWithin`,
  which holds the lock while waiting on the socket. The workable shape is to
  capture the socket under the lock before starting the goroutine.
- Two unlocked production reads of `c.ServerInfo` where no concurrent path with
  `reconnect`'s write could be constructed, and which the detector never flagged.
  Changed nothing; recorded as unverified either way.

### Corrections to the original record

- It said to take the Client's **read** lock. There is none — `Client` embeds a
  plain `sync.Mutex`.
- It suggested a single locked accessor, which is the unsafe shape above.
- It read the `initDB`/`Serve` frames in the trace as the read path. They are
  **stale-stack noise** on the test goroutine, which had earlier called `serve()`.
  That misreading is what produced the first wrong diagnosis.
- It said one `-race` run of the test would not reproduce it. It does, 1 in 20.

Checklist and evidence: `.docs/bugfixes/260905-1.md`. Gates: **615 passed · 13
skipped** on `make test` and `make race`, `make lint` 0 issues.
