### PR TITLE
Keep a mount cache the filesystem spells another way

### DIFF
--- a/.docs/bugfixes/260906-4.md
+++ b/.docs/bugfixes/260906-4.md
@@ -1,0 +1,97 @@
+# Bugfixes 2026-09-06 (4)
+
+- [x] wr's cleanup keep set names what must NOT be deleted by STRING and matches
+  those strings byte-for-byte against what the filesystem reports from readdir.
+  On a case-insensitive filesystem (ext4 with the casefold feature, SMB/CIFS,
+  APFS, HFS+) one directory has two spellings: the one the Job's MountConfig
+  gives and the one the directory was created with. `readdir` reports the
+  CREATED spelling, so the keep set misses, and a muxfys cache directory holding
+  un-uploaded job output is deleted before `Job.Unmount` can upload it. Both
+  keep mechanisms are affected: `jobWorkSpace.keptEntry`'s
+  `keep.workSpaceEntries[name]` map lookup (jobqueue/workspace.go), and
+  `removeAllExcept`'s `keepDirs[keepRel]` lookup (jobqueue/utils.go).
+    - Measured on this box against a real casefold ext4 image: `mkdir MyMount`
+      makes readdir report `MyMount` (the case as CREATED, NOT folded), while
+      `ls -d mymount` resolves; a pre-existing `mymount` plus `mkdir -p MyMount`
+      exits 0 and leaves ONE directory (same inode) that readdir reports as
+      `mymount`. So the exposure is the spelling that created the directory
+      differing from the spelling the Job's config gives, not readdir folding.
+    - Red command: `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue
+      -run TestCleanupKeepsMountCachesSpelledInAnotherCase -v`
+    - Reproduction rate before the fix: 10/10.
+    - Fixed in `jobqueue/utils.go` and `jobqueue/workspace.go`. New `sweepKeep`
+      holds the keep set in both forms one directory can be recognised by: the
+      rel paths it was always spelled with, and the identity each of those paths
+      reaches when the KERNEL resolves it through the handle already open on the
+      tree being swept. `keeps` matches either, so the union can only ever WIDEN
+      what a sweep leaves alone. Applied at `removeWorkSpaceEntries`,
+      `removeAllExcept`/`removeEntryWithExceptions` and `removeTmp`.
+    - The keep decision and the deletion are made from the SAME lstat, so a
+      directory swapped for another in between cannot be kept while the other is
+      deleted, and an entry gone since the readdir returns through `ignoreGone`
+      before the keep question is asked.
+    - `strings.HasPrefix(name, muxfysCachePrefix)` stays a NAME rule: muxfys
+      makes that dir itself inside a CacheBase wr made fresh for this run, so
+      readdir returns muxfys's own spelling and nothing can pre-exist for a fold
+      to collide with.
+    - Cost: the workspace sweep drops from 2 metadata syscalls per entry to 1, by
+      hoisting `sweptDir.sweepable`'s lstat of "." out of the loop that
+      `removeAllGuarded` had been paying it in. `removeWithExceptions` is
+      unchanged per entry. The additions are one-off, one lstat per configured
+      keep per sweep, so PR #575's 2.2x shape is not reintroduced.
+
+- [x] The same case-spelling miss destroys an un-uploaded muxfys cache through a
+  FOURTH path, found in review: a `MountTarget.CacheDir` relative to the
+  workspace that spells the working directory's own name in another case, eg.
+  `CWD/mixedcache` for a working directory readdir reports as `cwd`.
+  `keptDirs.protect` classifies through `relsBelowDirResolved`, which is a string
+  comparison (`EvalSymlinks` resolves symlinks but does not canonicalise case), so
+  the keep lands only in `workSpaceEntries["CWD"]` and `inActualCwd` stays empty.
+  `jobWorkSpace.empty` then takes `removeActualCwd`'s `len(keepDirs) == 0` branch,
+  which sweeps the whole working directory with no keep set at all, cache
+  included. Pre-existing, not introduced by the first fix, but the same bug: with
+  the first fix in place `removeWorkSpaceEntries` goes on to keep `cwd` BY
+  IDENTITY, so cleanup now leaves an emptied working directory behind and reports
+  success - the two-consumers-disagree shape `.docs/bugfixes/260902-3.md`
+  explicitly rejected.
+    - Red command: `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue
+      -run TestCleanupKeepsMountCachesSpelledInAnotherCase -v`, extended with a
+      mis-cased working-dir CacheDir case and a correctly-spelled control.
+    - Verified with a probe on the change's own `mountCaseFold` harness: the
+      mis-cased case fails, the control passes, and it fails identically with the
+      first fix stashed, so it predates it.
+    - Fixed at the CLASSIFICATION layer, so the two sweeps cannot disagree:
+      `keptDirs.workSpaceRels` now records the whole workspace-relative path of
+      every keep rather than only the entry name leading to it, and
+      `keptDirs.actualCwdKeeps` asks the workspace handle which entry each of
+      those leads through. `removeActualCwd` takes its answer from there and
+      nowhere else, so an empty keep list means the Job really claims nothing at
+      or inside the working directory rather than classification having failed to
+      see that it does. `entriesLeadingTo` is gone, its work folded into
+      `protect`, which still records a name per SPELLING.
+    - Only the LEADING component needs the filesystem asked about it: every
+      component below it is resolved by `sweepKeepIn` through the handle on the
+      directory it is an entry of, so a mis-spelling deeper down is already
+      matched by identity there.
+    - Mutations, both compiling and `go vet ./cmd/ ./jobqueue/` clean: dropping
+      `keeps`' identity scan reddens 3 of the 5 cases; dropping
+      `actualCwdKeeps`' filesystem lookup reddens the 4th. The `rels` half of the
+      union is pinned by `TestCleanupKeepsADirThatAppearsDuringTheSweep`, a dir
+      that appears at a kept path after the identities were resolved.
+
+- [ ] NOT FIXED, needs an owner decision: `nestedWorkSpaceBase`
+  (`jobqueue/utils.go`) matches `strings.HasSuffix(filepath.Base(rel), "_cwd")`
+  against a readdir name, which is the same byte comparison against a
+  filesystem-reported name as the bug above. On a case-insensitive filesystem a
+  directory already named `WR_CWD` in a parent Job's working directory absorbs a
+  child Job's `MkdirAll`, readdir reports `WR_CWD`, the suffix match misses, and
+  the parent's cleanup recurses into its children's LIVE workspaces. Data-loss
+  class, pre-existing, and not reachable by the fix above: a suffix rule has no
+  single path to stat, so there is no identity to compare.
+    - Reachability is low: it needs the parent Job's own Cmd to plant that name,
+      and that same Cmd could delete its children's work directly.
+    - Options: (a) leave it, recorded, on the reachability argument; (b) have the
+      child record the workspace-base name it actually created and match that
+      identity instead of the suffix; (c) make the suffix test
+      case-insensitive, which widens what is protected and so costs stranded
+      directories rather than deletions.

--- a/.docs/bugfixes/260906-4.md
+++ b/.docs/bugfixes/260906-4.md
@@ -79,7 +79,8 @@
       union is pinned by `TestCleanupKeepsADirThatAppearsDuringTheSweep`, a dir
       that appears at a kept path after the identities were resolved.
 
-- [ ] NOT FIXED, needs an owner decision: `nestedWorkSpaceBase`
+- [x] NOT FIXED, decided by the owner: leave it, recorded, on the
+  reachability argument (option (a) below). `nestedWorkSpaceBase`
   (`jobqueue/utils.go`) matches `strings.HasSuffix(filepath.Base(rel), "_cwd")`
   against a readdir name, which is the same byte comparison against a
   filesystem-reported name as the bug above. On a case-insensitive filesystem a
@@ -95,3 +96,9 @@
       identity instead of the suffix; (c) make the suffix test
       case-insensitive, which widens what is protected and so costs stranded
       directories rather than deletions.
+    - Decision: (a). The owner accepted the reachability argument - the parent
+      Job's own Cmd is the only thing that can plant the name, and that same Cmd
+      could delete its children's work directly, so closing this buys nothing
+      against an actor who already has the capability. Recorded rather than
+      fixed, deliberately, so a future reader knows it was weighed and not
+      missed.

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -1622,7 +1622,7 @@ func removeAllExcept(dir sweptDir, exceptions []string) error {
 		return err
 	}
 
-	return removeWithExceptions(dir.root, ".", info, exceptionDirs(exceptions))
+	return removeWithExceptions(dir.root, ".", info, sweepKeepIn(dir.root, exceptionDirs(exceptions)))
 }
 
 // removeAllGuarded deletes the entry of dir's own directory called name, and
@@ -1634,16 +1634,20 @@ func removeAllExcept(dir sweptDir, exceptions []string) error {
 // jobWorkSpace; all this bounds is how far a deletion already licensed goes.
 //
 // It keeps nothing, so it has no keep set to spell name against: name is handed
-// on as its own keep-set spelling, which nothing then reads. Every caller passes
-// a single component anyway - an entry of the workspace, its tmp or its working
-// directory - so the two spellings are the same string.
+// on as its own keep-set spelling, which nothing then reads. Its caller passes a
+// single component anyway - the Job's working directory - so the two spellings
+// are the same string.
+//
+// That there is nothing below name to keep is the caller's finding rather than
+// an assumption made here, and it is a finding about identities and not only
+// about strings; see removeActualCwd.
 func removeAllGuarded(dir sweptDir, name string) error {
 	info, ok, err := dir.sweepable()
 	if !ok {
 		return err
 	}
 
-	return removeEntryWithExceptions(dir.root, name, name, info, nil)
+	return removeEntryWithExceptions(dir.root, name, name, info, sweepKeep{})
 }
 
 // exceptionDirs turns removeAllExcept's exceptions into the set of dirs to keep,
@@ -1669,14 +1673,119 @@ func exceptionDirs(exceptions []string) map[string]bool {
 	return keepDirs
 }
 
+// sweepKeep is what a sweep must leave alone, held in both of the forms one
+// directory can be recognised by: the paths the Job's keep set spells it with,
+// relative to the root the sweep started from, and the identity each of those
+// paths reaches when the KERNEL resolves it.
+//
+// The paths alone are not enough, because they are compared against the names
+// readdir hands back, and for one directory those two need not be the same
+// string. A case-insensitive filesystem - ext4 with the casefold feature, APFS,
+// HFS+, SMB, some NFS servers - stores the name a directory was CREATED with,
+// hands that spelling back from readdir, and folds only names it is GIVEN;
+// Unicode normalisation gives one directory two spellings by another route. So a
+// MountConfig naming a cache dir in a case other than the one that made it names
+// the same directory in a way no byte comparison recognises, and the cache is
+// swept - which, since cleanup runs BEFORE Job.Unmount (client.go), destroys a
+// writable mount's un-uploaded output.
+//
+// The identities are a UNION with the paths and never a replacement for them,
+// for two reasons.
+//
+// The first is that this may only ever WIDEN what a sweep leaves alone. The name
+// rule is what cleanup kept by before there was an identity to compare, and
+// dropping it would delete something the old sweep kept - for a cache, the job's
+// own output, uploaded by nothing until Unmount.
+//
+// The second is that the two are read at different moments. The paths are
+// resolved once, at the top of the sweep, while the entries they are compared
+// against are read directory by directory on the way down. A directory created
+// at a kept path in that window, or one swapped for another there, has no
+// identity in this set, and its name is the only account of it there is; see
+// TestCleanupKeepsADirThatAppearsDuringTheSweep. A Job's own mounts can do that,
+// muxfys still running while cleanup sweeps the tree it is mounted in.
+type sweepKeep struct {
+	// rels are the paths to keep, relative to the root the sweep started from,
+	// spelled as exceptionDirs spells them.
+	rels map[string]bool
+
+	// dirs are the lstats of the directories those paths reach, to compare by
+	// os.SameFile against the entries the sweep finds. Only directories are
+	// recorded, because the keep set describes mount points and cache locations,
+	// which are directories by role: a sweep unlinks anything else before it ever
+	// asks what is kept, so an identity for a symlink or a file could only ever
+	// keep something that was already gone by then.
+	dirs []os.FileInfo
+}
+
+// sweepKeepIn resolves each of rels through dirRoot, so that the keep set's own
+// spelling reaches the directory whatever the filesystem stores that directory's
+// name as. The case-insensitive or normalising lookup is the kernel's to do; all
+// wr has to do is ask for it, and ask through the handle already open on the
+// tree being swept, so that no component above it is resolved from a string.
+//
+// The whole set is resolved once per sweep and not once per entry, so it costs
+// one lstat per keep the Job configured - a Job has one or two - rather than
+// anything per thing swept. Resolving it at keptDirs CONSTRUCTION time instead
+// would have no handle on the tree being swept to resolve it through, and would
+// spend those syscalls for a Job whose cleanup never runs.
+//
+// A rel that lstats to nothing, or to something that is not a directory, records
+// no identity and is left to the name rule.
+func sweepKeepIn(dirRoot *os.Root, rels map[string]bool) sweepKeep {
+	keep := sweepKeep{rels: rels}
+
+	for rel := range rels {
+		info, err := dirRoot.Lstat(rel)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+
+		keep.dirs = append(keep.dirs, info)
+	}
+
+	return keep
+}
+
+// keeps says whether the entry at keepRel, whose lstat is info, is one the sweep
+// must leave alone: because the keep set names it, or because it IS one of the
+// directories the keep set names, reached under a spelling that set does not
+// have.
+//
+// info must be the lstat the DELETION is about to be made against rather than an
+// earlier one. Deciding both questions from the one lstat is what stops a
+// directory swapped for another in between being kept while the other is
+// deleted, and it is why an entry that has gone since the readdir cannot be
+// mistaken for one the set does not claim: there is then no lstat to ask this of
+// and nothing left to delete either (see ignoreGone).
+//
+// A directory cannot be hard-linked, so a second name reaching one of these
+// identities is another way to that same directory rather than a directory of its
+// own - on Linux, a bind mount of it. Keeping such a name does keep a path the
+// Job did not spell, but only one leading to a directory the Job DID claim, so
+// this widens what survives a sweep and can never narrow it.
+func (k sweepKeep) keeps(keepRel string, info os.FileInfo) bool {
+	if k.rels[keepRel] {
+		return true
+	}
+
+	for _, dir := range k.dirs {
+		if os.SameFile(dir, info) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // removeWithExceptions deletes the contents of dirRoot's OWN directory, keeping
-// the dirs named in keepDirs. dirInfo must be the lstat of that directory, since
+// the dirs keep claims. dirInfo must be the lstat of that directory, since
 // that is what each entry's mount boundary is judged against, and the entry's
 // side of that comparison is an Lstat as well: a device number read through a
 // symlink would describe a filesystem that is not the one being swept.
 //
 // keepDir is that same directory's path relative to the root the sweep started
-// from, which is the spelling keepDirs is keyed by (see exceptionDirs). It is
+// from, which is the spelling keep.rels is keyed by (see exceptionDirs). It is
 // only ever joined with an entry's name to make a key, and never resolved by any
 // syscall - every syscall here names an entry of the held handle by its own
 // single component. That is what keeps the sweep's cost to one lookup per entry
@@ -1686,7 +1795,7 @@ func exceptionDirs(exceptions []string) map[string]bool {
 // is the same O(depth^2) the dirChain type describes and avoids the same way, by
 // keeping the handle the descent already opened.
 func removeWithExceptions(dirRoot *os.Root, keepDir string, dirInfo os.FileInfo,
-	keepDirs map[string]bool) error {
+	keep sweepKeep) error {
 	entries, err := readDirIn(dirRoot)
 	if err != nil {
 		return err
@@ -1695,7 +1804,7 @@ func removeWithExceptions(dirRoot *os.Root, keepDir string, dirInfo os.FileInfo,
 	for _, entry := range entries {
 		name := entry.Name()
 
-		err = removeEntryWithExceptions(dirRoot, name, filepath.Join(keepDir, name), dirInfo, keepDirs)
+		err = removeEntryWithExceptions(dirRoot, name, filepath.Join(keepDir, name), dirInfo, keep)
 		if err != nil {
 			return err
 		}
@@ -1711,7 +1820,7 @@ func removeWithExceptions(dirRoot *os.Root, keepDir string, dirInfo os.FileInfo,
 //
 // name is a single component, an entry of the directory dirRoot is the handle
 // on, and every syscall here names it. keepRel is the same entry's path relative
-// to the root the sweep started from, which is how keepDirs spells it, and it is
+// to the root the sweep started from, which is how keep.rels spells it, and it is
 // used for nothing else: getting the two the wrong way round would leave every
 // keep below the top level unmatched, which looks exactly like a working sweep
 // (see TestCleanupKeepsMountsNestedBelowTheWorkingDir).
@@ -1742,7 +1851,7 @@ func removeWithExceptions(dirRoot *os.Root, keepDir string, dirInfo os.FileInfo,
 // finds on the way down, and the deeper entries are exactly the ones that are
 // another Job's live output or the user's remote objects behind a live mount.
 func removeEntryWithExceptions(dirRoot *os.Root, name, keepRel string, dirInfo os.FileInfo,
-	keepDirs map[string]bool) error {
+	keep sweepKeep) error {
 	info, err := dirRoot.Lstat(name)
 	if err != nil {
 		return ignoreGone(err)
@@ -1756,11 +1865,11 @@ func removeEntryWithExceptions(dirRoot *os.Root, name, keepRel string, dirInfo o
 		return ignoreGone(dirRoot.Remove(name))
 	}
 
-	if keepDirs[keepRel] || nestedWorkSpaceBase(name) {
+	if keep.keeps(keepRel, info) || nestedWorkSpaceBase(name) {
 		return nil
 	}
 
-	return removeSweptDir(dirRoot, name, keepRel, info, keepDirs)
+	return removeSweptDir(dirRoot, name, keepRel, info, keep)
 }
 
 // removeSweptDir empties name - a directory entry of dirRoot the sweep has
@@ -1789,7 +1898,7 @@ func removeEntryWithExceptions(dirRoot *os.Root, name, keepRel string, dirInfo o
 // directory above it too. That is the leak nestedWorkSpaceBase describes, and it
 // is reported as success because there is nothing wrong and nothing to retry.
 func removeSweptDir(dirRoot *os.Root, name, keepRel string, dirInfo os.FileInfo,
-	keepDirs map[string]bool) error {
+	keep sweepKeep) error {
 	if sweptDirCheckedHook != nil {
 		sweptDirCheckedHook(name)
 	}
@@ -1799,7 +1908,7 @@ func removeSweptDir(dirRoot *os.Root, name, keepRel string, dirInfo os.FileInfo,
 		return err
 	}
 
-	err = removeWithExceptions(childRoot, keepRel, dirInfo, keepDirs)
+	err = removeWithExceptions(childRoot, keepRel, dirInfo, keep)
 
 	// closed before the rmdir below, and before returning any error, so a deep
 	// descent holds one handle per level of the path it is currently on and no

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -46,6 +46,7 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -472,6 +473,201 @@ func mountStaleRmdir(t *testing.T, mountPoint, backing string) (*staleRmdirFS, b
 	})
 
 	return sfs, true
+}
+
+// caseFoldNode is a loopback node whose LOOKUP folds case while its READDIR does
+// not, which is what a case-insensitive filesystem really does. ext4 with the
+// casefold feature was measured to behave exactly this way, and APFS, HFS+, SMB
+// and some NFS servers make the same bargain by a different route: the name a
+// directory was CREATED with is the name stored and the name readdir hands back,
+// and folding happens only to a name the filesystem is GIVEN. So `mkdir -p
+// MyCache` over an existing `mycache` exits 0 without making a second directory,
+// and from then on one inode has two spellings.
+//
+// That is the shape a Job's cleanup has to survive: its keep set is spelled by
+// the Job's MountConfig, while the sweep reads back the spelling whatever
+// created the directory used, and a byte-for-byte comparison of the two misses.
+//
+// Removals fold as well, so a directory named in one case really is deleted when
+// the sweep names it in the other, and a test sees the file that was inside it
+// gone rather than an error from a filesystem that merely refused the name.
+//
+// Every node is the root of a gofuse.LoopbackRoot of its OWN, so that no backing
+// path is ever derived from the name a node currently has in the kernel's tree:
+// the plain loopback builds one by joining the names of its ancestors, which
+// spells the path in the case that was LOOKED UP rather than the case on disk,
+// and the child then answers ENOENT to its own GETATTR.
+type caseFoldNode struct {
+	*gofuse.LoopbackNode
+}
+
+var _ = (gofuse.NodeWrapChilder)((*caseFoldNode)(nil))
+
+// WrapChild puts the folding on every node the loopback makes below this one,
+// for the reason staleRmdirNode.WrapChild gives: wrapping is not inherited, so
+// each wrapper has to hand it on to its own children.
+func (n *caseFoldNode) WrapChild(_ context.Context, ops gofuse.InodeEmbedder) gofuse.InodeEmbedder {
+	loopback, ok := ops.(*gofuse.LoopbackNode)
+	if !ok {
+		return ops
+	}
+
+	return &caseFoldNode{LoopbackNode: loopback}
+}
+
+// resolve gives the backing path of name, and whether anything is there at all.
+//
+// An exact match wins without a readdir, so the fold costs nothing for the
+// spelling on disk. Only a name that is NOT there is looked for case-insensitively
+// among the entries, which is the order a real folding filesystem's hash lookup
+// amounts to.
+func (n *caseFoldNode) resolve(name string) (string, bool) {
+	path := filepath.Join(n.RootData.Path, name)
+	if _, err := os.Lstat(path); err == nil {
+		return path, true
+	}
+
+	entries, err := os.ReadDir(n.RootData.Path)
+	if err != nil {
+		return "", false
+	}
+
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), name) {
+			return filepath.Join(n.RootData.Path, entry.Name()), true
+		}
+	}
+
+	return "", false
+}
+
+// childAt makes the node for the backing path resolve found, rooted at that path
+// so nothing below it is spelled by the names above it, and fills out with the
+// backing entry's own attributes.
+func (n *caseFoldNode) childAt(ctx context.Context, backing string,
+	out *fuse.EntryOut) (*gofuse.Inode, syscall.Errno) {
+	var st syscall.Stat_t
+
+	if err := syscall.Lstat(backing, &st); err != nil {
+		return nil, gofuse.ToErrno(err)
+	}
+
+	out.FromStat(&st)
+
+	sub := &gofuse.LoopbackRoot{Path: backing, Dev: n.RootData.Dev}
+	node := &caseFoldNode{LoopbackNode: &gofuse.LoopbackNode{RootData: sub}}
+	sub.RootNode = node
+
+	return n.NewInode(ctx, node, gofuse.StableAttr{Mode: st.Mode, Gen: 1, Ino: st.Ino}), 0
+}
+
+// Lookup finds an entry under any spelling of its name, which is the whole of
+// what makes this filesystem case-insensitive.
+func (n *caseFoldNode) Lookup(ctx context.Context, name string,
+	out *fuse.EntryOut) (*gofuse.Inode, syscall.Errno) {
+	backing, ok := n.resolve(name)
+	if !ok {
+		return nil, syscall.ENOENT
+	}
+
+	return n.childAt(ctx, backing, out)
+}
+
+// Mkdir refuses a name the directory already holds in ANOTHER case, as a
+// case-insensitive filesystem does. That is what makes `mkdir -p MyCache` over
+// an existing `mycache` leave one directory rather than two: MkdirAll reads the
+// EEXIST as success and keeps the directory that is already there, under the
+// spelling it already had.
+func (n *caseFoldNode) Mkdir(ctx context.Context, name string, mode uint32,
+	out *fuse.EntryOut) (*gofuse.Inode, syscall.Errno) {
+	if _, ok := n.resolve(name); ok {
+		return nil, syscall.EEXIST
+	}
+
+	path := filepath.Join(n.RootData.Path, name)
+	if err := os.Mkdir(path, os.FileMode(mode)); err != nil {
+		return nil, gofuse.ToErrno(err)
+	}
+
+	return n.childAt(ctx, path, out)
+}
+
+// backingName is the name the backing store spells name with, which is name
+// itself unless only a case-insensitive lookup finds it.
+func (n *caseFoldNode) backingName(name string) string {
+	backing, ok := n.resolve(name)
+	if !ok {
+		return name
+	}
+
+	return filepath.Base(backing)
+}
+
+// Rmdir deletes the directory the name resolves to, whichever case it is spelled
+// in on disk. Folding the removals as well as the lookups is what makes the
+// deletion this filesystem exists to expose a real one: a sweep that names the
+// configured spelling destroys the directory made under the other, rather than
+// being turned away by a name that does not exist.
+func (n *caseFoldNode) Rmdir(ctx context.Context, name string) syscall.Errno {
+	return n.LoopbackNode.Rmdir(ctx, n.backingName(name))
+}
+
+// Unlink deletes the entry the name resolves to; see Rmdir.
+func (n *caseFoldNode) Unlink(ctx context.Context, name string) syscall.Errno {
+	return n.LoopbackNode.Unlink(ctx, n.backingName(name))
+}
+
+// mountCaseFold really FUSE mounts a case-insensitive filesystem and returns a
+// directory inside it for a Job to use as its Cwd, taking the mount down when
+// the test ends. ok is false where the host refused the mount, exactly as for
+// mountStaleRmdir.
+//
+// Before it returns, it proves the mount folds: a directory created as
+// "FoldProbe" is found as "foldprobe", readdir still reports "FoldProbe", and a
+// removal aimed at "foldprobe" takes it away. Without that a host whose FUSE
+// behaved like plain ext4 would let the tests below pass while proving nothing.
+func mountCaseFold(t *testing.T) (string, bool) {
+	t.Helper()
+
+	backing := t.TempDir()
+	mountPoint := t.TempDir()
+
+	var st syscall.Stat_t
+
+	So(syscall.Stat(backing, &st), ShouldBeNil)
+
+	root := &gofuse.LoopbackRoot{Path: backing, Dev: st.Dev}
+	rootNode := &caseFoldNode{LoopbackNode: &gofuse.LoopbackNode{RootData: root}}
+	root.RootNode = rootNode
+
+	server, err := gofuse.Mount(mountPoint, rootNode, &gofuse.Options{})
+	if err != nil {
+		t.Logf("this host refused a FUSE mount at %s: %s", mountPoint, err)
+
+		return "", false
+	}
+
+	t.Cleanup(func() {
+		if uerr := server.Unmount(); uerr != nil {
+			t.Logf("could not unmount the case-insensitive filesystem at %s: %s", mountPoint, uerr)
+		}
+	})
+
+	cwd := filepath.Join(mountPoint, "cwd")
+	So(os.MkdirAll(filepath.Join(cwd, "FoldProbe"), os.ModePerm), ShouldBeNil)
+
+	info, err := os.Stat(filepath.Join(cwd, "foldprobe"))
+	So(err, ShouldBeNil)
+	So(info.IsDir(), ShouldBeTrue)
+
+	entries, err := os.ReadDir(cwd)
+	So(err, ShouldBeNil)
+	So(len(entries), ShouldEqual, 1)
+	So(entries[0].Name(), ShouldEqual, "FoldProbe")
+
+	So(os.Remove(filepath.Join(cwd, "foldprobe")), ShouldBeNil)
+
+	return cwd, true
 }
 
 // TestRemoveUpwardOnStaleHandle pins what the upward walk does with an errno it

--- a/jobqueue/workspace.go
+++ b/jobqueue/workspace.go
@@ -677,6 +677,24 @@ type keptDirs struct {
 	// the directories above a deeper one along with it.
 	workSpaceEntries map[string]bool
 
+	// workSpaceRels are the whole of those same paths, relative to the workspace,
+	// in every spelling relsBelowDirResolved gives them.
+	//
+	// They are what the working directory's keeps are recovered from at sweep
+	// time. The two sweeps meet at the working directory, and which of them hears
+	// about a keep is decided above by comparing STRINGS: a filesystem that
+	// spells one directory two ways hides a keep from BOTH. A CacheDir of
+	// "CWD/cache" is lexically not below the working directory wr created as
+	// "cwd", so inActualCwd records nothing, while only the leading entry name
+	// reaches workSpaceEntries. The working directory would then be emptied
+	// whole, cache included, and kept by the workspace sweep, which is the two
+	// consumers disagreeing about one workspace that .docs/bugfixes/260902-3.md
+	// rejected a design for producing.
+	//
+	// Asking the FILESYSTEM which entry of the workspace each of these leads
+	// through is what recovers it; see actualCwdKeeps.
+	workSpaceRels map[string]bool
+
 	// mountPoints are the Job's mount points that lie at or inside the
 	// workspace, absolute. They are the only directories Unmount's empty-dir
 	// tidy-up may walk: MountConfig.Mount may be an absolute path to any
@@ -715,7 +733,10 @@ type keptDirs struct {
 // keptDirs resolves every mount point and cache location the Job has, and
 // classifies each one against the workspace and the working directory.
 func (p *workSpacePaths) keptDirs() keptDirs {
-	keep := keptDirs{workSpaceEntries: make(map[string]bool, len(p.mounts))}
+	keep := keptDirs{
+		workSpaceEntries: make(map[string]bool, len(p.mounts)),
+		workSpaceRels:    make(map[string]bool, len(p.mounts)),
+	}
 
 	for _, mount := range p.mountPoints() {
 		// mountPoints keeps the LEXICAL answer, and is the one classification
@@ -821,10 +842,24 @@ func (k *keptDirs) protectCaches(p *workSpacePaths, mc MountConfig) {
 // directory is also inside the workspace, so it names the working directory as
 // the workspace entry leading to it, and that is what stops the workspace sweep
 // deleting the working directory out from under the first sweep's exceptions.
+//
+// There is a rel, and so a leading name, per spelling because the workspace sweep
+// works entry by entry: a symlink inside the workspace leading to another entry
+// of it gives one mount point two names, and only the resolved one names the
+// directory the mount is physically in - the one a RemoveAll would recurse into,
+// through the live mount. A dir that IS the workspace is an entry of nothing and
+// is left out; keptDirs records that as wholeWorkSpace instead.
 func (k *keptDirs) protect(p *workSpacePaths, dir string) {
 	k.protectInActualCwd(p.actualCwd, dir)
 
-	for _, name := range entriesLeadingTo(p.workSpace, dir) {
+	for _, rel := range relsBelowDirResolved(p.workSpace, dir) {
+		if rel == "." {
+			continue
+		}
+
+		k.workSpaceRels[rel] = true
+
+		name, _, _ := strings.Cut(rel, string(filepath.Separator))
 		k.workSpaceEntries[name] = true
 	}
 }
@@ -846,6 +881,51 @@ func (k *keptDirs) protectInActualCwd(actualCwd, dir string) {
 
 		k.inActualCwd = append(k.inActualCwd, rel)
 	}
+}
+
+// actualCwdKeeps is everything that must survive at or inside the Job's working
+// directory, as paths relative to it: what protectInActualCwd placed there by
+// name, and what only the FILESYSTEM can place there. whole says the working
+// directory itself must survive entire, and there is then nothing to sweep
+// around.
+//
+// protectInActualCwd compares strings, and a filesystem can spell one directory
+// two ways (see workSpaceRels), so a keep leading through the working directory
+// under another spelling of its NAME is missing from what that produced. Here
+// wsRoot is asked to look the leading entry of each keep up instead - the kernel
+// folds case and normalises for that lookup, which no comparison of wr's own can
+// - and the rest of the path becomes a keep of the working directory's own sweep.
+//
+// Only that leading entry needs asking: every component below it is resolved by
+// sweepKeepIn through the handle on the directory it is an entry of, so a
+// mis-spelling deeper down is already matched by identity there. The two sweeps
+// cannot disagree about that entry because both resolve the same leading names
+// through the same workspace handle, so neither can conclude on its own that the
+// working directory holds nothing worth keeping.
+//
+// It costs one lstat per configured keep, once per cleanup rather than once per
+// entry swept, and a Job that configured none pays none of them.
+func (k *keptDirs) actualCwdKeeps(wsRoot *os.Root, actualCwdInfo os.FileInfo) (bool, []string) {
+	whole, rels := k.wholeActualCwd, slices.Clone(k.inActualCwd)
+
+	for rel := range k.workSpaceRels {
+		name, below, _ := strings.Cut(rel, string(filepath.Separator))
+
+		info, err := wsRoot.Lstat(name)
+		if err != nil || !os.SameFile(info, actualCwdInfo) {
+			continue
+		}
+
+		if below == "" {
+			whole = true
+
+			continue
+		}
+
+		rels = append(rels, below)
+	}
+
+	return whole, rels
 }
 
 // cleanup wipes out the Job's working directory and the workspace holding it, as
@@ -891,6 +971,11 @@ func (ws *jobWorkSpace) cleanup() error {
 // A Job with no mounts gets no fast path around the keep set: that set is
 // already empty for such a Job, so the sweep below deletes everything anyway.
 //
+// What the working directory's own sweep must keep is asked of the workspace
+// handle rather than taken from classification alone, so that the two sweeps
+// cannot disagree about a keep the Job spelled in a case the filesystem does not
+// store it in; see actualCwdKeeps.
+//
 // What the workspace handle is paired with is the lstat of the directory above
 // it, without which a mount the Job's own Cmd raised over the workspace is
 // indistinguishable from the workspace itself; see sweptWorkSpace.
@@ -910,8 +995,8 @@ func (ws *jobWorkSpace) empty(chain dirChain) error {
 		return err
 	}
 
-	if !ws.keep.wholeActualCwd && actualCwd != nil {
-		if err = removeActualCwd(workSpace, ws.paths.actualCwdName, actualCwd, ws.keep.inActualCwd); err != nil {
+	if actualCwd != nil {
+		if err = removeActualCwd(workSpace, ws.paths.actualCwdName, actualCwd, ws.keep); err != nil {
 			return err
 		}
 	}
@@ -971,6 +1056,15 @@ func (ws *jobWorkSpace) actualCwdNow(wsRoot *os.Root) (os.FileInfo, error) {
 // The working directory needs no rule of its own: it survives exactly when
 // something inside or at it must, and protect() records that as the workspace
 // entry leading to it, which is the working directory's own name.
+//
+// This asks only about names, and a filesystem can spell one directory two ways
+// (see sweepKeep), so it is half of what the workspace sweep keeps rather than
+// the whole of it. The muxfysCachePrefix half needs no other half: a prefix has
+// no single path to resolve, and needs none, because muxfys makes that directory
+// itself inside a CacheBase wr made for this Job. readdir therefore hands back
+// muxfys's OWN spelling of it, and a filesystem that folds case cannot give it a
+// second one, there having been no entry of that name for muxfys's own mkdir to
+// find already there.
 func (ws *jobWorkSpace) keptEntry(name string) bool {
 	if ws.keep.workSpaceEntries[name] {
 		return true
@@ -979,29 +1073,53 @@ func (ws *jobWorkSpace) keptEntry(name string) bool {
 	return ws.keep.muxfysNamesWorkSpaceEntry && strings.HasPrefix(name, muxfysCachePrefix)
 }
 
-// removeWorkSpaceEntries deletes every entry of the workspace that keptEntry
-// doesn't claim. What survives is asked of the Job's own keep set and of nothing
-// else, so there is no second answer to what cleanup may delete. Each entry is
-// named to wsRoot by its own name alone, with no path above it left to resolve,
-// so nothing done here can be redirected elsewhere.
+// removeWorkSpaceEntries deletes every entry of the workspace that the Job's own
+// keep set doesn't claim, by the name it spells that entry with or by that entry
+// being one of the directories those names reach (see sweepKeep). What survives
+// is asked of that set and of nothing else, so there is no second answer to what
+// cleanup may delete. Each entry is named to the workspace handle by its own name
+// alone, with no path above it left to resolve, so nothing done here can be
+// redirected elsewhere.
 //
 // The keep set is not the whole of what survives, because it can only describe
-// what the Job itself configured: removeAllGuarded is what stops the deletion
-// crossing into another Job's workspace, through a live mount deeper down, or -
-// via the info sweptWorkSpace paired with the handle - into a mount raised over
-// the workspace itself, whose entries all look like ordinary entries of it.
+// what the Job itself configured: removeEntryWithExceptions is what stops the
+// deletion crossing into another Job's workspace, through a live mount deeper
+// down, or - via the info sweptWorkSpace paired with the handle - into a mount
+// raised over the workspace itself, whose entries all look like ordinary entries
+// of it.
+//
+// The workspace is asked whether it may be swept at all, and the keep set
+// resolved, ONCE for the whole sweep rather than once per entry as
+// removeAllGuarded would have it: both answers are the same for every entry, and
+// this is a loop every job cleanup runs.
+//
+// keptEntry and the sweep's own keep set read the same names, deliberately: an
+// entry the Job spelled the way the filesystem stores it is answered here and
+// costs no lstat, and what the sweep adds below is the IDENTITY of those same
+// names, which is the half keptEntry has no handle to ask. Those names never
+// match anything deeper than the top level either way, being single components
+// where a path below it has a separator in it.
 func (ws *jobWorkSpace) removeWorkSpaceEntries(workSpace sweptDir) error {
 	entries, err := readDirIn(workSpace.root)
 	if err != nil {
 		return err
 	}
 
+	wsInfo, ok, err := workSpace.sweepable()
+	if !ok {
+		return err
+	}
+
+	keep := sweepKeepIn(workSpace.root, ws.keep.workSpaceEntries)
+
 	for _, entry := range entries {
-		if ws.keptEntry(entry.Name()) {
+		name := entry.Name()
+
+		if ws.keptEntry(name) {
 			continue
 		}
 
-		if err = removeAllGuarded(workSpace, entry.Name()); err != nil {
+		if err = removeEntryWithExceptions(workSpace.root, name, name, wsInfo, keep); err != nil {
 			return err
 		}
 	}
@@ -1016,6 +1134,12 @@ func (ws *jobWorkSpace) removeWorkSpaceEntries(workSpace sweptDir) error {
 // alone, so nothing here can be redirected elsewhere.
 //
 // A workspace that has gone since it was proven leaves nothing to remove.
+//
+// The keep set is consulted twice, by name before the descent and by identity
+// after it, for the reason sweepKeep gives: a Job that pointed a cache at wr's
+// own TMPDIR spelled the name, and a filesystem that folds case need not spell it
+// the same way. The name check comes first so that a Job which keeps tmp pays no
+// descent at all.
 func (ws *jobWorkSpace) removeTmp() error {
 	if ws.keep.wholeWorkSpace || ws.keptEntry(createdTmpName) {
 		return nil
@@ -1037,11 +1161,26 @@ func (ws *jobWorkSpace) removeTmp() error {
 	}
 	defer workSpace.root.Close()
 
-	return removeAllGuarded(workSpace, createdTmpName)
+	wsInfo, ok, err := workSpace.sweepable()
+	if !ok {
+		return err
+	}
+
+	return removeEntryWithExceptions(workSpace.root, createdTmpName, createdTmpName, wsInfo,
+		sweepKeepIn(workSpace.root, ws.keep.workSpaceEntries))
 }
 
-// removeActualCwd deletes the Job's working directory, keeping the given relative
-// dirs if any were specified.
+// removeActualCwd deletes the Job's working directory, keeping whatever of the
+// Job's keep set lies at or inside it.
+//
+// What that is gets asked of actualCwdKeeps rather than read off the
+// classification, so that an empty answer means the Job's keep set really claims
+// nothing at or inside the working directory rather than merely having failed to
+// recognise that it does. That is what licenses the whole-directory branch below
+// to sweep with no keep set at all: a keep lost to classification would become a
+// deletion exactly here (.docs/bugfixes/260828-3.md LAYER 48). Both of the
+// answers it gives are honoured here and nowhere else, so there is one decision
+// about the working directory rather than one per caller.
 //
 // Either way the deletion goes through the guarded sweep rather than an
 // os.Root.RemoveAll: the working directory is where a Job that adds jobs leaves
@@ -1054,7 +1193,13 @@ func (ws *jobWorkSpace) removeTmp() error {
 // rather than a bare lstat so that a workspace which is itself a mount root
 // refuses the sweep of everything inside it, exactly as it refuses the
 // whole-directory deletion above.
-func removeActualCwd(workSpace sweptDir, actualCwdName string, actualCwdInfo os.FileInfo, keepDirs []string) error {
+func removeActualCwd(workSpace sweptDir, actualCwdName string, actualCwdInfo os.FileInfo,
+	keep keptDirs) error {
+	whole, keepDirs := keep.actualCwdKeeps(workSpace.root, actualCwdInfo)
+	if whole {
+		return nil
+	}
+
 	if len(keepDirs) == 0 {
 		return removeAllGuarded(workSpace, actualCwdName)
 	}
@@ -1182,29 +1327,4 @@ func resolvedDir(dir string) string {
 	}
 
 	return resolved
-}
-
-// entriesLeadingTo returns the name of the entry of dir that path is inside
-// (path itself, if it is a direct child), in each spelling that puts path
-// strictly inside dir. Nothing is returned for a path that is dir itself, which
-// relBelowDir reports as ".", or is not inside it at all.
-//
-// There is a name per spelling because this is what protects a mount point from
-// the workspace sweep and the sweep works entry by entry: a symlink inside dir
-// leading to another entry of dir gives the one mount point two names, and only
-// the resolved one names the directory the mount is physically in - the one a
-// RemoveAll would recurse into, through the live mount.
-func entriesLeadingTo(dir, path string) []string {
-	var names []string
-
-	for _, rel := range relsBelowDirResolved(dir, path) {
-		if rel == "." {
-			continue
-		}
-
-		name, _, _ := strings.Cut(rel, string(filepath.Separator))
-		names = append(names, name)
-	}
-
-	return names
 }

--- a/jobqueue/workspace_test.go
+++ b/jobqueue/workspace_test.go
@@ -295,6 +295,233 @@ func TestJobTmpDirRemovalCrossesNoMountBoundary(t *testing.T) {
 	})
 }
 
+// TestCleanupKeepsMountCachesSpelledInAnotherCase is TestCleanupKeepsMountCaches
+// again, on a filesystem where one directory has two spellings.
+//
+// wr's keep set is built from the strings in the Job's MountConfigs, and both
+// sweeps match those strings against the names readdir hands back. A
+// case-insensitive filesystem hands back the spelling the directory was CREATED
+// with (see caseFoldNode), which is whatever made the directory rather than
+// whatever the Job configured, so the two spellings differ and the keep misses.
+// What is then swept is a muxfys cache holding output that no Unmount has
+// uploaded yet: cleanup runs BEFORE Job.Unmount (client.go), so this destroys
+// the job's own output, which is the whole of what TestCleanupKeepsMountCaches
+// exists to prevent.
+//
+// There is one case per keep mechanism, because each matches by different means:
+// an absolute MountTarget.CacheDir is kept as an entry NAME of the workspace
+// (jobWorkSpace.keptEntry), a relative MountConfig.CacheBase as a PATH relative
+// to the working directory (removeAllExcept's keep set), and a cache at the Job's
+// own TMPDIR by the one name jobWorkSpace.removeTmp asks about. A CacheDir
+// relative to the workspace that spells the working directory's own name reaches
+// none of those three until the CLASSIFICATION handing a keep to one sweep or the
+// other recognises it (keptDirs.actualCwdKeeps). Fixing any of them alone leaves
+// a cache deletable through the others.
+//
+// Every case that can carries deletion controls, since a rule that kept too much
+// would satisfy the survival assertions on its own while stranding a workspace,
+// or a TMPDIR, per job.
+//
+// Case folding is the instance of this that can be reproduced on Linux. Unicode
+// normalisation - APFS, HFS+, SMB, some NFS servers - gives one directory two
+// spellings the same way, and is kept from by the same identity comparison.
+func TestCleanupKeepsMountCachesSpelledInAnotherCase(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a Job whose cache dirs are on disk under another spelling", t, func() {
+		if !canMountFuse() {
+			SkipConvey("this host will not let an unprivileged process raise a FUSE mount", func() {})
+
+			return
+		}
+
+		cwd, mounted := mountCaseFold(t)
+		if !mounted {
+			SkipConvey("this host refused an unprivileged FUSE mount", func() {})
+
+			return
+		}
+
+		cleanup := &Behaviour{When: OnExit, Do: Cleanup}
+
+		Convey("an absolute MountTarget.CacheDir in the workspace survives", func() {
+			job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+				Mount:   testWSMount,
+				Targets: []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}},
+			}}}
+			actualCwd, workSpace, tmpDir := realWorkSpace(job)
+
+			job.MountConfigs[0].Targets[0].CacheDir = filepath.Join(workSpace, "MixedCache")
+
+			cached := writeFileIn(filepath.Join(workSpace, "mixedcache"), "unuploaded.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(cached, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("a relative MountConfig.CacheBase in the working dir survives", func() {
+			job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+				Mount:     testWSMount,
+				CacheBase: "MixedBase",
+				Targets:   []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}},
+			}}}
+			actualCwd, _, tmpDir := realWorkSpace(job)
+
+			cached := writeFileIn(filepath.Join(actualCwd, "mixedbase", muxfysCachePrefix+"_c1"),
+				"unuploaded.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(cached, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("a MountTarget.CacheDir spelling the working dir itself in another case survives", func() {
+			// a CacheDir relative to the workspace that leads through the working
+			// directory is an already-supported shape, so the case a user gets
+			// wrong is one component of a path wr itself named. Spelled that way
+			// the cache is inside the working directory but classifies as neither
+			// inside it nor as an entry of the workspace leading anywhere the
+			// working-directory sweep hears about, so BOTH sweeps have to agree
+			// about it from one classification or the working directory is emptied
+			// out from under a keep the workspace sweep then honours.
+			job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+				Mount: testWSMount,
+				Targets: []MountTarget{{
+					Path: testWSTargetPath, Cache: true, Write: true,
+					CacheDir: filepath.Join(strings.ToUpper(createdCwdName), "mixedcache"),
+				}},
+			}}}
+			actualCwd, _, tmpDir := realWorkSpace(job)
+
+			cached := writeFileIn(filepath.Join(actualCwd, "mixedcache"), "unuploaded.txt")
+			output := writeFileIn(actualCwd, "out.txt")
+
+			err := cleanup.Trigger(OnExit, job)
+
+			soPathsExist(cached, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+
+		Convey("a MountTarget.CacheDir at the Job's own TMPDIR survives its reclaim", func() {
+			// Execute reclaims TMPDIR on every exit, whether or not the Job has a
+			// cleanup Behaviour, and asks the keep set about the one name it
+			// deletes; a Job that spelled that name in another case would
+			// otherwise have its cache reclaimed with the dir.
+			job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+				Mount:   testWSMount,
+				Targets: []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}},
+			}}}
+			_, workSpace, tmpDir := realWorkSpace(job)
+
+			job.MountConfigs[0].Targets[0].CacheDir = filepath.Join(workSpace, "TMP")
+
+			cached := writeFileIn(tmpDir, "unuploaded.txt")
+
+			buff := clog.ToBufferAtLevel("warn")
+
+			Reset(clog.ToDefault)
+
+			removeJobTmpDir(context.Background(), job)
+
+			soPathsExist(cached, cwd)
+			So(buff.String(), ShouldBeEmpty)
+		})
+
+		Convey("while a Job that names no cache there still has its TMPDIR reclaimed", func() {
+			// the control for the case above: keeping TMPDIR whenever a Job merely
+			// has a mount would leave one per job behind on this filesystem, and
+			// the survival assertion alone cannot tell that apart from the keep
+			// working.
+			job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+				Mount:   testWSMount,
+				Targets: []MountTarget{{Path: testWSTargetPath, Cache: true, Write: true}},
+			}}}
+			_, _, tmpDir := realWorkSpace(job)
+
+			junk := writeFileIn(tmpDir, "junk.txt")
+
+			buff := clog.ToBufferAtLevel("warn")
+
+			Reset(clog.ToDefault)
+
+			removeJobTmpDir(context.Background(), job)
+
+			soPathsGone(junk, tmpDir)
+			soPathsExist(cwd)
+			So(buff.String(), ShouldBeEmpty)
+		})
+	})
+}
+
+// TestCleanupKeepsADirThatAppearsDuringTheSweep pins the half of the keep set
+// that matches an entry by NAME, which the half that matches it by identity
+// cannot stand in for.
+//
+// The keep set's paths are resolved into identities once, at the top of a sweep,
+// while the entries they are compared against are read directory by directory on
+// the way down. A directory that appears at a kept path in that window has no
+// identity in the set, and its name is then the only account of it there is. A
+// Job's own mounts can put one there: cleanup runs BEFORE Job.Unmount
+// (client.go), so muxfys is still running, and still making cache dirs, while the
+// sweep walks the tree those mounts are in.
+func TestCleanupKeepsADirThatAppearsDuringTheSweep(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a Job whose mount point does not exist when cleanup starts", t, func() {
+		cwd := t.TempDir()
+		job := &Job{Cwd: cwd, MountConfigs: MountConfigs{{
+			Mount:   filepath.Join("holder", testWSMount),
+			Targets: []MountTarget{{Path: testWSTargetPath}},
+		}}}
+		actualCwd, _, tmpDir := realWorkSpace(job)
+
+		holder := filepath.Join(actualCwd, "holder")
+		So(os.MkdirAll(holder, os.ModePerm), ShouldBeNil)
+
+		output := writeFileIn(actualCwd, "out.txt")
+
+		Reset(func() { sweptDirCheckedHook = nil })
+
+		Convey("a dir appearing at the mount point mid-sweep is still kept", func() {
+			var mounted string
+
+			sweptDirCheckedHook = func(name string) {
+				// only the one entry this test made is acted on, so nothing here
+				// depends on readdir order.
+				if name != filepath.Base(holder) {
+					return
+				}
+
+				sweptDirCheckedHook = nil
+
+				mounted = writeFileIn(filepath.Join(holder, testWSMount), "unuploaded.txt")
+			}
+
+			err := (&Behaviour{When: OnExit, Do: Cleanup}).Trigger(OnExit, job)
+
+			soPathsExist(mounted, filepath.Join(holder, testWSMount), holder, actualCwd, cwd)
+			soPathsGone(output, tmpDir)
+
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 // realWorkSpace gives job the working directory mkHashedDir really creates for it
 // below job.Cwd, and returns that dir, the workspace holding it, and the tmp dir
 // wr makes beside it. The path wr builds is what proves a workspace is wr's own,


### PR DESCRIPTION
Cleanup's keep set names what must NOT be deleted by STRING, and matches those
strings byte-for-byte against what `readdir` reports. Where the filesystem
spells a name differently from the config, a **live mount point or an
un-uploaded muxfys cache is swept**.

## The mechanism, measured

The original record for this (`record-keepset-name-normalisation`) said
`readdir` folds the case. **It does not** — readdir reports the case as first
created. Measured on a real loop-mounted casefold ext4 image:

```
mkdir MyMount        -> readdir reports "MyMount"   (case as CREATED)
ls -d mymount        -> resolves (lookup is case-insensitive)
```

The miss needs a directory that ALREADY EXISTS in another case:

```
pre-existing:        mymount
wr does MkdirAll:    MyMount   -> exit 0, casefold resolves to the existing dir
stat both:           same inode -> ONE directory, two names
readdir reports:     mymount
keep set holds:      MyMount
keptEntry:           MISS -> the live mount point is swept
```

The same applies to Unicode normalisation (APFS, HFS+, SMB, some NFS servers),
where NFC and NFD spellings of one name differ byte-wise.

## Four sites, not one

- `keptEntry` (`jobqueue/workspace.go`) — the map lookup on `entry.Name()`.
- `removeAllExcept`'s `keepDirs[keepRel]` (`jobqueue/utils.go`) — identical flaw.
- `removeTmp`.
- **The worst one, found in review:** a `CacheDir` spelling the working
  directory's own name in another case (`CWD/mixedcache`) left `inActualCwd`
  empty, so `removeActualCwd` took its `len(keepDirs)==0` branch and swept the
  working directory **with no keep set at all** — while `removeWorkSpaceEntries`
  separately kept `cwd` by identity. An emptied working directory, reported as
  success. That is the two-consumers-disagree shape `.docs/bugfixes/260902-3.md`
  rejected, so it is fixed at the classification layer (`workSpaceRels` +
  `actualCwdKeeps`) and both sweeps now take the same answer.

## The change

`sweepKeep` holds the keep set in both forms a directory can be recognised by:
the paths it was always spelled with, **plus** the identity each reaches when the
kernel resolves it through the handle already open on the swept tree. A union,
never a replacement.

**It cannot delete what it should keep**: a union only widens; the keep decision
and the deletion come from the same lstat; a vanished entry hits `ignoreGone`
before the keep question is asked.

**It cannot keep what it should delete**: directories cannot be hard-linked, so
an identity match means the entry IS the configured keep. The only extra is a
bind mount of it, which is over-keeping and correct. The stranding bug #582
fixed is not regressed, and the must-still-delete controls pass.

**Performance is syscall-negative**: the workspace sweep drops from 2 lstats per
entry to 1, by hoisting `sweepable()`'s lstat of `"."` out of the loop
`removeAllGuarded` was paying it in. Additions are one-off — one lstat per
configured keep. The shape that caused #575's 2.2x regression is not
reintroduced.

`muxfysCachePrefix` stays a name rule deliberately: muxfys creates that
directory itself inside a CacheBase wr makes fresh per run, so nothing can
pre-exist for a fold to collide with.

## The test needs no root

A plain go-fuse loopback harness dead-ends — `LoopbackNode` re-derives its
backing path from the tree name, and fold aliasing corrupts it (LOOKUP succeeds,
GETATTR returns ENOENT). Giving every node its own `LoopbackRoot` rooted at its
backing path removes all name-derived paths, yielding an unprivileged kernel
mount with case-insensitive lookup and case-preserving readdir.

That harness was validated against the real ext4 image operation by operation,
and the same scenario was run against the real image: identical failures
pre-fix, all five cases green post-fix. So it runs in `make test` anywhere with
FUSE, and covers the SMB/APFS normalisation case too.

- Pre-fix: 24 assertions, **2 failures, 10/10 reproduction**.
- Post-fix: 83 assertions, 5 sub-cases, PASS. Suite skip count is 13 before and
  after, so it is not silently skipping.

## Mutations, both vet-clean before their verdict counted

- Dropping the identity scan from `keeps` -> **3 of 5 cases red**.
- Dropping `actualCwdKeeps`' filesystem lookup -> **the 4th case red**.

The `rels` half is pinned separately by
`TestCleanupKeepsADirThatAppearsDuringTheSweep`.

Gates: `make test` and `make race` both `621 passed · 13 skipped`, zero race
reports; `make lint` `0 issues.`
