### PR TITLE
Keep the upward tidy going past a parent that has already gone

### DIFF
--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -1,0 +1,7 @@
+# 260905-2
+
+- [ ] `dirChain.removeEmptyParents` stops on ANY error from removing a parent,
+      including the "already gone" case. A parent that another process removed
+      between our descent and our upward walk therefore strands every hashed
+      level above it, for good. Recorded finding:
+      `git show origin/record-upward-tidy-strands:.docs/bugfixes/260904-1.md`.

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -390,3 +390,27 @@ tree: `TestCreatedCwdDepthMatchesMkHashedDir`'s comment sits on `const
 testJobKey` at `jobqueue/utils_test.go:774`. It arrived in `60aae105`, which is
 on `origin/develop`, so it predates this branch and no gate fails on it. Left
 alone here to keep this a single-purpose change.
+
+## Copilot PRRT_kwDOAKD33M6fpGgU: garden-path sentence in removeEmptyParents
+
+Copilot read `jobqueue/utils.go:1223`'s "Two cleanups of one lost Job run in
+different processes" as missing a verb. It is not: "run" is the verb and "Two
+cleanups of one lost Job" its subject. The real fault is a garden path - "Job
+run" reads as a noun phrase, and "job run" is domain vocabulary here, so the
+reader parses it that way and has to back up. Reworded for that reason, not for
+grammar.
+
+Now "One lost Job gets two cleanups, running in different processes, so a
+parent that the other one removed between our descent and this walk is
+ordinary; stopping there stranded every hashed level above it under
+`<Cwd>/<AppName>_cwd` for good." Subject, verb and object come first, so the
+participle cannot be mistaken for a head noun. All three load-bearing facts
+survive: two cleanups per lost Job, in different processes (which is why
+`workspace.go`'s "cleanup runs twice for a lost job" is a race no lock closes);
+the other cleanup's removal is the ordinary case; and the stranding is
+permanent.
+
+Comment text only - the diff is two comment lines, and no executable line
+changed. No red command exists for a prose change and none was invented.
+`gofmt -l jobqueue/` empty, `go vet ./cmd/ ./jobqueue/` exit 0, `make lint`
+"0 issues." with `master` at `b2f0ff97` verified present first.

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -5,3 +5,82 @@
       between our descent and our upward walk therefore strands every hashed
       level above it, for good. Recorded finding:
       `git show origin/record-upward-tidy-strands:.docs/bugfixes/260904-1.md`.
+    - Red command: `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -run
+      '^TestRemoveUpwardPastGoneParent$' -v`, whose first case opens the chain,
+      lets another cleanup take the workspace and the deepest hashed level, then
+      walks up.
+    - Red output before the fix, from the throwaway probe of the same shape:
+
+      ```
+      Failures:
+
+        * /home/ubuntu/wr_tidy/jobqueue/zz_red_probe_test.go
+        Line 50:
+        Expected [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b] to be empty (but it wasn't)!
+
+      15 total assertions
+
+      --- FAIL: TestZZRedProbeStrand (0.00s)
+      ```
+
+## Measurements taken before implementing
+
+The recorded finding required these three before any fix was written.
+
+### 1. The strand is a real on-disk outcome
+
+Yes. With `jobqueue_cwd/a/b/c/key-uuid` proven and the chain open, another
+process removing `key-uuid` and `c` leaves `jobqueue_cwd`, `jobqueue_cwd/a` and
+`jobqueue_cwd/a/b` on disk after `removeUpward` returns nil. The assertion is on
+the surviving paths, not on a return value; see the red output above.
+
+### 2. The errno is ENOENT, and `os.IsNotExist` matches it
+
+Measured on ext4 (`df -T .` reports ext4) with a probe over `os.Root`, the same
+type `c.roots[i]` is. Every pinned-handle removal of a name that has gone gives
+errno 2 (ENOENT) with `os.IsNotExist` true, including when the pinned handle's
+OWN directory has been removed:
+
+```
+A: Remove(x) via pinned D handle, x already gone      errno=2 os.IsNotExist=true ESTALE=false
+B: Remove(x) via pinned handle whose own dir is gone  errno=2 os.IsNotExist=true ESTALE=false
+C2: gpRoot.Remove(P) after P gone                     errno=2 os.IsNotExist=true ESTALE=false
+D: Remove(x) where x is non-empty                     errno=39 (ENOTEMPTY) os.IsNotExist=false
+```
+
+ESTALE was not observed. It is a network-filesystem answer and this machine has
+no NFS mount to test against, and mounting one needs root, so ESTALE on NFS is
+UNVERIFIED either way.
+
+`openVerifiedDir`'s three failure exits, measured the same way:
+
+- `parent.OpenRoot(name)` with name gone: ENOENT, `os.IsNotExist` true.
+- `dirRoot.Stat(".")` after the directory was removed: no error at all on
+  Linux, so this exit does not fire for a removal race.
+- `proveSameDir` failure: `errNotBelowBaseDir`, carrying no errno, so
+  `os.IsNotExist` is false.
+
+So the doc comment on `dirChain.openLeaf` ("A dir that has gone since it was
+proven gives an os.IsNotExist error") is right for the reason that matters: the
+only exit a disappearance reaches is the first one.
+
+### 3. Continuing past a gone parent cannot reach a directory that is not wr's
+
+The candidate set is fixed before the loop runs and does not grow when the walk
+continues. `removeEmptyParents` (`jobqueue/utils.go:1220`) iterates
+`c.names[:len(c.names)-1]` with `i` from `len(parents)-1` down to `0`, so the
+shallowest removal it can make is `c.roots[0].Remove(c.names[0])`: an entry of
+the base directory, never the base itself. `c.names` is `provenDirs.rel` split
+on the separator (`jobqueue/utils.go:1052`), and `rel` is only ever made by
+`realDirBelow` (`jobqueue/utils.go:1347`), which requires `relIsBelow`
+(`jobqueue/utils.go:1524`) to reject `.`, `..` and any `../` prefix. Each name is
+a single component removed through the handle the descent opened and proved, so
+no part of the path is re-resolved from a string.
+
+Both callers are inside a tree wr made: cleanup walks up from the workspace
+under `<Cwd>/<AppName>_cwd` (`jobqueue/workspace.go:878`), and
+`rmEmptyMountDirs` walks only mount points already filtered to those at or
+inside `p.workSpace` (`jobqueue/workspace.go:728`).
+
+A parent that is genuinely not empty still stops the walk: ENOTEMPTY is not
+`os.IsNotExist` (probe case D above).

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -1,6 +1,6 @@
 # 260905-2
 
-- [ ] `dirChain.removeEmptyParents` stops on ANY error from removing a parent,
+- [x] `dirChain.removeEmptyParents` stops on ANY error from removing a parent,
       including the "already gone" case. A parent that another process removed
       between our descent and our upward walk therefore strands every hashed
       level above it, for good. Recorded finding:
@@ -9,19 +9,28 @@
       '^TestRemoveUpwardPastGoneParent$' -v`, whose first case opens the chain,
       lets another cleanup take the workspace and the deepest hashed level, then
       walks up.
-    - Red output before the fix, from the throwaway probe of the same shape:
+    - Red output before the fix:
 
       ```
+      === RUN   TestRemoveUpwardPastGoneParent
+
+        Given a proven workspace under wr's hashed levels
+          a second cleanup taking the workspace and deepest hashed level first still leaves nothing behind
+
       Failures:
 
-        * /home/ubuntu/wr_tidy/jobqueue/zz_red_probe_test.go
-        Line 50:
+        * /home/ubuntu/wr_tidy/jobqueue/utils_test.go
+        Line 330:
         Expected [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b] to be empty (but it wasn't)!
 
-      15 total assertions
-
-      --- FAIL: TestZZRedProbeStrand (0.00s)
+      --- FAIL: TestRemoveUpwardPastGoneParent (0.00s)
       ```
+
+    - Fixed. `jobqueue/utils.go`: the parent walk now treats a dir that has
+      already gone as removed and carries on, which is the rule `removeUpward`
+      already applied to the leaf. One condition changed; the candidate set, the
+      bound and the signature are untouched. `jobqueue/utils_test.go`: a new
+      behavioural test asserting which directories survive on disk.
 
 ## Measurements taken before implementing
 
@@ -84,3 +93,34 @@ inside `p.workSpace` (`jobqueue/workspace.go:728`).
 
 A parent that is genuinely not empty still stops the walk: ENOTEMPTY is not
 `os.IsNotExist` (probe case D above).
+
+## Why the tolerance is separate from errIsDirNotEmpty and errIsDirInUse
+
+Those two mean "stop, there is nothing of ours left here". "Already gone" means
+"this level is done, keep going". Opposite verdicts, so folding them together
+would be a bug, not a tidy-up. Measured: with the guard written as
+`err != nil && !errIsDirInUse(err) && !os.IsNotExist(err)`, `go vet ./cmd/
+./jobqueue/` clean, the third case below goes red because the walk carries on
+past a parent that is merely full and deletes a hashed level another Job had
+just made.
+
+## Mutation testing
+
+`go vet ./cmd/ ./jobqueue/` was clean before each verdict, so no verdict rests
+on a mutation that failed to compile.
+
+- Revert the fix to `if c.roots[i].Remove(parents[i]) != nil {`. RED: the
+  survival case fails at `jobqueue/utils_test.go:330` with the strand
+  `[jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b]`.
+- Fold "already gone" into `errIsDirInUse`. RED at
+  `jobqueue/utils_test.go:361`.
+- Drop the stop entirely, `_ = c.roots[i].Remove(parents[i])`. RED at
+  `jobqueue/utils_test.go:361`.
+
+The plain non-empty case CANNOT kill that third mutation, and this is
+structural rather than a weak assertion: `c.roots[i]` is the handle
+`c.names[i]` is an entry of, so a parent that will not go is still an entry of
+the directory the next removal targets, and that removal fails on its own. The
+stop only becomes load-bearing once a rename makes the pinned handle and the
+current name disagree, which is what the third Convey case arranges. Without
+that case the stop guard is untestable through on-disk survival.

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -154,3 +154,39 @@ untested branch: `ENOENT` and `ESTALE` are gone, while `ENOTEMPTY`, `EBUSY`,
 **Still worth doing on a real cluster:** run the errno probe at
 `<scratchpad>/errnoprobe/main.go` on Lustre and confirm which errno a pinned
 handle really gives. If it is neither, this fix still does nothing there.
+
+- [ ] `errIsGone` treats `ESTALE` as "already gone". A removal that fails
+      because the pinned HANDLE is stale, rather than because the name is
+      missing, therefore lets the upward walk carry on and delete the fresh
+      hashed level another Job's `mkHashedDir` has just made at that name.
+      The term also does not buy what it was added for: on the same filesystem
+      the leaf removal in `removeUpward` (`jobqueue/utils.go:1199`) still tests
+      `os.IsNotExist`, so the scenario the fix was written for returns `ESTALE`
+      there and never reaches `removeEmptyParents` at all.
+    - Red command: `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ -run
+      '^TestRemoveUpwardOnStaleHandle$' -v`, which FUSE mounts a filesystem
+      answering one removal with `ESTALE` while leaving the entry in place, then
+      walks up past it.
+    - Red evidence, from the throwaway probe of the same shape (kept at
+      `<scratchpad>/zz_estale_probe_test.go.txt`), `go vet ./cmd/ ./jobqueue/`
+      clean:
+
+      ```
+      D: a parent handle is stale, and the name it holds is a fresh dir
+        removeUpward err=<nil>
+        fs log:    [RMDIR key-uuid -> errno 0 RMDIR c -> ESTALE RMDIR c -> ESTALE
+                    RMDIR b -> errno 0 RMDIR a -> directory not empty]
+        survivors: [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b.old
+                    jobqueue_cwd/a/b.old/c]
+      ```
+
+      `RMDIR b -> errno 0` is the harm: `jobqueue_cwd/a/b` is the fresh directory
+      the other Job just made, and the walk deleted it. With the `ESTALE` term
+      dropped and `go vet` clean, the same probe stops at `c` and that directory
+      survives:
+
+      ```
+        fs log:    [RMDIR key-uuid -> errno 0 RMDIR c -> ESTALE RMDIR c -> ESTALE]
+        survivors: [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b
+                    jobqueue_cwd/a/b.old jobqueue_cwd/a/b.old/c]
+      ```

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -295,3 +295,98 @@ directs, reshuffles unrelated pre-existing declarations in that file: it moves
 the same orphaned-comment defect this item fixes in `jobqueue/utils.go`, so the
 tool can introduce it. `cleanorder` on `jobqueue/utils.go` is a no-op. Check its
 output before accepting it on a test file.
+
+- [x] `make lint` fails: the FUSE harness backing
+      `TestRemoveUpwardOnStaleHandle` builds its node tree through
+      `gofuse.LoopbackRoot.NewNode`, which go-fuse v2.10.1 deprecated in favour
+      of the `NodeWrapChilder` interface. staticcheck reports SA1019 twice, so
+      the gate is red on a test file the previous item added.
+    - Red command: `cd /home/ubuntu/wr_tidy && unset $(compgen -v | grep
+      '^OS_') && timeout 15m make lint`
+    - Red output before the fix (exit 2):
+
+      ```
+      jobqueue/utils_test.go:435:2: SA1019: root.NewNode is deprecated: use NodeWrapChilder instead. (staticcheck)
+      	root.NewNode = func(rootData *gofuse.LoopbackRoot, _ *gofuse.Inode, _ string,
+      	^
+      jobqueue/utils_test.go:439:18: SA1019: root.NewNode is deprecated: use NodeWrapChilder instead. (staticcheck)
+      	root.RootNode = root.NewNode(root, nil, "", &st)
+      	                ^
+      2 issues:
+      * staticcheck: 2
+      make: *** [Makefile:97: lint] Error 1
+      ```
+
+    - Fixed, test file only. `jobqueue/utils_test.go`: `staleRmdirNode` now
+      embeds `*gofuse.LoopbackNode` by pointer and carries a `WrapChild`
+      method, so the stale check is attached through the `NodeWrapChilder`
+      interface rather than through the deprecated `LoopbackRoot.NewNode` hook.
+      `mountStaleRmdir` builds the root node directly and passes it to
+      `gofuse.Mount`. `jobqueue/utils.go` is untouched (`git diff --quiet --
+      jobqueue/utils.go` exits 0). No test was deleted, skipped or weakened.
+
+## Why the pointer embed, and why WrapChild reaches the whole tree
+
+`(*Inode).newInode` (`fs/inode.go:377` of go-fuse v2.10.1) tests the PARENT's
+`ops` for `NodeWrapChilder`, and `rawBridge.newInodeUnlocked` (`fs/bridge.go:151`)
+stores the WRAPPER as that inode's ops. So the wrapping only recurses because
+each wrapped child is itself a `staleRmdirNode` and implements `WrapChild` in
+turn. It is measured rather than argued: the `ESTALE` in the test is injected at
+`Rmdir("c")` on the node for `b.old`, three levels below the mount root, and
+that is what the assertion turns on.
+
+`WrapChild` is handed the plain loopback node the loopback just made, and the
+node carries the `Inode` the FUSE bridge tracks it by, so it has to be kept
+rather than copied. That is why the embed changed from a value to a pointer.
+The method set is unchanged either way: `*staleRmdirNode` had the full
+`*LoopbackNode` set under both, and `Rmdir` still delegates through
+`n.LoopbackNode.Rmdir`.
+
+go-fuse's own example (`fs/windows_example_test.go:29-33`) writes the bare
+assertion `ops.(*fs.LoopbackNode)`, which `forcetypeassert` (`.golangci.yml:25`)
+rejects here, so the two-value form is used with the unwrapped value returned on
+the `!ok` branch. That branch is unreachable - the six inode-creating sites in
+`fs/loopback.go` all go through `LoopbackRoot.newNode`, which returns a
+`*LoopbackNode` now that `NewNode` is nil - and it could not hide a failure if
+it were reached: an unwrapped child injects no `ESTALE`, the walk deletes the
+fresh `b`, and the survivors assertion goes red. That is exactly the output the
+mutation below produces.
+
+## Mutation testing
+
+The migration must leave `TestRemoveUpwardOnStaleHandle` able to bite, so the
+mutation the previous item recorded was re-run against the migrated harness, by
+the implementor and again by the reviewer.
+
+- `CGO_ENABLED=1 go vet -tags netgo ./cmd/ ./jobqueue/` exit 0 with the
+  mutation applied, so the verdict does not rest on code that failed to compile.
+- Mutated guard in `removeEmptyParents`: `if err := c.roots[i].Remove(parents[i]);
+  err != nil && !os.IsNotExist(err) && !errors.Is(err, syscall.ESTALE) {`. RED:
+
+  ```
+    Line 547:
+    Expected: []string{"jobqueue_cwd", "jobqueue_cwd/a", "jobqueue_cwd/a/b", "jobqueue_cwd/a/b.old", "jobqueue_cwd/a/b.old/c"}
+    Actual:   []string{"jobqueue_cwd", "jobqueue_cwd/a", "jobqueue_cwd/a/b.old", "jobqueue_cwd/a/b.old/c"}
+  --- FAIL: TestRemoveUpwardOnStaleHandle (0.01s)
+  ```
+
+  The fresh `jobqueue_cwd/a/b` is destroyed, which is the data loss the test
+  exists to pin. Line 547 is the 527 the previous item recorded, shifted by the
+  migration's added lines.
+- Restored with `git checkout -- jobqueue/utils.go`: `git diff --quiet` exit 0,
+  and the test is green again at 9 assertions.
+
+## The FUSE mount really happened
+
+`TestRemoveUpwardOnStaleHandle` run on its own reports `9 total assertions` and
+PASS, with no `SkipConvey` line, both before the migration and after it. A
+skipped mount would have shown fewer. So the migration is verified on a real
+mount, not assumed.
+
+## Noticed while fixing, not fixed (second pass)
+
+The orphaned doc comment `cleanorder` produces on this file is already in the
+tree: `TestCreatedCwdDepthMatchesMkHashedDir`'s comment sits on `const
+testJobKey` at `jobqueue/utils_test.go:774`. It arrived in `60aae105`, which is
+on `origin/develop`, so it predates this branch and no gate fails on it. Left
+alone here to keep this a single-purpose change.

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -124,3 +124,33 @@ the directory the next removal targets, and that removal fails on its own. The
 stop only becomes load-bearing once a rename makes the pinned handle and the
 current name disagree, which is what the third Convey case arranges. Without
 that case the stop guard is untestable through on-disk survival.
+
+## The errno gap, closed as far as it can be here
+
+The measurement above establishes `ENOENT` **on ext4 only**. wr runs on Lustre
+and NFS, where an operation through a handle whose object has been removed
+reports the **handle** as stale rather than the name as missing. Left at
+`os.IsNotExist`, this fix would silently do nothing on the filesystems that
+produced the original complaint - which is the worst possible outcome for a
+change of this kind: green tests, no effect where it matters.
+
+So the condition is now `errIsGone`, covering `ENOENT` and `ESTALE`.
+
+**`ESTALE` is unverified and is labelled as such in the code.** No network
+filesystem was available, and mounting one needs root. It is included on two
+grounds rather than as a guess:
+
+- It means the same thing. `ESTALE` is returned precisely because the object the
+  handle names is gone.
+- Being wrong is cheap. If the directory somehow still exists, the level above it
+  is not empty either, so the next removal fails with `ENOTEMPTY` and the walk
+  stops there anyway. The failure mode is the current behaviour, not a deletion.
+
+`errIsGone` is pinned directly by `TestErrIsGone` rather than left as an
+untested branch: `ENOENT` and `ESTALE` are gone, while `ENOTEMPTY`, `EBUSY`,
+`EACCES` and `nil` are not. Dropping the `ESTALE` term turns that test red
+(`go vet` clean first).
+
+**Still worth doing on a real cluster:** run the errno probe at
+`<scratchpad>/errnoprobe/main.go` on Lustre and confirm which errno a pinned
+handle really gives. If it is neither, this fix still does nothing there.

--- a/.docs/bugfixes/260905-2.md
+++ b/.docs/bugfixes/260905-2.md
@@ -155,7 +155,7 @@ untested branch: `ENOENT` and `ESTALE` are gone, while `ENOTEMPTY`, `EBUSY`,
 `<scratchpad>/errnoprobe/main.go` on Lustre and confirm which errno a pinned
 handle really gives. If it is neither, this fix still does nothing there.
 
-- [ ] `errIsGone` treats `ESTALE` as "already gone". A removal that fails
+- [x] `errIsGone` treats `ESTALE` as "already gone". A removal that fails
       because the pinned HANDLE is stale, rather than because the name is
       missing, therefore lets the upward walk carry on and delete the fresh
       hashed level another Job's `mkHashedDir` has just made at that name.
@@ -190,3 +190,108 @@ handle really gives. If it is neither, this fix still does nothing there.
         survivors: [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b
                     jobqueue_cwd/a/b.old jobqueue_cwd/a/b.old/c]
       ```
+
+    - Fixed. `jobqueue/utils.go` is now byte-identical to its state at
+      `90c69097` (`git diff 90c69097 -- jobqueue/utils.go` is empty):
+      `errIsGone` is deleted and the guard is back to `!os.IsNotExist(err)`.
+      Deleting it also reattaches `errIsDirInUse`'s doc comment to
+      `errIsDirInUse`, which `04b1c08c` had orphaned. `jobqueue/utils_test.go`:
+      `TestErrIsGone` deleted, which likewise reattaches
+      `TestRemoveUpwardPastGoneParent`'s doc comment to its own function, and a
+      new `TestRemoveUpwardOnStaleHandle` added.
+
+## The errno gap, reopened
+
+The section above, "The errno gap, closed as far as it can be here", is
+SUPERSEDED. It is left in place because it records what was believed at the
+time, but two of its claims are wrong, and both were measured.
+
+**"Being wrong is cheap" is false.** It argued that a directory wrongly judged
+gone still makes the level above it non-empty, so the next removal fails with
+`ENOTEMPTY` and the walk stops anyway. It does not. `c.roots[i]` is a handle
+pinned during the descent, so the next removal names the CURRENT entry of the
+NEXT pinned handle, and after a rename or a remove-and-recreate of a shared
+hashed level that is a different, fresh, empty directory another Job's
+`mkHashedDir` has just made. It is removed, not refused. That is the same
+disagreement between a pinned handle and a current name that the third Convey
+case of `TestRemoveUpwardPastGoneParent` already turns on, and which
+`90c69097`'s own mutation section describes; the two commits contradicted each
+other.
+
+**"No such filesystem was available" is false as a reason not to measure.** What
+is needed is not a network filesystem but one that answers a removal with
+`ESTALE`, and this repository already raises unprivileged FUSE mounts in its own
+tests (`canMountFuse` and `mountLoopback`, `jobqueue/workspace_test.go`). A
+go-fuse filesystem whose `Rmdir` answers `ESTALE` gives the errno directly, and
+`os.Root.Remove` surfaces it unchanged as `removeat key-uuid: stale file
+handle`. That is what `TestRemoveUpwardOnStaleHandle` now does.
+
+What CANNOT be measured here, and stays unverified, is which errno Lustre or NFS
+really give for a removal through a pinned handle. Nothing in this repository
+answers that.
+
+**The term also bought nothing where it was aimed.** Measured on the same FUSE
+filesystem, with the removal of the workspace answered `ESTALE`, the walk never
+reached `removeEmptyParents` at all:
+
+```
+removeUpward err=removeat key-uuid: stale file handle
+survivors: [jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b jobqueue_cwd/a/b/c
+            jobqueue_cwd/a/b/c/key-uuid]
+```
+
+`removeUpward`'s leaf removal (`jobqueue/utils.go:1199`) still tests
+`os.IsNotExist`, and so do the descent (`:1071`), `realDirBelow` (`:1403`),
+`:1814` and `ignoreGone` (`:1889`). On a filesystem that reports stale handles
+the whole operation aborts before the parent walk, so tolerating `ESTALE` at one
+of those six sites could not deliver what it was added for. Making all six
+tolerate it is a larger change that nobody can justify until the cluster errno
+is measured.
+
+## Why the test is a mounted filesystem and not a predicate
+
+`TestErrIsGone` asserted a private predicate against errno constants. It could
+only fail if someone edited the predicate, and it went green on the very code
+whose on-disk behaviour was wrong, so it never had a verdict to give.
+`removeEmptyParents` calls `os.Root.Remove` with no injection seam, so the only
+way to put a chosen errno in front of the walk is a filesystem that produces
+one. `TestRemoveUpwardOnStaleHandle` therefore mounts one, and asserts on which
+directories survive on disk, which is the same boundary the rest of this
+checklist's tests use.
+
+Both elements of its scenario are load-bearing. Without the rename, forgiving
+`ESTALE` at `c` leads to a `b` that still contains `c`, so `ENOTEMPTY` stops the
+walk and the survivors are the same either way. Without the fresh `b`, the
+removal of `b` gets `ENOENT`, which the unmutated guard forgives too, and again
+the survivors match. Only both together make the stop observable.
+
+## Mutation testing
+
+`go vet ./cmd/ ./jobqueue/` was clean before each verdict, so no verdict rests
+on a mutation that failed to compile.
+
+- Put the `ESTALE` term back inline, `... && !os.IsNotExist(err) &&
+  !errors.Is(err, syscall.ESTALE)`. RED: `TestRemoveUpwardOnStaleHandle` at
+  `jobqueue/utils_test.go:527`, the fresh `jobqueue_cwd/a/b` missing from the
+  survivors. `TestRemoveUpwardPastGoneParent` and `TestRmEmptyDirsIn` stay
+  green, so nothing else in the suite kills this one.
+- Revert `90c69097`'s condition to `if c.roots[i].Remove(parents[i]) != nil {`.
+  RED: `TestRemoveUpwardPastGoneParent` at `jobqueue/utils_test.go:333` with the
+  strand `[jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b]`, the same strand the
+  first item of this checklist recorded. `TestRemoveUpwardOnStaleHandle` stays
+  green: the two tests kill disjoint mutations.
+- Drop the stop entirely, `_ = c.roots[i].Remove(parents[i])`. RED: both
+  `TestRemoveUpwardPastGoneParent` and `TestRemoveUpwardOnStaleHandle`.
+- Forgive `ENOTEMPTY` as well, `... && !errIsDirNotEmpty(err)`. RED:
+  `TestRemoveUpwardPastGoneParent` at `jobqueue/utils_test.go:364`, the fresh
+  `jobqueue_cwd/a` deleted. A genuinely non-empty parent still stops the walk.
+
+## Noticed while fixing, not fixed
+
+`cleanorder -min-diff jobqueue/utils_test.go`, which the Go implementor workflow
+directs, reshuffles unrelated pre-existing declarations in that file: it moves
+`testJobKey` and `mkHashedDirSweepTries` upward and glues
+`TestCreatedCwdDepthMatchesMkHashedDir`'s doc comment onto `testJobKey`. That is
+the same orphaned-comment defect this item fixes in `jobqueue/utils.go`, so the
+tool can introduce it. `cleanorder` on `jobqueue/utils.go` is a no-op. Check its
+output before accepting it on a test file.

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1211,17 +1211,28 @@ func (c dirChain) removeUpward() error {
 
 // removeEmptyParents removes the empty parent directories of the chain's leaf,
 // from the deepest up, stopping before the base and at the first dir that will
-// not go.
+// not go. A dir that has ALREADY gone is not one of those: it counts as removed,
+// and the walk carries on above it, which is the same rule removeUpward applies
+// to the leaf.
+//
+// That is deliberately NOT folded into errIsDirNotEmpty or errIsDirInUse, which
+// carry the opposite verdict: they mean "stop, there is nothing of ours left
+// here", while "already gone" means "this level is done, keep going". Two
+// cleanups of one lost Job run in different processes, so a parent that the
+// other one removed between our descent and this walk is ordinary; stopping
+// there stranded every hashed level above it under <Cwd>/<AppName>_cwd for good.
 //
 // The chain is what makes it safe to remove these without re-proving each level:
 // every one is an ancestor of a leaf already proven to be inside the base, and
 // each removal is made in the directory the descent opened, which cannot be
-// outside the base however the names resolve now.
+// outside the base however the names resolve now. Carrying on cannot widen that:
+// the candidate set is fixed before the loop, so the shallowest removal is still
+// an entry of the base rather than the base itself.
 func (c dirChain) removeEmptyParents() {
 	parents := c.names[:len(c.names)-1]
 
 	for i := len(parents) - 1; i >= 0; i-- {
-		if c.roots[i].Remove(parents[i]) != nil {
+		if err := c.roots[i].Remove(parents[i]); err != nil && !os.IsNotExist(err) {
 			return
 		}
 	}

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1232,7 +1232,7 @@ func (c dirChain) removeEmptyParents() {
 	parents := c.names[:len(c.names)-1]
 
 	for i := len(parents) - 1; i >= 0; i-- {
-		if err := c.roots[i].Remove(parents[i]); err != nil && !errIsGone(err) {
+		if err := c.roots[i].Remove(parents[i]); err != nil && !os.IsNotExist(err) {
 			return
 		}
 	}
@@ -1333,25 +1333,6 @@ func errIsDirNotEmpty(err error) bool {
 // It is asked only of the removal of a directory, so a mounted-on FILE - which
 // unlink also refuses with EBUSY - is still reported: the sweep leaves that
 // entry alone via the mount boundary rather than trying and forgiving it.
-// errIsGone says if err means the thing being removed is no longer there, so a
-// walk removing a chain of directories may treat that level as done and carry on
-// above it.
-//
-// ENOENT is what a local filesystem gives, measured through an os.Root on ext4,
-// including the case the removal goes through a handle whose own directory has
-// since been removed.
-//
-// ESTALE is here for the network filesystems wr actually runs on - Lustre, NFS -
-// where an operation through a handle whose object has been removed reports the
-// handle as stale rather than the name as missing. That is UNVERIFIED: no such
-// filesystem was available to measure, and mounting one needs root. It is
-// included because it means the same thing and because being wrong is cheap: if
-// the directory somehow still exists, the level above it is not empty either, so
-// the next removal fails with ENOTEMPTY and the walk stops there anyway.
-func errIsGone(err error) bool {
-	return os.IsNotExist(err) || errors.Is(err, syscall.ESTALE)
-}
-
 func errIsDirInUse(err error) bool {
 	return errIsDirNotEmpty(err) || errors.Is(err, syscall.EBUSY)
 }

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1232,7 +1232,7 @@ func (c dirChain) removeEmptyParents() {
 	parents := c.names[:len(c.names)-1]
 
 	for i := len(parents) - 1; i >= 0; i-- {
-		if err := c.roots[i].Remove(parents[i]); err != nil && !os.IsNotExist(err) {
+		if err := c.roots[i].Remove(parents[i]); err != nil && !errIsGone(err) {
 			return
 		}
 	}
@@ -1333,6 +1333,25 @@ func errIsDirNotEmpty(err error) bool {
 // It is asked only of the removal of a directory, so a mounted-on FILE - which
 // unlink also refuses with EBUSY - is still reported: the sweep leaves that
 // entry alone via the mount boundary rather than trying and forgiving it.
+// errIsGone says if err means the thing being removed is no longer there, so a
+// walk removing a chain of directories may treat that level as done and carry on
+// above it.
+//
+// ENOENT is what a local filesystem gives, measured through an os.Root on ext4,
+// including the case the removal goes through a handle whose own directory has
+// since been removed.
+//
+// ESTALE is here for the network filesystems wr actually runs on - Lustre, NFS -
+// where an operation through a handle whose object has been removed reports the
+// handle as stale rather than the name as missing. That is UNVERIFIED: no such
+// filesystem was available to measure, and mounting one needs root. It is
+// included because it means the same thing and because being wrong is cheap: if
+// the directory somehow still exists, the level above it is not empty either, so
+// the next removal fails with ENOTEMPTY and the walk stops there anyway.
+func errIsGone(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, syscall.ESTALE)
+}
+
 func errIsDirInUse(err error) bool {
 	return errIsDirNotEmpty(err) || errors.Is(err, syscall.EBUSY)
 }

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1217,8 +1217,8 @@ func (c dirChain) removeUpward() error {
 //
 // That is deliberately NOT folded into errIsDirNotEmpty or errIsDirInUse, which
 // carry the opposite verdict: they mean "stop, there is nothing of ours left
-// here", while "already gone" means "this level is done, keep going". Two
-// cleanups of one lost Job run in different processes, so a parent that the
+// here", while "already gone" means "this level is done, keep going". One lost
+// Job gets two cleanups, running in different processes, so a parent that the
 // other one removed between our descent and this walk is ordinary; stopping
 // there stranded every hashed level above it under <Cwd>/<AppName>_cwd for good.
 //

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -40,6 +40,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -295,6 +296,29 @@ func TestRmEmptyDirsIn(t *testing.T) {
 // The assertions are on which directories survive on disk, because a stranded
 // hashed level is invisible in the return value: the walk returns nil whether
 // it tidied everything or gave up at the first level someone else had taken.
+// TestErrIsGone pins which errnos count as "already removed" for the upward
+// walk. ENOENT is measured on ext4 by the walk's own test above; ESTALE cannot
+// be, because it needs a network filesystem this machine does not have, so it is
+// asserted directly on the predicate rather than left as an untested branch.
+func TestErrIsGone(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("errIsGone recognises a thing that is no longer there", t, func() {
+		So(errIsGone(syscall.ENOENT), ShouldBeTrue)
+		So(errIsGone(syscall.ESTALE), ShouldBeTrue)
+		So(errIsGone(&os.PathError{Op: "unlinkat", Err: syscall.ESTALE}), ShouldBeTrue)
+
+		Convey("and nothing else, so a real failure still stops the walk", func() {
+			So(errIsGone(syscall.ENOTEMPTY), ShouldBeFalse)
+			So(errIsGone(syscall.EBUSY), ShouldBeFalse)
+			So(errIsGone(syscall.EACCES), ShouldBeFalse)
+			So(errIsGone(nil), ShouldBeFalse)
+		})
+	})
+}
+
 func TestRemoveUpwardPastGoneParent(t *testing.T) {
 	if runnermode || servermode {
 		return

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -278,6 +279,127 @@ func TestRmEmptyDirsIn(t *testing.T) {
 			So(errors.Is(err, errNotBelowBaseDir), ShouldBeTrue)
 		})
 	})
+}
+
+// TestRemoveUpwardPastGoneParent covers the ordinary case of two cleanups of
+// one lost Job running in different processes: the hashed levels under
+// <Cwd>/<AppName>_cwd are shared, so the other process's cleanup can take a
+// level out from under ours at any moment.
+//
+// The concurrent removal is made BETWEEN openChain and removeUpward because
+// that is the production interleaving: the other cleanup lands after our
+// descent has pinned its handles, and those two calls are exactly what
+// rmEmptyDirsIn makes. Removing anything earlier would only exercise the
+// descent, which already treats a component that has gone as its end.
+//
+// The assertions are on which directories survive on disk, because a stranded
+// hashed level is invisible in the return value: the walk returns nil whether
+// it tidied everything or gave up at the first level someone else had taken.
+func TestRemoveUpwardPastGoneParent(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a proven workspace under wr's hashed levels", t, func() {
+		cwd := t.TempDir()
+		cwdBase := AppName + createdCwdBaseSuffix
+		base := filepath.Join(cwd, cwdBase)
+		h1 := filepath.Join(base, "a")
+		h2 := filepath.Join(h1, "b")
+		h3 := filepath.Join(h2, "c")
+		workSpace := filepath.Join(h3, "key-uuid")
+		So(os.MkdirAll(workSpace, 0o700), ShouldBeNil)
+
+		cwdRoot := rootOf(cwd)
+		defer cwdRoot.Close()
+
+		proven, ok := realDirBelow(cwdRoot, workSpace)
+		So(ok, ShouldBeTrue)
+
+		chain, err := proven.openChain()
+		So(err, ShouldBeNil)
+
+		defer chain.closeAll()
+
+		Convey("a second cleanup taking the workspace and deepest hashed level first still leaves nothing behind", func() {
+			So(os.Remove(workSpace), ShouldBeNil)
+			So(os.Remove(h3), ShouldBeNil)
+
+			So(chain.removeUpward(), ShouldBeNil)
+
+			So(survivorsBelow(cwd), ShouldBeEmpty)
+		})
+
+		Convey("a genuinely non-empty parent still stops the walk", func() {
+			So(os.WriteFile(filepath.Join(h1, "output.txt"), []byte("kept\n"), 0o600), ShouldBeNil)
+
+			So(chain.removeUpward(), ShouldBeNil)
+
+			So(survivorsBelow(cwd), ShouldResemble, []string{
+				cwdBase,
+				filepath.Join(cwdBase, "a"),
+				filepath.Join(cwdBase, "a", "output.txt"),
+			})
+		})
+
+		Convey("a parent that will not go stops the walk, even where the level above it would give way", func() {
+			// what the stop is worth: a pinned handle and the current name
+			// disagree once something in the tree has been renamed, which any
+			// process sharing the Cwd can do, so the level above a dir that will
+			// not go is no longer bound to be non-empty. Carrying on there would
+			// take the fresh hashed level another Job's mkHashedDir has just
+			// made. Without a rename the stop saves doomed syscalls and nothing
+			// else, since a dir that would not go is still an entry of its own
+			// parent.
+			moved := filepath.Join(base, "a.old")
+			So(os.Rename(h1, moved), ShouldBeNil)
+			So(os.Mkdir(h1, 0o700), ShouldBeNil)
+			So(os.WriteFile(filepath.Join(moved, "b", "keep.txt"), []byte("kept\n"), 0o600), ShouldBeNil)
+
+			So(chain.removeUpward(), ShouldBeNil)
+
+			So(survivorsBelow(cwd), ShouldResemble, []string{
+				cwdBase,
+				filepath.Join(cwdBase, "a"),
+				filepath.Join(cwdBase, "a.old"),
+				filepath.Join(cwdBase, "a.old", "b"),
+				filepath.Join(cwdBase, "a.old", "b", "keep.txt"),
+			})
+		})
+	})
+}
+
+// survivorsBelow lists every path still under dir, relative to it, so a strand
+// shows up as the directories it is rather than as a stat error.
+//
+// WalkDir reports an error only for dir itself or for a directory it has
+// already visited, never for a file. A directory below dir is therefore
+// recorded before the read of it fails, so the skip drops only its contents,
+// and a strand can never be passed off as an empty tree; the skip does drop
+// the children that were readable, which no assertion here needs. An error on
+// dir itself, a failed lstat of it say, leaves the list empty, but dir is the
+// test's own temp dir and the shallowest removal the code under test can make
+// is an entry of dir, never dir itself.
+func survivorsBelow(dir string) []string {
+	var out []string
+
+	prefix := dir + string(filepath.Separator)
+
+	// the walk function returns nothing but fs.SkipDir, which WalkDir itself
+	// swallows, so there is never an error here to check.
+	_ = filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error { //nolint:errcheck
+		if err != nil {
+			return fs.SkipDir
+		}
+
+		if path != dir {
+			out = append(out, strings.TrimPrefix(path, prefix))
+		}
+
+		return nil
+	})
+
+	return out
 }
 
 // startMemoryHoldingChild runs this test binary as a child holding

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -399,10 +399,33 @@ func (f *staleRmdirFS) isStale(name string) bool {
 
 // staleRmdirNode is a loopback node that asks its filesystem whether an entry is
 // stale before passing a directory removal down to the backing directory.
+//
+// The loopback is embedded by pointer because WrapChild is handed the plain
+// loopback node the loopback just made, and has to keep that node rather than a
+// copy of it: the node carries the Inode the FUSE bridge tracks it by.
 type staleRmdirNode struct {
-	gofuse.LoopbackNode
+	*gofuse.LoopbackNode
 
 	fs *staleRmdirFS
+}
+
+var _ = (gofuse.NodeWrapChilder)((*staleRmdirNode)(nil))
+
+// WrapChild puts the stale check on every node the loopback makes below this
+// one. It is what carries the behaviour down the whole tree: a node's children
+// are only wrapped where the node itself implements this, so each wrapper has to
+// hand the same wrapping on to its own children.
+//
+// The loopback only ever makes plain loopback nodes, so anything else is handed
+// back unwrapped rather than guessed at; were that ever to happen the stale
+// check would stop firing, and the test that depends on it would say so.
+func (n *staleRmdirNode) WrapChild(_ context.Context, ops gofuse.InodeEmbedder) gofuse.InodeEmbedder {
+	loopback, ok := ops.(*gofuse.LoopbackNode)
+	if !ok {
+		return ops
+	}
+
+	return &staleRmdirNode{LoopbackNode: loopback, fs: n.fs}
 }
 
 // Rmdir answers ESTALE for the one entry the test named, without touching it,
@@ -432,13 +455,10 @@ func mountStaleRmdir(t *testing.T, mountPoint, backing string) (*staleRmdirFS, b
 
 	sfs := &staleRmdirFS{}
 	root := &gofuse.LoopbackRoot{Path: backing, Dev: st.Dev}
-	root.NewNode = func(rootData *gofuse.LoopbackRoot, _ *gofuse.Inode, _ string,
-		_ *syscall.Stat_t) gofuse.InodeEmbedder {
-		return &staleRmdirNode{LoopbackNode: gofuse.LoopbackNode{RootData: rootData}, fs: sfs}
-	}
-	root.RootNode = root.NewNode(root, nil, "", &st)
+	rootNode := &staleRmdirNode{LoopbackNode: &gofuse.LoopbackNode{RootData: root}, fs: sfs}
+	root.RootNode = rootNode
 
-	server, err := gofuse.Mount(mountPoint, root.RootNode, &gofuse.Options{})
+	server, err := gofuse.Mount(mountPoint, rootNode, &gofuse.Options{})
 	if err != nil {
 		t.Logf("this host refused a FUSE mount at %s: %s", mountPoint, err)
 

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -28,6 +28,7 @@ package jobqueue
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -44,6 +45,7 @@ import (
 	"testing"
 	"time"
 
+	gofuse "github.com/hanwen/go-fuse/v2/fs"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -296,29 +298,6 @@ func TestRmEmptyDirsIn(t *testing.T) {
 // The assertions are on which directories survive on disk, because a stranded
 // hashed level is invisible in the return value: the walk returns nil whether
 // it tidied everything or gave up at the first level someone else had taken.
-// TestErrIsGone pins which errnos count as "already removed" for the upward
-// walk. ENOENT is measured on ext4 by the walk's own test above; ESTALE cannot
-// be, because it needs a network filesystem this machine does not have, so it is
-// asserted directly on the predicate rather than left as an untested branch.
-func TestErrIsGone(t *testing.T) {
-	if runnermode || servermode {
-		return
-	}
-
-	Convey("errIsGone recognises a thing that is no longer there", t, func() {
-		So(errIsGone(syscall.ENOENT), ShouldBeTrue)
-		So(errIsGone(syscall.ESTALE), ShouldBeTrue)
-		So(errIsGone(&os.PathError{Op: "unlinkat", Err: syscall.ESTALE}), ShouldBeTrue)
-
-		Convey("and nothing else, so a real failure still stops the walk", func() {
-			So(errIsGone(syscall.ENOTEMPTY), ShouldBeFalse)
-			So(errIsGone(syscall.EBUSY), ShouldBeFalse)
-			So(errIsGone(syscall.EACCES), ShouldBeFalse)
-			So(errIsGone(nil), ShouldBeFalse)
-		})
-	})
-}
-
 func TestRemoveUpwardPastGoneParent(t *testing.T) {
 	if runnermode || servermode {
 		return
@@ -388,6 +367,169 @@ func TestRemoveUpwardPastGoneParent(t *testing.T) {
 				filepath.Join(cwdBase, "a.old"),
 				filepath.Join(cwdBase, "a.old", "b"),
 				filepath.Join(cwdBase, "a.old", "b", "keep.txt"),
+			})
+		})
+	})
+}
+
+// staleRmdirFS is a filesystem whose rmdir answers ESTALE for one named entry,
+// and leaves that entry where it is. That is what a stale handle means: the
+// HANDLE the operation went through is unusable, while the object it named is
+// still there.
+//
+// The name is set by the test goroutine after the tree has been built through
+// the mount, while the FUSE server goroutine reads it in Rmdir. The kernel
+// syscall between the two is not an edge the race detector can see, so the name
+// is held atomically; nil means nothing is stale yet.
+type staleRmdirFS struct {
+	staleName atomic.Pointer[string]
+}
+
+// setStale names the entry whose removal reports a stale handle from now on.
+func (f *staleRmdirFS) setStale(name string) {
+	f.staleName.Store(&name)
+}
+
+// isStale says whether name is the entry whose removal reports a stale handle.
+func (f *staleRmdirFS) isStale(name string) bool {
+	stale := f.staleName.Load()
+
+	return stale != nil && *stale == name
+}
+
+// staleRmdirNode is a loopback node that asks its filesystem whether an entry is
+// stale before passing a directory removal down to the backing directory.
+type staleRmdirNode struct {
+	gofuse.LoopbackNode
+
+	fs *staleRmdirFS
+}
+
+// Rmdir answers ESTALE for the one entry the test named, without touching it,
+// and otherwise removes it the way the loopback does.
+func (n *staleRmdirNode) Rmdir(ctx context.Context, name string) syscall.Errno {
+	if n.fs.isStale(name) {
+		return syscall.ESTALE
+	}
+
+	return n.LoopbackNode.Rmdir(ctx, name)
+}
+
+// mountStaleRmdir really FUSE mounts backing over mountPoint as a staleRmdirFS,
+// returning the filesystem so a test can name the entry whose removal reports a
+// stale handle, and takes the mount down when the test ends. ok is false where
+// the host refused the mount, exactly as for mountLoopback.
+//
+// The mount has to be the real thing rather than a wrapped os.Root, because what
+// is under test is what an errno arriving at c.roots[i].Remove does to the walk,
+// and only a filesystem can produce that errno.
+func mountStaleRmdir(t *testing.T, mountPoint, backing string) (*staleRmdirFS, bool) {
+	t.Helper()
+
+	var st syscall.Stat_t
+
+	So(syscall.Stat(backing, &st), ShouldBeNil)
+
+	sfs := &staleRmdirFS{}
+	root := &gofuse.LoopbackRoot{Path: backing, Dev: st.Dev}
+	root.NewNode = func(rootData *gofuse.LoopbackRoot, _ *gofuse.Inode, _ string,
+		_ *syscall.Stat_t) gofuse.InodeEmbedder {
+		return &staleRmdirNode{LoopbackNode: gofuse.LoopbackNode{RootData: rootData}, fs: sfs}
+	}
+	root.RootNode = root.NewNode(root, nil, "", &st)
+
+	server, err := gofuse.Mount(mountPoint, root.RootNode, &gofuse.Options{})
+	if err != nil {
+		t.Logf("this host refused a FUSE mount at %s: %s", mountPoint, err)
+
+		return nil, false
+	}
+
+	t.Cleanup(func() {
+		if uerr := server.Unmount(); uerr != nil {
+			t.Logf("could not unmount the stale-rmdir filesystem at %s: %s", mountPoint, uerr)
+		}
+	})
+
+	return sfs, true
+}
+
+// TestRemoveUpwardOnStaleHandle pins what the upward walk does with an errno it
+// does not recognise: it stops there, and whatever directory is standing at that
+// name is left alone.
+//
+// ESTALE is the case that makes the conservative verdict the right one to pin.
+// It says the HANDLE is unusable, never that the name is missing, so the
+// directory can still be there - and the walk's next removal names the CURRENT
+// entry of the next pinned handle, which after a rename or a remove-and-recreate
+// of a shared hashed level is a different, fresh, empty directory another Job's
+// mkHashedDir has just made. Treating ESTALE as "already gone" therefore deletes
+// that directory, and this test is where that shows: the fresh <base>/a/b below
+// does not survive it.
+//
+// Whether Lustre or NFS really report ESTALE for a removal through a pinned
+// handle is UNMEASURED; no such filesystem was available. That is why the errno
+// does not belong in the "gone" set, and anyone widening that set later has to
+// answer the deletion here first.
+func TestRemoveUpwardOnStaleHandle(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a proven workspace on a filesystem that can report a stale handle", t, func() {
+		if !canMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		backing := t.TempDir()
+		cwd := t.TempDir()
+
+		stale, mounted := mountStaleRmdir(t, cwd, backing)
+		if !mounted {
+			SkipConvey("this host refused an unprivileged FUSE mount", func() {})
+
+			return
+		}
+
+		cwdBase := AppName + createdCwdBaseSuffix
+		base := filepath.Join(cwd, cwdBase)
+		h1 := filepath.Join(base, "a")
+		h2 := filepath.Join(h1, "b")
+		h3 := filepath.Join(h2, "c")
+		workSpace := filepath.Join(h3, "key-uuid")
+		So(os.MkdirAll(workSpace, 0o700), ShouldBeNil)
+
+		cwdRoot := rootOf(cwd)
+		defer cwdRoot.Close()
+
+		proven, ok := realDirBelow(cwdRoot, workSpace)
+		So(ok, ShouldBeTrue)
+
+		chain, err := proven.openChain()
+		So(err, ShouldBeNil)
+
+		defer chain.closeAll()
+
+		Convey("a stale handle stops the walk, sparing the fresh dir standing at the name above it", func() {
+			// another Job's mkHashedDir has taken b and made a new one since our
+			// descent pinned the old, so our handle and the name now disagree:
+			// the only thing keeping the walk off the new b is its refusal to
+			// carry on past an errno it does not recognise.
+			So(os.Rename(h2, filepath.Join(h1, "b.old")), ShouldBeNil)
+			So(os.Mkdir(h2, 0o700), ShouldBeNil)
+
+			stale.setStale("c")
+
+			So(chain.removeUpward(), ShouldBeNil)
+
+			So(survivorsBelow(cwd), ShouldResemble, []string{
+				cwdBase,
+				filepath.Join(cwdBase, "a"),
+				filepath.Join(cwdBase, "a", "b"),
+				filepath.Join(cwdBase, "a", "b.old"),
+				filepath.Join(cwdBase, "a", "b.old", "c"),
 			})
 		})
 	})


### PR DESCRIPTION
The upward tidy stops at the first parent that will not go. A parent that has
**already gone** was being treated as one of those, so the walk stopped there —
stranding every hashed level above it under `<Cwd>/<AppName>_cwd` permanently.

Two cleanups of one lost Job run in different processes, so a parent removed by
the other one between our descent and this walk is ordinary, not exceptional.

## The change

`removeEmptyParents` (`jobqueue/utils.go`) now treats `os.IsNotExist` as
"removed, carry on", which is the same rule `removeUpward` already applies to
the leaf:

```go
if err := c.roots[i].Remove(parents[i]); err != nil && !os.IsNotExist(err) {
    return
}
```

This is deliberately **not** folded into `errIsDirNotEmpty` or `errIsDirInUse`.
Those carry the opposite verdict — "stop, nothing of ours is left here" —
while "already gone" means "this level is done, keep going".

## Why carrying on cannot widen the blast radius

The candidate set is fixed before the loop, so the shallowest removal is still
an entry of the base, never the base itself. Every level is an ancestor of a
leaf already proven inside the base, and each removal is made in the directory
the descent opened, so it cannot escape the base however the names resolve now.

## On ESTALE

An earlier commit on this branch also tolerated `syscall.ESTALE`, on the theory
that being wrong there was cheap. **That was wrong and is reverted.** Measured
on a FUSE filesystem that answers one `rmdir` with `ESTALE`: because each step
holds a pinned handle to its parent, the next removal names the *current* entry
of the *next* handle. After a rename, that is a different, fresh, empty
directory — and it gets deleted, not refused. The tolerance would have deleted a
directory another job had just created.

It also never bought what it was added for: `os.IsNotExist` is still the test at
five sibling sites, so on an ESTALE-reporting filesystem the leaf removal aborts
before this walk is ever reached.

## Tests

- `TestRemoveUpwardPastGoneParent` — the original strand. Reverting the guard to
  `if c.roots[i].Remove(parents[i]) != nil` goes red with the strand
  `[jobqueue_cwd jobqueue_cwd/a jobqueue_cwd/a/b]`.
- `TestRemoveUpwardOnStaleHandle` — mounts a real FUSE filesystem answering one
  `rmdir` with `ESTALE`. Re-adding the ESTALE tolerance goes red, showing the
  fresh `jobqueue_cwd/a/b` deleted. Both elements of its scenario are
  load-bearing: without the rename `ENOTEMPTY` stops the walk anyway; without
  the fresh dir `ENOENT` is forgiven anyway.
- Non-empty parents still stop the walk: dropping `&& !errIsDirNotEmpty(err)`
  goes red.

Each mutation was confirmed to compile (`go vet` clean) before its verdict was
counted.

Gates: `616 passed · 13 skipped`, `0 issues.`
