### PR TITLE
Lock Job status stream reads against concurrent writes

### DIFF
--- a/.docs/bugfixes/260906-1.md
+++ b/.docs/bugfixes/260906-1.md
@@ -127,3 +127,101 @@
   Mutant race sites: `job.go:981` vs `serverCLI.go:399` (`StdOutC`),
   `job.go:1003` vs `serverCLI.go:403` (`StdErrC`), `job.go:804` vs
   `serverWebI.go:949-950` (`EnvC`/`EnvCRetrieved`). Reverted, green 5/5.
+
+- [x] The reader goroutine in `statusRacedAgainst`
+  (`jobqueue/job_status_streams_race_test.go:136-144`) drops errors returned by
+  `job.ToStatus()` (it just `return`s), so the test can pass even if `ToStatus`
+  intermittently fails during the concurrent run. Capturing the first error and
+  returning it after the wait makes failures actionable and avoids masking
+  flakiness.
+
+  - Source: Copilot review on PR #583, thread `PRRT_kwDOAKD33M6frGXJ`.
+
+  Red command. The masking is invisible to any ordinary run, so the loop is a
+  transient injection that makes `ToStatus()` fail on the reader's first call of
+  each round, plus an `atomic.Int64` counting every read the reader performs
+  (recipe kept out of the repo; both variants `go vet -tags netgo ./jobqueue/`
+  clean, exit 0, before any verdict was believed):
+
+  ```
+  unset $(compgen -v | grep '^OS_')
+  CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue/ \
+    -run 'TestJobStatusStreamsStdRace|TestJobStatusStreamsEnvRace' -v
+  ```
+
+  On the pre-fix helper the injected failure is swallowed and BOTH tests still
+  pass, having performed 1 read per round instead of 300:
+
+  ```
+  DEMO READS Std: 20
+  --- PASS: TestJobStatusStreamsStdRace (0.00s)
+  DEMO READS Env: 40
+  --- PASS: TestJobStatusStreamsEnvRace (0.00s)
+  ok  github.com/VertebrateResequencing/wr/jobqueue  0.028s
+  ```
+
+  (`demoReads` is cumulative across the two tests: 20 each, against the
+  20 rounds x 300 calls = 6000 the loop is supposed to make. The 0.00s runtime
+  against the normal ~1s is the concurrency window collapsing.)
+
+  Fix: `jobqueue/job_status_streams_race_test.go` only (+40/-11). The reader
+  goroutine now runs all `statusStreamsRaceCalls` iterations even after a
+  failure and keeps the FIRST error in a `readErr` local, which
+  `statusRacedAgainst` returns after `wg.Wait()`. `readErr` is written only by
+  the reader goroutine and read only after the wait, so the `sync.WaitGroup`
+  supplies the happens-before edge and a plain `error` needs no further
+  synchronisation.
+
+  Continuing rather than returning is the point of the change, not a detail: the
+  loop exists to keep `ToStatus()` reads overlapping the writer's whole run, so
+  an early return shrinks the window the race detector gets to watch by 300x
+  while leaving the test green. That is the same "guard that reports success
+  having exercised almost nothing" shape as the earlier counter-of-absence and
+  `> 0` assertion findings.
+
+  Both callers had the same masking one level up: `status, err =
+  statusRacedAgainst(...)` inside the 20-round loop overwrote every round's
+  error but the last. They now retain the first error across rounds in `raceErr`
+  and assert on that, with the assertion still outside the loop (go-conventions
+  bars `So()` in loops of >20 iterations). `status.StdOut`, `status.StdErr` and
+  `status.Env` are untouched, as are `statusStreamsRaceJobs` and
+  `statusStreamsRaceCalls`.
+
+  Post-fix verdicts, each `go vet -tags netgo ./jobqueue/` clean and exit 0
+  first:
+
+  | Check | Verdict |
+  |---|---|
+  | Same injection on the fixed helper | RED, both tests, 6000 reads each |
+  | `RLock`/`RUnlock` removed from `Env()`/`StdOut()`/`StdErr()` | RED, 6 x `WARNING: DATA RACE` |
+  | Unmutated, `-race` | green 8/8 runs |
+
+  The injected-failure run now reports it:
+
+  ```
+  DEMO READS Std: 6000
+  Expected: nil
+  Actual:   'injected ToStatus failure'
+  --- FAIL: TestJobStatusStreamsStdRace (0.25s)
+  DEMO READS Env: 12000
+  --- FAIL: TestJobStatusStreamsEnvRace (0.01s)
+  FAIL  github.com/VertebrateResequencing/wr/jobqueue  0.276s
+  ```
+
+  The production-lock mutation still names the same sites the original fix
+  guards: `job.go:981` vs `serverCLI.go:399` (`StdOutC`), `job.go:1003` vs
+  `serverCLI.go:403` (`StdErrC`), `job.go:804` vs `serverWebI.go:925-926`
+  (`EnvC`/`EnvCRetrieved`). `jobqueue/job.go` restored byte-for-byte
+  (`git diff --quiet -- jobqueue/job.go` passes).
+
+  Gates from `/home/ubuntu/wr_race`: `make test` 619 passed · 13 skipped,
+  `make race` 619 passed · 13 skipped with zero `WARNING: DATA RACE`,
+  `make lint` `0 issues.`
+
+  Gate noise, not a finding: the first `make test` run failed
+  `TestSchedulerSubmitJobsAndWait` (`client/client_test.go:969`) after 7.67s on a
+  box carrying other agents' builds (load average 1.89-3.68). It passes alone
+  (`go test -tags netgo --count 1 ./client/ -run TestSchedulerSubmitJobsAndWait`,
+  ok 4.339s) and the immediate full re-run was green. It is in neither package
+  this change touches. Flagged here so a recurrence is recognised as the second
+  sighting rather than the first.

--- a/.docs/bugfixes/260906-1.md
+++ b/.docs/bugfixes/260906-1.md
@@ -1,0 +1,129 @@
+# Bugfixes 2026-09-06
+
+- [x] `(*Job).statusStreams()` reads three compressed fields with NO lock held,
+  while a runner's heartbeat RPC writes two of them under `job.Lock()` on the
+  SAME queue-held `*Job`.
+
+  The unlocked reads, all from `statusStreams` (`jobqueue/job.go:1647`, `:1651`,
+  `:1655`):
+
+  - `j.StdErr()` - `jobqueue/job.go:985-990`, reads `j.StdErrC` bare
+  - `j.StdOut()` - `jobqueue/job.go:967-972`, reads `j.StdOutC` bare
+  - `j.Env()` - `jobqueue/job.go:799-801`, reads `j.EnvC` and `j.EnvCRetrieved`
+    bare
+
+  The locked writes, on a queue-held Job:
+
+  - `applyLiveSnapshot` (`jobqueue/serverCLI.go:389-405`) does `job.Lock();
+    defer job.Unlock()` then `job.StdOutC = jes.Stdout` and `job.StdErrC =
+    jes.Stderr`. Reached from a runner's touch RPC: `handleTouch`
+    (`serverCLI.go:1196`) -> `touchJob` -> `emitLiveTouchSnapshot`
+    (`serverCLI.go:1256-1261`).
+  - The same two fields are written again on the JobEnded path at
+    `serverCLI.go:1363-1364`.
+
+  The reader, on the same pointer:
+
+  ```
+  queue change-callback goroutine
+    jobqueue/server.go:4983        q.SetChangedCallback(...)
+    jobqueue/jobtransition.go:213  emitChangeCallbackTransition
+    jobqueue/jobtransition.go:254  job := inter.(*Job)     <- queue-held pointer
+    jobqueue/jobtransition.go:269  waitForJobStartTime(job)  <- when to == JobStateRunning
+    jobqueue/jobtransition.go:271  job.ToStatus()
+    jobqueue/job.go:1537 -> 1647   statusStreams -> StdErr()/StdOut()/Env()
+  ```
+
+  The overlap is by design: `waitForJobStartTime(job)` deliberately spins until
+  the runner's `Started` RPC lands, so the reader is made to wait for exactly
+  the runner whose subsequent touches write these fields.
+
+  `EnvC`/`EnvCRetrieved` are the same unlocked-read shape in the same function.
+  They are race-free today only because of two unstated invariants
+  (`copyJobForClient` is the only way a queue-held Job becomes client-facing,
+  and no DB retrieval memoises a `*Job`), so they are fixed under the same
+  discipline.
+
+  Red command (10/10 runs RED on `ae368add`, ~1.2s per run). It was first built
+  as a throwaway harness (`TestRedStdRace`/`TestRedEnvRace`) and became the
+  committed regression test `jobqueue/job_status_streams_race_test.go`:
+
+  ```
+  unset $(compgen -v | grep '^OS_')
+  CGO_ENABLED=1 go test -tags netgo -race --count 1 ./jobqueue/ \
+    -run 'TestJobStatusStreamsStdRace|TestJobStatusStreamsEnvRace'
+  ```
+
+  Bounded output:
+
+  ```
+  ==================
+  WARNING: DATA RACE
+  Write at 0x00c0002d2268 by goroutine 17:
+    ...jobqueue.applyLiveSnapshot()
+        /home/ubuntu/wr_race/jobqueue/serverCLI.go:399 +0x2ba
+
+  Previous read at 0x00c0002d2268 by goroutine 16:
+    ...jobqueue.(*Job).StdOut()
+        /home/ubuntu/wr_race/jobqueue/job.go:968 +0x3b
+    ...jobqueue.(*Job).statusStreams()
+        /home/ubuntu/wr_race/jobqueue/job.go:1651 +0x8b
+    ...jobqueue.(*Job).ToStatus()
+        /home/ubuntu/wr_race/jobqueue/job.go:1537 +0x8f
+  ==================
+  WARNING: DATA RACE
+  Write at 0x00c0002d2250 by goroutine 17:
+    ...jobqueue.applyLiveSnapshot()
+        /home/ubuntu/wr_race/jobqueue/serverCLI.go:403 +0x37a
+
+  Previous read at 0x00c0002d2250 by goroutine 16:
+    ...jobqueue.(*Job).StdErr()
+        /home/ubuntu/wr_race/jobqueue/job.go:986 +0x3b
+    ...jobqueue.(*Job).statusStreams()
+        /home/ubuntu/wr_race/jobqueue/job.go:1647 +0x6b
+  ==================
+  --- FAIL: TestRedStdRace (0.86s)
+  --- FAIL: TestRedEnvRace (0.27s)
+  FAIL	github.com/VertebrateResequencing/wr/jobqueue	1.199s
+  ```
+
+  Eight `WARNING: DATA RACE` reports per run in total, naming `StdOutC`
+  (`job.go:968`, `:972` vs `serverCLI.go:399`), `StdErrC` (`job.go:986`, `:990`
+  vs `serverCLI.go:403`), and `EnvC`/`EnvCRetrieved` (`job.go:800` vs
+  `serverWebI.go:944-950`).
+
+  Fix: `jobqueue/job.go` only (+32/-7). `Env()`, `StdOut()` and `StdErr()` each
+  take `j.RLock()`, copy out the stored environment (via the existing
+  `storedEnvLocked`, whose caller-holds-the-read-lock contract this satisfies)
+  or the `StdOutC`/`StdErrC` slice header, then release the lock BEFORE
+  decompressing and decoding. `Env()` no longer calls `envOverrideSnapshot`,
+  which takes `j.RLock()` itself: `sync.RWMutex` is not safely reentrant for
+  readers, so an outer `RLock` around it would deadlock behind a waiting writer.
+  `envOverrideSnapshot` and `envCurrentOverrides` are unchanged, and
+  `statusStreams` still calls `envCurrentOverrides` with no lock held.
+
+  Copying the slice header out is sufficient because all five fields are only
+  ever replaced wholesale. Every write site across the repo, tests included, is
+  a plain whole-slice assignment; a grep for `append(x.Field, ...)`,
+  `copy(x.Field, ...)` and `x.Field[i] = ...` on `StdOutC`, `StdErrC`, `EnvC`,
+  `EnvCRetrieved` and `EnvOverride` returns zero hits. This is the same
+  reasoning `storedEnvLocked` already documents and `workSpaceSnapshotLocked`
+  already relies on.
+
+  Regression test: `jobqueue/job_status_streams_race_test.go`, driving
+  `job.ToStatus()` on one goroutine against `applyLiveSnapshot` (Std) and
+  `resetCompletedJobForRerun` (Env) on another, over one `*Job` per round.
+
+  Mutation verdicts, each `go vet ./cmd/ ./jobqueue/` clean and exit 0 before
+  the verdict was believed:
+
+  | Mutation (RLock/RUnlock removed, locals kept) | `go vet` | Verdict |
+  |---|---|---|
+  | `StdOut()` unlocked | clean, exit 0 | RED |
+  | `StdErr()` unlocked | clean, exit 0 | RED |
+  | `Env()` unlocked | clean, exit 0 | RED |
+  | all three | clean, exit 0 | RED 10/10 runs |
+
+  Mutant race sites: `job.go:981` vs `serverCLI.go:399` (`StdOutC`),
+  `job.go:1003` vs `serverCLI.go:403` (`StdErrC`), `job.go:804` vs
+  `serverWebI.go:949-950` (`EnvC`/`EnvCRetrieved`). Reverted, green 5/5.

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -796,8 +796,16 @@ func (j *Job) WallTime() time.Duration {
 // variables instead. A stored non-nil empty environment returns an empty slice.
 // In both cases, alters the return value to apply any overrides stored in
 // job.EnvOverride.
+//
+// The stored environment is copied out under the Job's read lock and decoded
+// after releasing it, since the manager writes these fields under the Job's
+// write lock while a status gather is reading them.
 func (j *Job) Env() ([]string, error) {
-	return jobEnv{envC: j.EnvC, overrides: j.envOverrideSnapshot(), retrieved: j.EnvCRetrieved}.decode()
+	j.RLock()
+	stored := j.storedEnvLocked()
+	j.RUnlock()
+
+	return stored.decode()
 }
 
 // envDecodeHook, when set, is called every time a Job's stored environment is
@@ -964,17 +972,28 @@ func (j *Job) Getenv(key string) string {
 // nothing to STDOUT, you will get an empty string. Note that StdOutC is only
 // populated if you got the Job from GetByCmd(_, true), and if the Job's Cmd ran
 // but failed.
+//
+// The manager writes StdOutC and StdErrC under the Job's write lock while a
+// status gather is reading them, so the slice header is copied out under the
+// read lock, which is then released for the decompress. Copying the header is
+// enough, since both are only ever replaced wholesale - by a runner's snapshot
+// of its Cmd's output, by the retrieval that fills them from the database, and
+// by the reset that clears them for a rerun - so the bytes are never written to.
 func (j *Job) StdOut() (string, error) {
-	if len(j.StdOutC) == 0 {
+	j.RLock()
+	stdOutC := j.StdOutC
+	j.RUnlock()
+
+	if len(stdOutC) == 0 {
 		return "", nil
 	}
 
-	decomp, err := decompress(j.StdOutC)
+	decomp, err := decompress(stdOutC)
 	if err != nil {
 		return "", err
 	}
 
-	return string(decomp), err
+	return string(decomp), nil
 }
 
 // StdErr returns the decompressed job.StdErrC, which is the head and tail of
@@ -982,17 +1001,23 @@ func (j *Job) StdOut() (string, error) {
 // nothing to STDERR, you will get an empty string. Note that StdErrC is only
 // populated if you got the Job from GetByCmd(_, true), and if the Job's Cmd ran
 // but failed.
+//
+// It takes the read lock for the same reason StdOut does.
 func (j *Job) StdErr() (string, error) {
-	if len(j.StdErrC) == 0 {
+	j.RLock()
+	stdErrC := j.StdErrC
+	j.RUnlock()
+
+	if len(stdErrC) == 0 {
 		return "", nil
 	}
 
-	decomp, err := decompress(j.StdErrC)
+	decomp, err := decompress(stdErrC)
 	if err != nil {
 		return "", err
 	}
 
-	return string(decomp), err
+	return string(decomp), nil
 }
 
 // TriggerBehaviours triggers this Job's Behaviours based on if its Cmd got

--- a/jobqueue/job_status_streams_race_test.go
+++ b/jobqueue/job_status_streams_race_test.go
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// statusStreamsRaceJobs is how many separate Jobs the race tests below
+	// contend on. A fresh Job per round gives the race detector fresh addresses
+	// to watch, which finds an unsynchronised access far more reliably than
+	// hammering one address for longer does.
+	statusStreamsRaceJobs = 20
+
+	// statusStreamsRaceCalls is how many times each of the two contending
+	// goroutines calls into the production code per Job.
+	statusStreamsRaceCalls = 300
+)
+
+// TestJobStatusStreamsStdRace covers the overlap the manager creates by design:
+// the queue's change-callback goroutine calls ToStatus() on the queue-held *Job
+// (jobtransition.go, after waitForJobStartTime deliberately waits for the
+// runner's Started RPC), while that same runner's touches reach
+// applyLiveSnapshot, which writes StdOutC and StdErrC on the same *Job under its
+// write lock.
+//
+// ToStatus() gathers the streams BEFORE it takes the Job's read lock, so the
+// accessors it calls must take that lock themselves. The race detector is the
+// verdict here: remove the locking from StdOut()/StdErr() and this goes red.
+func TestJobStatusStreamsStdRace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given the head and tail of a running Cmd's output", t, func() {
+		const std = "some stdout that is long enough to be worth compressing"
+
+		compressed, err := compress([]byte(std))
+		So(err, ShouldBeNil)
+
+		Convey("ToStatus() on a Job a runner is touching does not race with the touch", func() {
+			var status JStatus
+
+			for range statusStreamsRaceJobs {
+				job := newStatusStreamsRaceJob()
+				snapshot := &JobEndState{Cwd: job.Cwd, Stdout: compressed, Stderr: compressed}
+
+				status, err = statusRacedAgainst(job, func() { applyLiveSnapshot(job, snapshot) })
+			}
+
+			So(err, ShouldBeNil)
+			So(status.StdOut, ShouldEqual, std)
+			So(status.StdErr, ShouldEqual, std)
+		})
+	})
+}
+
+// TestJobStatusStreamsEnvRace is TestJobStatusStreamsStdRace for EnvC and
+// EnvCRetrieved, which ToStatus() reads through Env() in the same unlocked
+// gather, and which the web interface's rerun of a completed job clears under
+// the Job's write lock.
+func TestJobStatusStreamsEnvRace(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a completed Job with a stored environment", t, func() {
+		envC, err := compressEnv([]string{"WR_RACE_ONE=1", "WR_RACE_TWO=2"})
+		So(err, ShouldBeNil)
+
+		Convey("ToStatus() on it does not race with the web interface rerunning it", func() {
+			var status JStatus
+
+			for range statusStreamsRaceJobs {
+				job := newStatusStreamsRaceJob()
+				job.State = JobStateComplete
+				job.EnvC = envC
+				job.EnvCRetrieved = true
+
+				status, err = statusRacedAgainst(job, func() { resetCompletedJobForRerun(job) })
+			}
+
+			So(err, ShouldBeNil)
+			So(status.Env, ShouldBeEmpty)
+		})
+	})
+}
+
+// newStatusStreamsRaceJob makes a running Job that ToStatus() can be called on.
+func newStatusStreamsRaceJob() *Job {
+	return &Job{
+		Cmd:          "sleep 1",
+		Cwd:          "/tmp",
+		RepGroup:     "status_streams_race",
+		Requirements: &scheduler.Requirements{RAM: 1, Time: 1, Cores: 1},
+		State:        JobStateRunning,
+	}
+}
+
+// statusRacedAgainst calls job.ToStatus() on one goroutine while write runs on
+// another, both statusStreamsRaceCalls times against the one *Job, then returns
+// the status of the settled Job.
+func statusRacedAgainst(job *Job, write func()) (JStatus, error) {
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for range statusStreamsRaceCalls {
+			if _, err := job.ToStatus(); err != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range statusStreamsRaceCalls {
+			write()
+		}
+	}()
+
+	wg.Wait()
+
+	return job.ToStatus()
+}

--- a/jobqueue/job_status_streams_race_test.go
+++ b/jobqueue/job_status_streams_race_test.go
@@ -67,16 +67,24 @@ func TestJobStatusStreamsStdRace(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("ToStatus() on a Job a runner is touching does not race with the touch", func() {
-			var status JStatus
+			var (
+				status  JStatus
+				raceErr error
+			)
 
 			for range statusStreamsRaceJobs {
 				job := newStatusStreamsRaceJob()
 				snapshot := &JobEndState{Cwd: job.Cwd, Stdout: compressed, Stderr: compressed}
 
-				status, err = statusRacedAgainst(job, func() { applyLiveSnapshot(job, snapshot) })
+				var roundErr error
+
+				status, roundErr = statusRacedAgainst(job, func() { applyLiveSnapshot(job, snapshot) })
+				if raceErr == nil {
+					raceErr = roundErr
+				}
 			}
 
-			So(err, ShouldBeNil)
+			So(raceErr, ShouldBeNil)
 			So(status.StdOut, ShouldEqual, std)
 			So(status.StdErr, ShouldEqual, std)
 		})
@@ -97,7 +105,10 @@ func TestJobStatusStreamsEnvRace(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("ToStatus() on it does not race with the web interface rerunning it", func() {
-			var status JStatus
+			var (
+				status  JStatus
+				raceErr error
+			)
 
 			for range statusStreamsRaceJobs {
 				job := newStatusStreamsRaceJob()
@@ -105,10 +116,15 @@ func TestJobStatusStreamsEnvRace(t *testing.T) {
 				job.EnvC = envC
 				job.EnvCRetrieved = true
 
-				status, err = statusRacedAgainst(job, func() { resetCompletedJobForRerun(job) })
+				var roundErr error
+
+				status, roundErr = statusRacedAgainst(job, func() { resetCompletedJobForRerun(job) })
+				if raceErr == nil {
+					raceErr = roundErr
+				}
 			}
 
-			So(err, ShouldBeNil)
+			So(raceErr, ShouldBeNil)
 			So(status.Env, ShouldBeEmpty)
 		})
 	})
@@ -127,18 +143,26 @@ func newStatusStreamsRaceJob() *Job {
 
 // statusRacedAgainst calls job.ToStatus() on one goroutine while write runs on
 // another, both statusStreamsRaceCalls times against the one *Job, then returns
-// the status of the settled Job.
+// the status of the settled Job, along with the first error either the racing
+// reads or that final read produced.
 func statusRacedAgainst(job *Job, write func()) (JStatus, error) {
-	var wg sync.WaitGroup
+	var (
+		wg      sync.WaitGroup
+		readErr error
+	)
 
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
 
+		// this loop must run in full even after a failure: its job is to keep
+		// reads overlapping the writer's entire run, so stopping early would
+		// silently shrink the window the race detector gets to watch. readErr
+		// is written only here and read only after wg.Wait().
 		for range statusStreamsRaceCalls {
-			if _, err := job.ToStatus(); err != nil {
-				return
+			if _, err := job.ToStatus(); err != nil && readErr == nil {
+				readErr = err
 			}
 		}
 	}()
@@ -153,5 +177,10 @@ func statusRacedAgainst(job *Job, write func()) (JStatus, error) {
 
 	wg.Wait()
 
-	return job.ToStatus()
+	status, err := job.ToStatus()
+	if readErr != nil {
+		return status, readErr
+	}
+
+	return status, err
 }


### PR DESCRIPTION
`(*Job).statusStreams()` read three compressed fields with no lock held, while a
runner's heartbeat RPC writes two of them under `job.Lock()` on the **same
queue-held `*Job`**.

## Why the two really do overlap

```
queue change-callback goroutine
  jobqueue/jobtransition.go:254  job := inter.(*Job)      <- queue-held pointer
  jobqueue/jobtransition.go:269  waitForJobStartTime(job) <- when to == JobStateRunning
  jobqueue/jobtransition.go:271  job.ToStatus()
  jobqueue/job.go:1537 -> 1647   statusStreams -> StdErr()/StdOut()/Env()
```

against `applyLiveSnapshot` (`jobqueue/serverCLI.go:389-405`), which writes
`job.StdOutC`/`job.StdErrC` under the Job's lock, reached from `handleTouch`
(`serverCLI.go:1196`) on a runner heartbeat, and again on the JobEnded path at
`serverCLI.go:1363-1364`.

The overlap is **by design**: `waitForJobStartTime(job)` deliberately spins until
the runner's `Started` RPC lands, so the reader is made to wait for exactly the
runner whose subsequent touches write these fields.

## The change

`Env()`, `StdOut()` and `StdErr()` each take `j.RLock()`, copy the snapshot out,
release, then decompress:

```go
func (j *Job) Env() ([]string, error) {
	j.RLock()
	stored := j.storedEnvLocked()
	j.RUnlock()

	return stored.decode()
}
```

`jobqueue/job.go` only, +32/-7.

## A second defect the same change fixes

The old `Env()` read `EnvOverride` under one lock acquisition (via
`envOverrideSnapshot`) and `EnvC`/`EnvCRetrieved` under none, so those three
could tear **relative to each other**, not only against a writer. One
acquisition removes that.

## Why it cannot deadlock

`Env()` no longer calls `envOverrideSnapshot`, which takes `RLock` itself —
nesting that inside another `RLock` deadlocks if a writer arrives between the
two, since Go's `RWMutex` is not safely reentrant for readers. It calls
`storedEnvLocked` instead, whose body is three bare field reads. Nothing inside
any of the three critical sections acquires a lock, and no caller of
`Env()`/`Getenv()`/`StdOut()`/`StdErr()`/`ToStatus()` anywhere in the repo holds
the Job's lock — `ToStatus` calls `statusStreams()` at `job.go:1537` *before* its
own `RLock` at `:1542`. `decompress`, the binc decode and `os.Environ()` all run
after `RUnlock`.

## Why copying the header out is enough

Every write site of `StdOutC`, `StdErrC`, `EnvC`, `EnvCRetrieved` and
`EnvOverride` across the repo, tests included, is a whole-slice assignment.
Greps for `append(x.Field, ...)`, `copy(x.Field, ...)` and `x.Field[i] = ...` on
all five return zero hits, so no in-place mutation can be observed through a
copied header.

## Evidence

- Red: `TestJobStatusStreamsStdRace` / `TestJobStatusStreamsEnvRace`, **10/10
  runs**, 8 `WARNING: DATA RACE` each, naming `job.go:968` and `:986` against
  `serverCLI.go:399` and `:403`.
- Mutation (all three `RLock` pairs removed, still compiling, `go vet` clean):
  **red 10/10**. Each accessor was also mutated individually and each is
  independently red, so no one guard carries the others.

Gates: `make test` and `make race` both `619 passed · 13 skipped`, zero race
reports; `make lint` `0 issues.`
