### PR TITLE
Exclude the unstable gosec G703 from test files

### DIFF
--- a/.docs/bugfixes/260906-2.md
+++ b/.docs/bugfixes/260906-2.md
@@ -113,3 +113,27 @@
     assertions are byte-identical apart from a proven no-op, and a test
     asserting a config line exists or that comments are absent would assert an
     implementation detail.
+
+## A fifth load-sensitive test, observed while gating this branch
+
+`TestReliable4StatusSeedBoundary` failed once during central gating of this
+branch, taking **60.68s**. It is not in the set the other records name
+(`TestReliable2FastStartupNoHistoryScan`, `TestRESTJobModificationEndpoint`,
+`TestServerWebI`, `TestJobqueueSignal`), so it is recorded here rather than
+waved through.
+
+Established as contention, not this change, three ways:
+
+- Run alone at load ~1.2 it takes **7s and passes, 3/3**. The failing run was
+  ~9x slower, with three agents running Go suites on the same 4-CPU box.
+- A full `make test` re-run at low load on the same tree is green:
+  `617 passed · 13 skipped · 29 packages · 6m31s`.
+- This branch changes `.golangci.yml`, `jobqueue/deletion_probes_test.go`,
+  `jobqueue/lost_job_behaviours_test.go` and `jobqueue/serverWebI_test.go`.
+  `TestReliable4StatusSeedBoundary` is in none of them, and no production code
+  is touched at all.
+
+Not fixed, and deliberately so: a test that asserts a timing boundary cannot
+hold on a saturated box, and "fixing" it would mean weakening the boundary it
+exists to check. The actionable form of this is the same as for the other four
+- check load before believing a failure.

--- a/.docs/bugfixes/260906-2.md
+++ b/.docs/bugfixes/260906-2.md
@@ -1,0 +1,115 @@
+# Bugfixes 260906-2
+
+- [x] `gosec`'s `G703: Path traversal via taint analysis` is inter-procedural
+  and unstable in this package. It fires and stops firing on test helpers
+  based on completely unrelated edits, including a change to a Go comment and
+  a markdown file, and it reproduces after `golangci-lint cache clean`. That
+  instability makes suppression impossible in both directions: when the
+  finding is absent, `nolintlint` reports the `//nolint:gosec` directive as
+  unused, which is itself an error; when it is present, the directive is
+  required. There is no stable state. It has been worked around three
+  different ways in three PRs (#577 statement-splitting, #578 `//nolint`, #579
+  `filepath.Clean`), and some places use `#nosec` specifically because
+  nolintlint cannot inspect `#nosec` and therefore cannot report it unused.
+  Every instance has been a test helper acting on a path the test itself
+  created under `t.TempDir()`; no production code path has ever been
+  implicated. Exclude `G703` from `_test.go` files in `.golangci.yml`, then
+  remove only the directives and comments that exclusion makes dead.
+  - Red command (run from `/home/ubuntu/wr_tidy`, tree otherwise clean):
+
+    ```
+    sed -i 's|// #nosec G703 -- test-controlled path under t.TempDir|//nolint:gosec // test-controlled path under t.TempDir|g' \
+      jobqueue/deletion_probes_test.go && golangci-lint run
+    ```
+
+    That rewrites the five `#nosec G703` markers in the one helper into the
+    directive form the repo would otherwise use. Output:
+
+    ```
+    jobqueue/deletion_probes_test.go:1284:32: directive `//nolint:gosec // test-controlled path under t.TempDir` is unused for linter "gosec" (nolintlint)
+    jobqueue/deletion_probes_test.go:1288:51: directive `//nolint:gosec // test-controlled path under t.TempDir` is unused for linter "gosec" (nolintlint)
+    jobqueue/deletion_probes_test.go:1289:51: directive `//nolint:gosec // test-controlled path under t.TempDir` is unused for linter "gosec" (nolintlint)
+    jobqueue/deletion_probes_test.go:1290:51: directive `//nolint:gosec // test-controlled path under t.TempDir` is unused for linter "gosec" (nolintlint)
+    jobqueue/deletion_probes_test.go:1292:28: directive `//nolint:gosec // test-controlled path under t.TempDir` is unused for linter "gosec" (nolintlint)
+    5 issues:
+    * nolintlint: 5
+    ```
+
+    The standard suppression form is an error, so the code is pinned to
+    `#nosec`, which nolintlint cannot audit.
+  - Second red symptom, present on every run of `make lint` on the unmodified
+    tree: the prose explaining that workaround is itself parsed as a
+    directive.
+
+    ```
+    level=warning msg="[runner/nolint_filter] Found unknown linters in //nolint directives: gosec because nolintlint does not inspect #nosec, so it cannot report"
+    ```
+  - Green: `.golangci.yml` excludes `G703` from `_test\.go`; every G703
+    suppression and the prose justifying it is gone; `make lint` and
+    `golangci-lint run --new-from-rev=""` report no gosec or nolintlint issue
+    and no `nolint_filter` warning; perturbing a Go comment and a markdown
+    file cannot flip the result.
+
+  - Fixed. `.golangci.yml` gains one exclusion rule in
+    `linters.exclusions.rules`, scoped to `gosec` + `path: _test\.go` +
+    `text: "G703"`. Nothing else in that file changed, and production gosec
+    coverage is untouched: `jobqueue/server.go:4865` still reports G703 when
+    its directive is stripped, and `jobqueue/archivefold.go:158` still reports
+    G115.
+  - Removed, each proven dead by lint rather than by reading:
+    `jobqueue/deletion_probes_test.go` loses the eight-line doc-comment
+    paragraph explaining the `#nosec`-versus-`//nolint` technique and the five
+    `// #nosec G703` markers in `replaceWithADirOfItsOwn`;
+    `jobqueue/serverWebI_test.go:3489` loses one `// #nosec G703`. Exclusion
+    rules run before the nolint filter, so any surviving G703 directive is now
+    unconditionally reported unused — re-adding one at
+    `deletion_probes_test.go:1276` produces exactly that error, and the tree's
+    zero `nolintlint` count proves none is left.
+  - Kept: every other gosec directive, each still naming a live rule when
+    stripped — G204 (`reliable4_runnerpid_test.go:317`'s gosec half,
+    `behaviours_test.go:163`, `serverWebI_test.go:3333`,
+    `scheduler/process_test.go:398`), G115 (`archivefold.go:158`), G306
+    (`scheduler/scheduler_lsf_test.go:990`), G101 (`jobqueue_test.go:131`),
+    G404. No non-gosec directive was touched: `noctx` 13, `nilnil` 13,
+    `errcheck` 61, `misspell` 5, `forbidigo` 11, `gochecknoglobals` 71,
+    `usetesting` 6 and `dogsled` 6 are unchanged from the base commit.
+  - `jobqueue/lost_job_behaviours_test.go:627` reverts the #579 workaround
+    `os.Stat(filepath.Clean(path))` to `os.Stat(path)`. Every caller passes a
+    `mkHashedDir` path built with `filepath.Join`, which Cleans internally, so
+    the wrap was a no-op; and `soGoneWithin`'s own timeout fallback
+    `soPathsGone` stats the same raw value, so the helper had been polling one
+    string and asserting on another. `path/filepath` has 16 other uses in the
+    file, so the import stays.
+  - The instability reproduced live on the unmodified tree, which is why the
+    unfiltered figure below is 40 rather than 37 in some runs. Two consecutive
+    `golangci-lint run --new-from-rev=""` invocations on the pristine
+    checkout, nothing edited between them:
+
+    ```
+    run 1: jobqueue/behaviours_test.go:536:20  G703: Path traversal via taint analysis (gosec)
+           jobqueue/behaviours_test.go:1850:20 G703: Path traversal via taint analysis (gosec)
+           jobqueue/jobqueue_test.go:398:22    G703: Path traversal via taint analysis (gosec)
+           40 issues: * gosec: 3
+    run 2 (after golangci-lint cache clean): 37 issues, no gosec
+    ```
+
+    `behaviours_test.go:1850` is `soPathsGone`'s own `os.Stat`, which confirms
+    the `filepath.Clean` in its sibling was cargo rather than protection.
+  - Stability demonstration: three cold `golangci-lint cache clean` cycles on
+    the fixed tree gave `0 issues.` filtered and 37 unfiltered every time. A
+    reviewer separately ran seven perturb-and-revert states — a Go comment in
+    a test file, a Go comment in production `jobqueue/utils.go`, a Go comment
+    beside the live production G703 in `jobqueue/server.go`, an appended
+    `README.md` line, and two of those repeated after `cache clean` — all
+    `0 issues.` filtered and 37 unfiltered, zero gosec, zero nolintlint.
+    Nothing flipped. The exclusion drops the issue before the nolint filter
+    runs, so the unstable analysis result no longer feeds a directive-usage
+    decision at all.
+  - Gates: `make lint` `0 issues.` with the
+    `[runner/nolint_filter] Found unknown linters in //nolint directives`
+    warning gone; `golangci-lint run --new-from-rev=""` 37 issues, zero gosec
+    and zero nolintlint; `make test` 617 passed, 13 skipped, 29 packages.
+  - No new test. Per testing-principles, no supported behaviour changed: the
+    assertions are byte-identical apart from a proven no-op, and a test
+    asserting a config line exists or that comments are absent would assert an
+    implementation detail.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,6 +139,10 @@ linters:
           - revive
         path: _test\.go
       - linters:
+          - gosec
+        path: _test\.go
+        text: "G703"
+      - linters:
           - funlen
           - mnd
         path: internal

--- a/jobqueue/deletion_probes_test.go
+++ b/jobqueue/deletion_probes_test.go
@@ -1272,24 +1272,16 @@ type probeWindowRow struct {
 // It asserts the identity really did change, so an ordering that lets the inode
 // be reused fails here, naming the premise, rather than turning over the
 // expectation of whichever row relied on it.
-//
-// gosec cannot prove the dir passed in is clean, so it reports G703 on each of
-// the calls below; every caller passes a path this test built under its own
-// t.TempDir(), so the only taint is the test's own. #nosec rather than
-// //nolint:gosec because nolintlint does not inspect #nosec, so it cannot report
-// the directive as unused on a run that does not reach gosec's analysis of this
-// file - which is also the repo's convention for this rule in a test (see
-// serverWebI_test.go).
 func replaceWithADirOfItsOwn(dir string) {
-	checked, err := os.Lstat(dir) // #nosec G703 -- test-controlled path under t.TempDir
+	checked, err := os.Lstat(dir)
 	So(err, ShouldBeNil)
 
 	spare := dir + "_spare"
-	So(os.MkdirAll(spare, os.ModePerm), ShouldBeNil) // #nosec G703 -- test-controlled path under t.TempDir
-	So(os.RemoveAll(dir), ShouldBeNil)               // #nosec G703 -- test-controlled path under t.TempDir
-	So(os.Rename(spare, dir), ShouldBeNil)           // #nosec G703 -- test-controlled path under t.TempDir
+	So(os.MkdirAll(spare, os.ModePerm), ShouldBeNil)
+	So(os.RemoveAll(dir), ShouldBeNil)
+	So(os.Rename(spare, dir), ShouldBeNil)
 
-	now, err := os.Lstat(dir) // #nosec G703 -- test-controlled path under t.TempDir
+	now, err := os.Lstat(dir)
 	So(err, ShouldBeNil)
 	So(os.SameFile(now, checked), ShouldBeFalse)
 }

--- a/jobqueue/lost_job_behaviours_test.go
+++ b/jobqueue/lost_job_behaviours_test.go
@@ -624,7 +624,7 @@ func soGoneWithin(path string) {
 	deadline := time.Now().Add(lostRunSettleTime)
 
 	for time.Now().Before(deadline) {
-		_, err := os.Stat(filepath.Clean(path))
+		_, err := os.Stat(path)
 		if os.IsNotExist(err) {
 			return
 		}

--- a/jobqueue/serverWebI_test.go
+++ b/jobqueue/serverWebI_test.go
@@ -3486,7 +3486,6 @@ export function setupLiveWalltime(job, walltime) {
 	rewritten = strings.ReplaceAll(rewritten, "'/js/wr/utility.js'", fmt.Sprintf("%q", fileURL(utilityPath)))
 
 	modalPath := filepath.Join(dir, "modal-handlers.js")
-	// #nosec G703 -- modalPath is generated inside t.TempDir for a test-only module.
 	err = os.WriteFile(modalPath, []byte(rewritten), 0600)
 	So(err, ShouldBeNil)
 


### PR DESCRIPTION
`gosec`'s `G703: Path traversal via taint analysis` is **inter-procedural and
unstable** in this package. It fires and stops firing on test helpers based on
completely unrelated edits — including a change to a Go comment and a markdown
file — and it reproduces after `golangci-lint cache clean`, so it is not a
caching artefact.

That makes suppression impossible in **both** directions: when the finding is
absent, `nolintlint` reports the `//nolint:gosec` directive as unused, which is
itself an error; when it is present, the directive is required. There is no
stable state. It has been worked around three different ways in three PRs —
#577 split a statement, #578 added `//nolint`, #579 added `filepath.Clean` — and
some sites use `#nosec` **specifically because** `nolintlint` cannot inspect it
and therefore cannot report it unused.

Every instance has been a test helper acting on a path the test itself created
under `t.TempDir()`. No production code path has ever been implicated and no
instance has been a real vulnerability.

## The change

One exclusion rule, scoped to the rule and to test files:

```yaml
      - linters:
          - gosec
        path: _test\.go
        text: "G703"
```

Production scope is provably untouched: stripping `jobqueue/server.go:4865`'s
directive still yields `G703`, and `jobqueue/archivefold.go:158`'s still yields
`G115`.

Removed as now-dead: 6 × `// #nosec G703` and the 8-line paragraph in
`jobqueue/deletion_probes_test.go` explaining the `#nosec`-vs-`//nolint`
technique. Every other gosec directive was proven live by stripping it
individually and reading which rule the site then names — G204, G115, G306,
G404 and G101 all stay. Non-gosec directive counts are unchanged.

The removals are mandatory, not cosmetic: exclusion rules run *before* the
nolint filter, so re-adding `//nolint:gosec` under the new config gives
`directive ... is unused for linter "gosec"`.

## This is not count-neutral — it removes three real findings

The pre-change unfiltered baseline is **not reproducible**, because the
instability struck during verification. Two consecutive runs on the pristine
checkout, nothing edited between them:

```
run 1: behaviours_test.go:536, behaviours_test.go:1850, jobqueue_test.go:398
       -> 40 issues: gosec: 3
run 2: (after cache clean) -> 37 issues, no gosec
```

Those three G703 findings were latent and **entirely unsuppressed**; `make lint`
hid them only because those lines predate `master` and `new-from-rev: master`
filters them out. The honest figure is 40 -> 37.

## A real test defect found while reverting #579's workaround

`os.Stat(filepath.Clean(path))` is reverted to `os.Stat(path)`. Every caller
passes a `mkHashedDir` path built with `filepath.Join`, which Cleans internally,
so the wrap was a semantic no-op — but `soGoneWithin`'s timeout fallback calls
`soPathsGone(path)` with the **unmodified** value, so the two sibling helpers
were polling one string and asserting on another. `behaviours_test.go:1850`, one
of the three latent findings above, is `soPathsGone`'s own `os.Stat` — independent
confirmation that the `Clean` was cargo rather than protection.

## Stability demonstrated

Three cold `cache clean` cycles, plus seven perturb-and-revert states: a Go
comment in a test file, a Go comment in production `jobqueue/utils.go`, a Go
comment beside the live production G703 in `jobqueue/server.go`, an appended
`README.md` line, and two of those repeated after `cache clean`. All `0 issues.`
filtered, 37 unfiltered, zero gosec, zero nolintlint. Nothing flipped.

The mechanism explains why: the exclusion drops the issue before the nolint
filter runs, so the unstable analysis result no longer feeds a directive-usage
decision at all.

Gates: `make lint` `0 issues.` (the pre-existing
`[runner/nolint_filter] Found unknown linters in //nolint directives` warning is
gone — it was the removed paragraph being parsed as a directive);
`make test` `617 passed · 13 skipped`.
