### PR TITLE
Shell quote container command lines, and say why a mount is rejected

### DIFF
--- a/.docs/bugfixes/260907-1.md
+++ b/.docs/bugfixes/260907-1.md
@@ -171,7 +171,7 @@
       below to only run when the modification could actually make the mounts
       live.
 
-- [ ] The validation message never reaches a `wr add` or `wr mod` user.
+- [x] The validation message never reaches a `wr add` or `wr mod` user.
   `Server.replyError` (`jobqueue/serverCLI.go:712-724`) sends the client only
   `serverResponse{Err: srerr}`; the detailed `qerr` goes into the returned
   `Error` for the manager log alone. So the clear message the 2 items above
@@ -196,3 +196,74 @@
       ```
 
       The server rejects the job correctly; the reason is simply not sent.
+    - Fixed. `malformedAddJobMessage` moved from `jobqueue/serverCLI.go` to
+      `jobqueue/job.go`, where the rest of the job-payload validation already
+      lives, so it is callable from both sides. `addValidationError` wraps it
+      as `Error{Op: requestMethodAdd, Item: message, Err: ErrBadRequest}` -
+      the shape `modifyValidationError` already set - and
+      `Client.AddWithWarnings` and `Client.AddAndReturnIDsWithWarnings` return
+      it before sending. `Client.Add`, `Client.AddAndReturnIDs`,
+      `AddAndWait` and `AddAndWaitWithWarnings` all funnel through those two.
+      `handleAdd` still calls the same function server-side as defence in
+      depth for any non-`Client` caller, so the two sides cannot disagree.
+      `Server.replyError` and the wire protocol are untouched. The user now
+      sees:
+
+      ```
+      jobqueue add(jobs[0].ContainerMounts "/data/set,1:/data" is invalid: "1"
+        is not an absolute path; commas separate mounts, so a mount path
+        containing a comma can't be expressed in this format): bad request
+        (missing arguments?)
+      ```
+    - Regression test: `TestClientAddErrorNamesTheProblem`
+      (`jobqueue/client_payload_test.go`), 5 malformed cases across all 4 Add
+      variants plus an accept case, asserting `err.Error()` carries the detail
+      and that nothing was transmitted. The existing add-rejection tests gained
+      nested cases that call `server.handleRequest` directly, bypassing
+      `Client.Add*`, so the server-side check stays separately proven.
+    - Also narrowed `jobsValidationError` to return early unless the modifier
+      sets `WithDocker`, `WithSingularity` or `ContainerMounts`, closing the
+      review finding above, and documented the lock
+      `modifiedContainerMountsMessage` takes.
+    - Mutation check, each `go vet ./container/ ./jobqueue/ ./cmd/` clean so it
+      provably compiled, each reverted: `addValidationError` forced to find no
+      message -> `TestClientAddErrorNamesTheProblem`,
+      `TestServerRejectsAddWithNilDependency` and
+      `TestServerRejectsAddWithCommaInContainerMountPath` all red with
+      `Item:""` against the expected detailed `Item`; the narrowing early
+      return deleted -> `TestServerRejectsModifyThatMakesContainerMountsLive`
+      red at its "can't make the mounts live is accepted" case.
+    - Verified the docker/singularity skip path really skips rather than
+      silently passing, by building the test binary and running it under
+      `env -i` with a PATH containing neither binary: `TestRunRealAwkwardPaths`
+      reported `S` and "0 total assertions (one or more sections skipped)" for
+      both blocks. With both present it runs 3 and 2 assertions. Nothing else
+      added on this branch needs docker, singularity, FUSE or a network.
+
+- [x] `make lint` fails on 2 issues introduced by the item above, whose
+  implementor was killed by a rate limit before it could run the gate:
+
+  ```
+  jobqueue/modify_validation_test.go:458:2: declaration has 3 blank identifiers (dogsled)
+  	added, _, _, _, srerr, err := h.server.createJobs(context.Background(), []*Job{job}, envkey, false)
+  jobqueue/client_payload_test.go:1051:10: string `jobs[1].Behaviours[1] is nil` has 3 occurrences, make it a constant (goconst)
+  2 issues:
+  * dogsled: 1
+  * goconst: 1
+  make: *** [Makefile:97: lint] Error 1
+  ```
+
+  Confirmed by the orchestrator and attributed with
+  `golangci-lint run --new-from-rev=b89eff75`, so it is neither the
+  `parallel golangci-lint is running` flake nor pre-existing.
+    - Fixed in the 2 flagged test files only, asserting more rather than less.
+      `addUnvalidatedJob` now names all 6 of `createJobs`' returns and asserts
+      `dups`, `complete` and `warnings` instead of discarding 3 with `_`. The
+      briefed assertion `AddWarnings{}` turned out to be wrong and the test
+      said so - `validationJobsWithMounts` gives every job a dependency on a
+      dep group nothing is a member of, so `createJobs` correctly warns
+      `NeverSeenDepGroups: ["original-dependency"]`; the true value is
+      asserted and the dep group name hoisted to
+      `modifierValidationDepGroup` so fixture and assertion cannot drift.
+      `jobs[1].Behaviours[1] is nil` hoisted to `nilBehaviourItem` and used at
+      all 3 sites. `make lint` now reports `0 issues.`

--- a/.docs/bugfixes/260907-1.md
+++ b/.docs/bugfixes/260907-1.md
@@ -103,7 +103,7 @@
       worked for docker, and the documented format is absolute, so this is a
       net improvement - but it is worth a release note.
 
-- [ ] `wr mod --with_docker <image>` can give a job an image while leaving a
+- [x] `wr mod --with_docker <image>` can give a job an image while leaving a
   comma-broken `ContainerMounts` that `wr add` accepted, because no image was
   set at add time. `modifier.ContainerMountsSet` is false, so
   `JobModifier.validationMessage` skips the check and the malformed mounts
@@ -112,3 +112,87 @@
   above. Not a regression: both steps were accepted before that change too.
   `JobModifier.Modify` holds the Jobs, so a post-modification
   `job.containerMountsMessage()` check inside `modifyJob` closes it.
+    - Red command (a throwaway harness in the `jobqueue` package, modelled on
+      `newModifierValidationHarness`; the implementor turns it into the
+      regression test): add a job with `ContainerMounts: "/data/set,1:/data"`
+      and no image (accepted, because the value is ignored), then
+      `client.Modify` with `modifier.SetWithDocker("alpine")` and assert the
+      modify is rejected.
+
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -run TestRed2ModifyAddsImageToBrokenMounts -v`
+    - Ran for real (not skipped). 9 total assertions, 1 failure:
+      `Line 86: Expected '<nil>' to NOT be nil (but it was)!` - the modify
+      succeeds when it should be rejected. The harness also logs the resulting
+      damage, which is the point of the item:
+
+      ```
+      modified job's docker command line: cat /tmp/cmdfile | docker run --rm
+        --name f0eac11bec737cf7b93dfc2239fd5222 -w "$PWD"
+        --mount type=bind,source="$PWD",target="$PWD"
+        --mount type=bind,source=/data/set,target=/data/set
+        --mount type=bind,source=1,target=/data -i alpine /bin/sh
+      ```
+
+      One requested mount became two, the second with the relative source `1`.
+    - Fixed. `JobModifier.jobsValidationError` (`jobqueue/job.go`) previews each
+      Job with `overrideKeyContainer` - the same helper `modifiedKey` uses to
+      work out a modification without applying it - and rejects the whole
+      modification if any Job would end up with unusable container mounts. It
+      runs as a pre-pass in `JobModifier.Modify` before the `modifyJob` loop,
+      not inside it, so a rejected batch is never half-applied, which is what
+      `TestServerRejectsModifyWithNilNestedEntriesAtomically`'s queue and DB
+      snapshots require. Both server paths (`modifyJobs` and
+      `modifyJobsByKeys`) go through `Modify`, so both are covered.
+    - Regression test: `TestServerRejectsModifyThatMakesContainerMountsLive`
+      (`jobqueue/modify_validation_test.go`), asserting at the `client.Modify`
+      boundary that the modification is rejected and that queue, DB and server
+      mode are untouched, plus 3 accept cases so the check cannot pass by
+      rejecting everything. 103 assertions.
+    - Mutation check, each `go vet` clean, each reverted: passing `nil` instead
+      of `jobs` to `jobsValidationError` -> red, the modify succeeded and
+      returned its key map.
+    - Also took the reviewer's 4 minor findings on the item above: the stale
+      `validationError` doc comment, `MountSpecPaths`' doc now stating that a
+      3-or-more-part spec also yields the local path twice (behaviour
+      deliberately unchanged - see the open item below), the `jobs[N]` index
+      missing from the REST rejection message, and the comma advice being
+      appended even to a value containing no comma.
+    - Correction to this item as first written: it suggested the check go
+      inside `modifyJob`. That is impossible - `modifyJob` calls `applyTo`
+      under the Job's write lock and `Modify` returns its partially built key
+      map on error, so jobs 0..N-1 would already be mutated when job N was
+      rejected, which is exactly what the atomicity snapshots forbid. The
+      pre-pass placement is the correct reading.
+    - Left open for the repo owner, from the review: a Job persisted by a
+      pre-fix wr can already hold an image plus comma-broken mounts (nothing
+      validates `ContainerMounts` on database recovery), and the pre-pass
+      checks every Job in the batch, so an unrelated `wr mod --priority 7`
+      over its rep group is now rejected wholesale. Narrowed under the item
+      below to only run when the modification could actually make the mounts
+      live.
+
+- [ ] The validation message never reaches a `wr add` or `wr mod` user.
+  `Server.replyError` (`jobqueue/serverCLI.go:712-724`) sends the client only
+  `serverResponse{Err: srerr}`; the detailed `qerr` goes into the returned
+  `Error` for the manager log alone. So the clear message the 2 items above
+  add is invisible on the primary CLI path, which defeats the point of adding
+  it. `Client.Modify` already validates client-side before sending
+  (`jobqueue/client.go:1257`), so the `Client.Add*` family should do the same
+  for the checks `malformedAddJobMessage` makes. Found while verifying where
+  the item above's error surfaces.
+    - Red command (throwaway harness in the `jobqueue` package, using the same
+      real-`Server`-behind-a-`captureSocket` wiring as
+      `TestServerRejectsAddWithCommaInContainerMountPath`): `client.Add` a job
+      with `WithDocker: "alpine"` and `ContainerMounts: "/data/set,1:/data"`,
+      then assert the returned error text names the problem.
+
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -run TestRed3AddErrorTellsUserWhy -v`
+    - Ran for real (not skipped). 5 total assertions, 1 failure:
+
+      ```
+      what the user sees: jobqueue add(): bad request (missing arguments?)
+      Line 52: Expected 'jobqueue add(): bad request (missing arguments?)' to
+        contain substring 'not an absolute path' (but it didn't)!
+      ```
+
+      The server rejects the job correctly; the reason is simply not sent.

--- a/.docs/bugfixes/260907-1.md
+++ b/.docs/bugfixes/260907-1.md
@@ -1,0 +1,114 @@
+# Bugfixes 2026-09-07
+
+- [x] `DockerRunCmd` (`container/run.go:108-114`) builds a `/bin/sh` command
+  line by string concatenation with every value interpolated unquoted, and
+  `dockerMounts` (`container/run.go:120-140`) emits mount paths as given. A
+  mount path containing a space breaks the shell word and docker's `--mount`
+  parsing; a path containing a shell metacharacter is interpolated into a line
+  executed by `/bin/sh`; and `$PWD` is unquoted too, so a working directory
+  with a space produces a wrong bind mount with no user input involved.
+  `SingularityRunCmd` and `singularityMounts` build their line the same way.
+  Fix the quoting, reusing `github.com/kballard/go-shellquote` as
+  `jobqueue/job.go:346` already does. `$PWD` must keep expanding at run time.
+  Do not change the user-facing `ContainerMounts` format.
+    - Red command (a throwaway harness in the `container` package driving real
+      docker; the implementor turns it into the regression test):
+
+      ```go
+      root := t.TempDir()                              // dirs with spaces
+      homeDir := filepath.Join(root, "home dir")       // becomes the cwd
+      mountDir := filepath.Join(root, "mnt A")         // becomes the mount
+      cmd := DockerRunCmd("alpine", cmdFile, "wrredspace1",
+          []string{mountDir + ":/mntA"}, nil)
+      out, err := realTestTryCmd(cmd, homeDir)         // asserts on behaviour
+      So(err, ShouldBeNil)
+      So(out, ShouldContainSubstring, "a.file")
+      ```
+
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./container -v -run TestRedHarnessSpaces`
+    - Ran for real against docker 29.1.3 (not skipped). 3/3 runs red. 4 total
+      assertions, 2 failures, both `exit status 125` (docker CLI usage error)
+      with empty stdout:
+
+      ```
+      A mount path containing a space really mounts
+        cmdline: cat /tmp/container.cmd800374611 | docker run --rm --name wrredspace1
+          -w $PWD --mount type=bind,source=$PWD,target=$PWD
+          --mount type=bind,source=/tmp/TestRedHarnessSpaces608264140/001/mnt A,target=/mntA
+          -i alpine /bin/sh
+        output: ""
+        Line 50: Expected: nil  Actual: 'exit status 125'
+
+      A working directory containing a space really becomes the container cwd
+        cmdline: cat /tmp/container.cmd2669616090 | docker run --rm --name wrredspace2
+          -w $PWD --mount type=bind,source=$PWD,target=$PWD -i alpine /bin/sh
+        output: ""
+        Line 65: Expected: nil  Actual: 'exit status 125'
+      ```
+
+      Run by hand, the unquoted `$PWD` case shows what docker actually sees:
+      `Unable to find image 'dir:latest' locally` - the second half of
+      `/tmp/.../home dir` was parsed as the image name.
+    - Fixed. `container/run.go` now runs every interpolated value through
+      `shellquote.Join` (already a direct dependency, already used this way at
+      `jobqueue/job.go:346`): `cmdFile`, `name`, `image`, each `-e` env name,
+      each docker `--mount` value (quoted whole, so a space inside a field
+      survives docker's own csv parse) and each singularity `-B` spec.
+      `SingularityRunCmd`/`singularityMounts` shared the defect and got the
+      same treatment. `$PWD` is the one value that cannot go through
+      `shellquote.Join`, which would emit `'$PWD'` and kill the expansion, so
+      the new `workDirMountArgs` const emits `-w "$PWD" --mount
+      type=bind,source="$PWD",target="$PWD"`: adjacent shell quoting
+      concatenates into a single word and an expansion inside double quotes is
+      not re-scanned for splitting, so the value survives a space and docker
+      still receives one `--mount` argument. `MountSpecPaths` was extracted and
+      exported so the `"/local[:/in]"` format is parsed in one place, which the
+      new validation reuses rather than re-implementing.
+    - Regression test: `container/run_test.go`'s `TestRunRealAwkwardPaths`,
+      which is the red harness folded in, asserting observable container
+      behaviour (`pwd` inside the container, and files really visible at their
+      mount targets) rather than the generated command string. It really RAN
+      against docker 29.1.3 and singularity-ce 4.1.1: 3 assertions in the
+      docker block, 2 in the singularity block, no `SkipConvey`. The
+      exact-command-string assertions in `TestRunDocker`/`TestRunSingularity`
+      were updated for `$PWD` -> `"$PWD"` and extended with a
+      space-and-metacharacter case; none was deleted or weakened.
+    - Comma validation added: `containerMountsMessage` (`jobqueue/job.go`)
+      rejects a `ContainerMounts` value that splits into a spec whose local or
+      in-container path is not absolute, which is the detectable symptom of a
+      comma inside a path (`/data/set,1:/data` splits into `/data/set` and
+      `1:/data`). The `ContainerMounts` format is unchanged. The error reaches
+      the user at submission time from three sites, because there is no single
+      shared add-validation choke point: `malformedAddJobMessage`
+      (`jobqueue/serverCLI.go`) for `wr add` and the client `Add*` family,
+      `JobModifier.validationMessage` (`jobqueue/job.go`) for
+      `wr mod --container_mounts`, and `decodeAndConvertJobs`
+      (`jobqueue/serverREST.go`) for `POST /rest/v1/jobs/` - `restJobsAdd`
+      calls `createJobs` directly and never reaches `handleAdd`, verified by
+      reading the call paths and by the endpoint returning 201 for the
+      malformed value until the third site was added.
+    - Mutation check, each mutation `go vet ./container/ ./jobqueue/ ./cmd/`
+      clean so it provably compiled, each reverted afterwards:
+      un-quoting the docker `--mount` value -> `exit status 127`; un-quoting
+      `$PWD` alone -> `exit status 125`, the exact recorded symptom; un-quoting
+      the singularity `-B` spec -> `exit status 127`; making
+      `containerMountsMessage` a no-op -> all 3 validation tests red
+      (`Expected: true / Actual: false` at `client_payload_test.go:829` and
+      `modify_validation_test.go:68`, `Expected: 400 / Actual: 201` at
+      `rest_test.go:511`), which also shows each of the 3 call sites is
+      separately load-bearing.
+    - Also user-visible: `--container_mounts '~/data:/data'` used to work for
+      singularity through accidental shell tilde expansion of an unquoted
+      `-B` arg. It is now quoted and rejected at add as non-absolute. It never
+      worked for docker, and the documented format is absolute, so this is a
+      net improvement - but it is worth a release note.
+
+- [ ] `wr mod --with_docker <image>` can give a job an image while leaving a
+  comma-broken `ContainerMounts` that `wr add` accepted, because no image was
+  set at add time. `modifier.ContainerMountsSet` is false, so
+  `JobModifier.validationMessage` skips the check and the malformed mounts
+  reach docker at run time - the exact failure the validation above exists to
+  prevent, reachable in two user steps. Found by the reviewer of the item
+  above. Not a regression: both steps were accepted before that change too.
+  `JobModifier.Modify` holds the Jobs, so a post-modification
+  `job.containerMountsMessage()` check inside `modifyJob` closes it.

--- a/container/run.go
+++ b/container/run.go
@@ -38,11 +38,22 @@ import (
 	"strings"
 
 	"github.com/VertebrateResequencing/wr/clog"
+	"github.com/kballard/go-shellquote"
 )
 
 // dockerMountParts is the number of parts we expect to see after splitting
 // mount args on a colon.
 const dockerMountParts = 2
+
+// workDirMountArgs bind mounts the current working directory inside the
+// container and makes it the workdir.
+//
+// $PWD stays a shell expansion so that the shell we build the command line for
+// resolves it at run time, which rules out shellquote.Join(): that would emit
+// '$PWD' and kill the expansion. The double quotes keep the expansion while
+// still making each of these a single argument when the working directory
+// contains a space.
+const workDirMountArgs = ` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`
 
 // PrepareCmdFile creates a temporary file containing the given command and
 // returns its path, as well as a method you can defer that will delete the
@@ -110,7 +121,7 @@ func DockerRunCmd(image, cmdFile, name string, mounts, env []string) string {
 	envArgs := dockerEnv(env)
 
 	return fmt.Sprintf("cat %s | docker run --rm --name %s%s%s -i %s /bin/sh",
-		cmdFile, name, mountArgs, envArgs, image)
+		shellquote.Join(cmdFile), shellquote.Join(name), mountArgs, envArgs, shellquote.Join(image))
 }
 
 // dockerMounts takes a list of "/local/path[:/inside/container/path]" values
@@ -118,31 +129,36 @@ func DockerRunCmd(image, cmdFile, name string, mounts, env []string) string {
 //
 // It always returns a mount for $PWD and sets -w to that as well.
 func dockerMounts(mounts []string) string {
-	args := " -w $PWD --mount type=bind,source=$PWD,target=$PWD"
+	var args strings.Builder
 
-	var argsSb121 strings.Builder
+	args.WriteString(workDirMountArgs)
 
 	for _, spec := range mounts {
-		parts := strings.Split(spec, ":")
-		out := parts[0]
-		in := parts[0]
+		out, in := MountSpecPaths(spec)
 
-		if len(parts) == dockerMountParts {
-			in = parts[1]
-		}
-
-		fmt.Fprintf(&argsSb121, " --mount type=bind,source=%s,target=%s", out, in)
+		fmt.Fprintf(&args, " --mount %s", shellquote.Join("type=bind,source="+out+",target="+in))
 	}
 
-	args += argsSb121.String()
+	return args.String()
+}
 
-	return args
+// MountSpecPaths splits a mount specification in the form
+// "/local/path[:/inside/container/path]" in to its local path and its path
+// inside the container, which are the same when the spec has no colon.
+func MountSpecPaths(spec string) (local, inContainer string) {
+	parts := strings.Split(spec, ":")
+
+	if len(parts) == dockerMountParts {
+		return parts[0], parts[1]
+	}
+
+	return parts[0], parts[0]
 }
 
 // dockerEnv takes a list of environment variable names and converts them in to
 // a series of `docker run -e` args.
 func dockerEnv(names []string) string {
-	return listToPrefixedString(names, " -e ")
+	return listToPrefixedString(shellQuoteEach(names), " -e ")
 }
 
 // listToPrefixedString creates a single string comprising vals concatenated
@@ -174,11 +190,24 @@ func listToPrefixedString(vals []string, prefix string) string {
 func SingularityRunCmd(image, cmdFile string, mounts []string) string {
 	mountArgs := singularityMounts(mounts)
 
-	return fmt.Sprintf("cat %s | singularity shell%s %s", cmdFile, mountArgs, image)
+	return fmt.Sprintf("cat %s | singularity shell%s %s",
+		shellquote.Join(cmdFile), mountArgs, shellquote.Join(image))
 }
 
 // singularityMounts takes a list of "/local/path[:/inside/container/path]"
 // values and converts them in to a series of `singularity shell -B` args.
 func singularityMounts(mounts []string) string {
-	return listToPrefixedString(mounts, " -B ")
+	return listToPrefixedString(shellQuoteEach(mounts), " -B ")
+}
+
+// shellQuoteEach shell quotes each of the given values, so that each stays a
+// single word once the command line built from them is executed by a shell.
+func shellQuoteEach(vals []string) []string {
+	quoted := make([]string, len(vals))
+
+	for i, val := range vals {
+		quoted[i] = shellquote.Join(val)
+	}
+
+	return quoted
 }

--- a/container/run.go
+++ b/container/run.go
@@ -144,7 +144,14 @@ func dockerMounts(mounts []string) string {
 
 // MountSpecPaths splits a mount specification in the form
 // "/local/path[:/inside/container/path]" in to its local path and its path
-// inside the container, which are the same when the spec has no colon.
+// inside the container.
+//
+// The 2 are the same when the spec has no colon, and - preserving the behaviour
+// of the code this was extracted from - also when it has 2 or more, so "/a:/b:ro"
+// gives ("/a", "/a") rather than ("/a", "/b"). One consequence is that
+// jobqueue's containerMountsMessage then checks the local path twice and never
+// inspects the in-container one. What a 3-part spec should mean is a user-facing
+// format question, so the behaviour is left as it was.
 func MountSpecPaths(spec string) (local, inContainer string) {
 	parts := strings.Split(spec, ":")
 

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -40,6 +40,69 @@ import (
 
 const dirMode os.FileMode = 0755
 
+// realTestDirNames are the base names of the directories realTestSetup
+// creates: the one that becomes the working directory, and the 2 that get
+// mounted inside the container.
+type realTestDirNames struct {
+	home   string
+	mountA string
+	mountB string
+}
+
+func plainTestDirNames() realTestDirNames {
+	return realTestDirNames{home: "home", mountA: "mntA", mountB: "mntB"}
+}
+
+// awkwardTestDirNames contain a space and shell metacharacters, which must
+// survive being interpolated in to a command line that a shell then executes.
+func awkwardTestDirNames() realTestDirNames {
+	return realTestDirNames{home: "home dir", mountA: "mnt A", mountB: "mnt B;rm -rf x&*'q'"}
+}
+
+func TestRunRealAwkwardPaths(t *testing.T) {
+	containerCmd := "pwd && ls *.file && ls /mntA && ls /mntB"
+
+	Convey("DockerRunCmd's command really works when the paths contain spaces and metacharacters", t, func() {
+		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "docker", containerCmd, awkwardTestDirNames())
+		if err != nil {
+			SkipConvey(fmt.Sprintf("Can't really test the docker command line: %s", err), nil)
+
+			return
+		}
+
+		defer cleanup()
+
+		uniqueDir := filepath.Dir(homeDir)
+		cmd := DockerRunCmd("alpine", cmdFile, filepath.Base(uniqueDir), mounts, nil)
+
+		actual, err := realTestTryCmd(cmd, homeDir)
+		So(err, ShouldBeNil)
+
+		// the space-containing working directory really is the container's
+		// cwd, and the space and metacharacter containing directories really
+		// are mounted where they were asked for.
+		So(actual, ShouldContainSubstring, homeDir+"\n")
+		So(actual, ShouldContainSubstring, "home.file\na.file\nb.file\n")
+	})
+
+	Convey("SingularityRunCmd's command really works when the paths contain spaces and metacharacters", t, func() {
+		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "singularity", containerCmd, awkwardTestDirNames())
+		if err != nil {
+			SkipConvey(fmt.Sprintf("Can't really test the singularity command line: %s", err), nil)
+
+			return
+		}
+
+		defer cleanup()
+
+		cmd := SingularityRunCmd("docker://alpine", cmdFile, mounts)
+
+		actual, err := realTestTryCmd(cmd, homeDir)
+		So(err, ShouldBeNil)
+		So(actual, ShouldEqual, homeDir+"\nhome.file\na.file\nb.file\n")
+	})
+}
+
 func TestRunPrepare(t *testing.T) {
 	ctx := context.Background()
 
@@ -101,15 +164,26 @@ func TestRunDocker(t *testing.T) {
 		cmd := DockerRunCmd("myimage", "/path/to/cmds", "uniqueID", nil, nil)
 
 		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
-			" -w $PWD --mount type=bind,source=$PWD,target=$PWD -i myimage /bin/sh")
+			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage /bin/sh`)
 
 		cmd = DockerRunCmd("myimage", "/path/to/cmds", "uniqueID",
 			[]string{"/foo/bar:/bar", "/foo/car"}, []string{"A", "B"})
 
 		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
-			" -w $PWD --mount type=bind,source=$PWD,target=$PWD"+
+			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
 			" --mount type=bind,source=/foo/bar,target=/bar --mount type=bind,source=/foo/car,target=/foo/car"+
 			" -e A -e B -i myimage /bin/sh")
+	})
+
+	Convey("DockerRunCmd quotes values containing spaces and shell metacharacters", t, func() {
+		cmd := DockerRunCmd("my image", "/path to/cmds", "unique ID",
+			[]string{"/foo/b ar;rm -rf x:/b ar", "/foo/car"}, []string{"A B"})
+
+		So(cmd, ShouldEqual, "cat '/path to/cmds' | docker run --rm --name 'unique ID'"+
+			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
+			" --mount 'type=bind,source=/foo/b ar;rm -rf x,target=/b ar'"+
+			" --mount type=bind,source=/foo/car,target=/foo/car"+
+			" -e 'A B' -i 'my image' /bin/sh")
 	})
 }
 
@@ -123,6 +197,13 @@ func TestRunSingularity(t *testing.T) {
 
 		So(cmd, ShouldEqual, "cat /path/to/cmds | singularity shell -B /foo/bar:/bar -B /foo/car myimage")
 	})
+
+	Convey("SingularityRunCmd quotes values containing spaces and shell metacharacters", t, func() {
+		cmd := SingularityRunCmd("my image", "/path to/cmds", []string{"/foo/b ar;rm -rf x:/b ar", "/foo/car"})
+
+		So(cmd, ShouldEqual, "cat '/path to/cmds' | singularity shell"+
+			" -B '/foo/b ar;rm -rf x:/b ar' -B /foo/car 'my image'")
+	})
 }
 
 func TestRunReal(t *testing.T) {
@@ -133,7 +214,7 @@ func TestRunReal(t *testing.T) {
 	expected := "car\nrab\nhome.file\na.file\nb.file\n"
 
 	Convey("DockerRunCmd's command really works", t, func() {
-		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "docker", containerCmd)
+		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "docker", containerCmd, plainTestDirNames())
 		if err != nil {
 			SkipConvey(fmt.Sprintf("Can't really test the docker command line: %s", err), nil)
 
@@ -151,7 +232,7 @@ func TestRunReal(t *testing.T) {
 	})
 
 	Convey("SingularityRunCmd's command really works", t, func() {
-		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "singularity", containerCmd)
+		cmdFile, homeDir, mounts, cleanup, err := realTestSetup(t, "singularity", containerCmd, plainTestDirNames())
 		if err != nil {
 			SkipConvey(fmt.Sprintf("Can't really test the singularity command line: %s", err), nil)
 
@@ -180,7 +261,7 @@ func fileDoesNotExist(path string) bool {
 	return os.IsNotExist(err)
 }
 
-func realTestSetup(t *testing.T, exe, containerCmd string) (cmdFile, homeDir string,
+func realTestSetup(t *testing.T, exe, containerCmd string, names realTestDirNames) (cmdFile, homeDir string,
 	mounts []string, cleanup func(), err error) {
 	t.Helper()
 
@@ -189,7 +270,7 @@ func realTestSetup(t *testing.T, exe, containerCmd string) (cmdFile, homeDir str
 			mounts, cleanup, err
 	}
 
-	rootDir, homeDir, mountADir, mountBDir, err := createRealTestDirs()
+	rootDir, homeDir, mountADir, mountBDir, err := createRealTestDirs(names)
 	if err != nil {
 		return cmdFile, homeDir,
 			mounts, cleanup, err
@@ -228,25 +309,25 @@ func removeTestRootDir(t *testing.T, dir string) {
 	}
 }
 
-func createRealTestDirs() (root, home, mountA, mountB string, err error) {
+func createRealTestDirs(names realTestDirNames) (root, home, mountA, mountB string, err error) {
 	root, err = os.MkdirTemp("", "container_run_test")
 	if err != nil {
 		return root, home, mountA, mountB, err
 	}
 
-	home = filepath.Join(root, "home")
+	home = filepath.Join(root, names.home)
 
 	if err = os.Mkdir(home, dirMode); err != nil {
 		return root, home, mountA, mountB, err
 	}
 
-	mountA = filepath.Join(root, "mntA")
+	mountA = filepath.Join(root, names.mountA)
 
 	if err = os.Mkdir(mountA, dirMode); err != nil {
 		return root, home, mountA, mountB, err
 	}
 
-	mountB = filepath.Join(root, "mntB")
+	mountB = filepath.Join(root, names.mountB)
 	err = os.Mkdir(mountB, dirMode)
 
 	return root, home, mountA, mountB, err

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1197,6 +1197,10 @@ func (c *Client) AddWithWarnings(
 	envVars []string,
 	ignoreComplete bool,
 ) (added int, existed int, warnings AddWarnings, err error) {
+	if validationErr, invalid := addValidationError(jobs); invalid {
+		return 0, 0, AddWarnings{}, validationErr
+	}
+
 	compressed, err := c.CompressEnv(envVars)
 	if err != nil {
 		return 0, 0, AddWarnings{}, err
@@ -1226,6 +1230,10 @@ func (c *Client) AddAndReturnIDsWithWarnings(
 	envVars []string,
 	ignoreComplete bool,
 ) (ids []string, warnings AddWarnings, err error) {
+	if validationErr, invalid := addValidationError(jobs); invalid {
+		return nil, AddWarnings{}, validationErr
+	}
+
 	compressed, err := c.CompressEnv(envVars)
 	if err != nil {
 		return nil, AddWarnings{}, err

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -70,6 +70,10 @@ const (
 	// containerMountsWellFormed has 2 mounts, one of them without an
 	// in-container path.
 	containerMountsWellFormed = "/data/set:/data,/other"
+
+	// containerMountsRelative is a single invalid mount with no comma in it, so
+	// the comma advice would be irrelevant to it.
+	containerMountsRelative = "data:/data"
 )
 
 const (
@@ -845,6 +849,22 @@ func TestServerRejectsAddWithCommaInContainerMountPath(t *testing.T) {
 
 		_, _, err = client.Add([]*Job{singularityJob}, env, false)
 		assertRejected(err)
+
+		Convey("While a relative mount path with no comma is rejected without the comma advice", func() {
+			_, _, err = client.Add([]*Job{
+				containerMountsJob(containerMountsRelative, containerMountsTestImage, ""),
+			}, env, false)
+
+			var jqErr Error
+
+			So(errors.As(err, &jqErr), ShouldBeTrue)
+			So(sock.serverErr, ShouldNotBeNil)
+			So(sock.serverErr.Error(), ShouldContainSubstring,
+				fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path",
+					containerMountsRelative, "data"))
+			So(sock.serverErr.Error(), ShouldNotContainSubstring, "commas separate mounts")
+			So(server.q.Stats().Items, ShouldEqual, 0)
+		})
 
 		Convey("While well-formed mounts, and a value no container will use, are accepted", func() {
 			added, existed, err := client.Add([]*Job{

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -55,6 +55,24 @@ import (
 var errCaptureSocketUnsupported = errors.New("unsupported capture socket operation")
 
 const (
+	// payloadContainerMountsGroup is the rep and req group of the jobs the
+	// container_mounts validation test adds.
+	payloadContainerMountsGroup = "payload-container-mounts"
+
+	// containerMountsTestImage is a container image name, needed because
+	// ContainerMounts is only validated when an image is in use.
+	containerMountsTestImage = "alpine"
+
+	// containerMountsWithComma has a comma inside its local path, so splitting
+	// it on the comma yields "1" as a local path.
+	containerMountsWithComma = "/data/set,1:/data"
+
+	// containerMountsWellFormed has 2 mounts, one of them without an
+	// in-container path.
+	containerMountsWellFormed = "/data/set:/data,/other"
+)
+
+const (
 	liveExecuteTouchInterval      = 100 * time.Millisecond
 	liveExecuteRetryWait          = 10 * time.Millisecond
 	liveExecuteRetryTime          = time.Second
@@ -770,6 +788,89 @@ func TestServerRejectsAddWithNilDependency(t *testing.T) {
 		So(existed, ShouldEqual, 0)
 		So(server.q.Stats().Items, ShouldEqual, 1)
 	})
+}
+
+func TestServerRejectsAddWithCommaInContainerMountPath(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A container_mounts path containing a comma is rejected at the add boundary", t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tmpDir := t.TempDir()
+		testDB, _, err := initDB(ctx, filepath.Join(tmpDir, "queue.db"),
+			filepath.Join(tmpDir, "queue.db.bak"), internal.Development, false, false)
+
+		So(err, ShouldBeNil)
+
+		defer func() { So(testDB.close(ctx), ShouldBeNil) }()
+
+		ch := new(codec.BincHandle)
+		token := bytes.Repeat([]byte("x"), tokenLength)
+		sock := &captureSocket{ch: ch}
+		server := &Server{
+			ch: ch, sock: sock, token: token, db: testDB,
+			q: queue.New(ctx, payloadContainerMountsGroup), rpl: newRGToKeys(),
+			depGroups: newDepGroupMembers(), up: true,
+		}
+		sock.server = server
+
+		id, err := uuid.NewV4()
+		So(err, ShouldBeNil)
+
+		client := &Client{ch: ch, clientid: id, sock: sock, token: token}
+		env := []string{"PAYLOAD_CONTAINER_MOUNTS=1"}
+
+		assertRejected := func(err error) {
+			var jqErr Error
+
+			So(errors.As(err, &jqErr), ShouldBeTrue)
+			So(jqErr, ShouldResemble, Error{Op: requestMethodAdd, Err: ErrBadRequest})
+			So(sock.serverErr, ShouldNotBeNil)
+			So(sock.serverErr.Error(), ShouldContainSubstring,
+				fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path",
+					containerMountsWithComma, "1"))
+			So(sock.serverErr.Error(), ShouldContainSubstring,
+				"commas separate mounts, so a mount path containing a comma can't be expressed in this format")
+			So(server.q.Stats().Items, ShouldEqual, 0)
+		}
+
+		dockerJob := containerMountsJob(containerMountsWithComma, containerMountsTestImage, "")
+		singularityJob := containerMountsJob(containerMountsWithComma, "", containerMountsTestImage+".sif")
+
+		_, _, err = client.Add([]*Job{dockerJob}, env, false)
+		assertRejected(err)
+
+		_, _, err = client.Add([]*Job{singularityJob}, env, false)
+		assertRejected(err)
+
+		Convey("While well-formed mounts, and a value no container will use, are accepted", func() {
+			added, existed, err := client.Add([]*Job{
+				containerMountsJob(containerMountsWellFormed, containerMountsTestImage, ""),
+				containerMountsJob(containerMountsWithComma, "", ""),
+			}, env, false)
+
+			So(err, ShouldBeNil)
+			So(sock.serverErr, ShouldBeNil)
+			So(added, ShouldEqual, 2)
+			So(existed, ShouldEqual, 0)
+			So(server.q.Stats().Items, ShouldEqual, 2)
+		})
+	})
+}
+
+func containerMountsJob(mounts, docker, singularity string) *Job {
+	return &Job{
+		Cmd:             "echo " + mounts + " " + docker + singularity,
+		RepGroup:        payloadContainerMountsGroup,
+		ReqGroup:        payloadContainerMountsGroup,
+		Requirements:    &scheduler.Requirements{RAM: 100, Time: time.Second, Cores: 1, Disk: 1},
+		ContainerMounts: mounts,
+		WithDocker:      docker,
+		WithSingularity: singularity,
+	}
 }
 
 func TestServerRejectsAddWithNilBehaviour(t *testing.T) {

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -74,6 +74,10 @@ const (
 	// containerMountsRelative is a single invalid mount with no comma in it, so
 	// the comma advice would be irrelevant to it.
 	containerMountsRelative = "data:/data"
+
+	// nilBehaviourItem is the item a malformed add names when the second
+	// behaviour of the second job is nil.
+	nilBehaviourItem = "jobs[1].Behaviours[1] is nil"
 )
 
 const (
@@ -744,13 +748,28 @@ func TestServerRejectsAddWithNilDependency(t *testing.T) {
 			var jqErr Error
 
 			So(errors.As(err, &jqErr), ShouldBeTrue)
-			So(jqErr, ShouldResemble, Error{Op: requestMethodAdd, Err: ErrBadRequest})
-			So(sock.serverErr, ShouldNotBeNil)
-			So(sock.serverErr.Error(), ShouldContainSubstring, "jobs[1].Dependencies[1] is nil")
+			So(jqErr, ShouldResemble, Error{
+				Op: requestMethodAdd, Item: "jobs[1].Dependencies[1] is nil", Err: ErrBadRequest,
+			})
+			So(sock.sent, ShouldBeNil)
 			So(server.q.Stats().Items, ShouldEqual, 0)
 			So(valid.EnvKey, ShouldBeBlank)
 			So(malformed.EnvKey, ShouldBeBlank)
 		}
+
+		var encoded []byte
+
+		enc := codec.NewEncoderBytes(&encoded, ch)
+		err = enc.Encode(&clientRequest{
+			Method: requestMethodAdd, Token: token, Env: []byte("encoded environment"), Jobs: jobs,
+		})
+		So(err, ShouldBeNil)
+
+		err = server.handleRequest(ctx, &mangos.Message{Body: encoded})
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "jobs[1].Dependencies[1] is nil")
+		So(sock.response().Err, ShouldEqual, ErrBadRequest)
+		So(server.q.Stats().Items, ShouldEqual, 0)
 
 		_, _, err = client.Add(jobs, env, false)
 		assertRejected(err)
@@ -831,13 +850,14 @@ func TestServerRejectsAddWithCommaInContainerMountPath(t *testing.T) {
 			var jqErr Error
 
 			So(errors.As(err, &jqErr), ShouldBeTrue)
-			So(jqErr, ShouldResemble, Error{Op: requestMethodAdd, Err: ErrBadRequest})
-			So(sock.serverErr, ShouldNotBeNil)
-			So(sock.serverErr.Error(), ShouldContainSubstring,
-				fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path",
-					containerMountsWithComma, "1"))
-			So(sock.serverErr.Error(), ShouldContainSubstring,
-				"commas separate mounts, so a mount path containing a comma can't be expressed in this format")
+			So(jqErr, ShouldResemble, Error{
+				Op: requestMethodAdd,
+				Item: fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path; "+
+					"commas separate mounts, so a mount path containing a comma "+
+					"can't be expressed in this format", containerMountsWithComma, "1"),
+				Err: ErrBadRequest,
+			})
+			So(sock.sent, ShouldBeNil)
 			So(server.q.Stats().Items, ShouldEqual, 0)
 		}
 
@@ -850,6 +870,25 @@ func TestServerRejectsAddWithCommaInContainerMountPath(t *testing.T) {
 		_, _, err = client.Add([]*Job{singularityJob}, env, false)
 		assertRejected(err)
 
+		Convey("And a client that skips the client-side check is still rejected by the server", func() {
+			var encoded []byte
+
+			enc := codec.NewEncoderBytes(&encoded, ch)
+			err = enc.Encode(&clientRequest{
+				Method: requestMethodAdd, Token: token, Env: []byte("encoded environment"),
+				Jobs: []*Job{dockerJob},
+			})
+			So(err, ShouldBeNil)
+
+			err = server.handleRequest(ctx, &mangos.Message{Body: encoded})
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring,
+				fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path",
+					containerMountsWithComma, "1"))
+			So(sock.response().Err, ShouldEqual, ErrBadRequest)
+			So(server.q.Stats().Items, ShouldEqual, 0)
+		})
+
 		Convey("While a relative mount path with no comma is rejected without the comma advice", func() {
 			_, _, err = client.Add([]*Job{
 				containerMountsJob(containerMountsRelative, containerMountsTestImage, ""),
@@ -858,11 +897,12 @@ func TestServerRejectsAddWithCommaInContainerMountPath(t *testing.T) {
 			var jqErr Error
 
 			So(errors.As(err, &jqErr), ShouldBeTrue)
-			So(sock.serverErr, ShouldNotBeNil)
-			So(sock.serverErr.Error(), ShouldContainSubstring,
+			So(jqErr.Err, ShouldEqual, ErrBadRequest)
+			So(jqErr.Item, ShouldContainSubstring,
 				fmt.Sprintf("jobs[0].ContainerMounts %q is invalid: %q is not an absolute path",
 					containerMountsRelative, "data"))
-			So(sock.serverErr.Error(), ShouldNotContainSubstring, "commas separate mounts")
+			So(jqErr.Item, ShouldNotContainSubstring, "commas separate mounts")
+			So(sock.sent, ShouldBeNil)
 			So(server.q.Stats().Items, ShouldEqual, 0)
 		})
 
@@ -890,6 +930,182 @@ func containerMountsJob(mounts, docker, singularity string) *Job {
 		ContainerMounts: mounts,
 		WithDocker:      docker,
 		WithSingularity: singularity,
+	}
+}
+
+// TestClientAddErrorNamesTheProblem covers what a `wr add` user actually sees.
+// Server.replyError sends the client the bare ErrBadRequest and keeps the
+// detailed reason for the manager log, so a server-side rejection used to tell
+// the user only "bad request (missing arguments?)" - which defeats the point of
+// naming the offending value at all. Client.Add* therefore makes the same checks
+// before sending, the way Client.Modify already did.
+func TestClientAddErrorNamesTheProblem(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A client Add error names the problem rather than just a bad request", t, func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		tmpDir := t.TempDir()
+		testDB, _, err := initDB(ctx, filepath.Join(tmpDir, "queue.db"),
+			filepath.Join(tmpDir, "queue.db.bak"), internal.Development, false, false)
+		So(err, ShouldBeNil)
+
+		defer func() { So(testDB.close(ctx), ShouldBeNil) }()
+
+		ch := new(codec.BincHandle)
+		token := bytes.Repeat([]byte("x"), tokenLength)
+		sock := &captureSocket{ch: ch}
+		server := &Server{
+			ch: ch, sock: sock, token: token, db: testDB,
+			q: queue.New(ctx, payloadContainerMountsGroup), rpl: newRGToKeys(),
+			depGroups: newDepGroupMembers(), up: true,
+		}
+		sock.server = server
+
+		id, err := uuid.NewV4()
+		So(err, ShouldBeNil)
+
+		client := &Client{ch: ch, clientid: id, sock: sock, token: token}
+		env := []string{"PAYLOAD_ADD_ERROR=1"}
+		valid := containerMountsJob(containerMountsWellFormed, containerMountsTestImage, "")
+
+		for _, test := range malformedAddTests() {
+			for _, variant := range clientAddVariants(client, env) {
+				Convey(test.name+" via "+variant.name, func() {
+					err = variant.add(test.jobs(valid))
+
+					var jqErr Error
+
+					So(errors.As(err, &jqErr), ShouldBeTrue)
+					So(jqErr, ShouldResemble, Error{
+						Op: requestMethodAdd, Item: test.item, Err: ErrBadRequest,
+					})
+					So(err.Error(), ShouldContainSubstring, test.item)
+					So(sock.sent, ShouldBeNil)
+					So(server.q.Stats().Items, ShouldEqual, 0)
+					So(valid.EnvKey, ShouldBeBlank)
+				})
+			}
+		}
+
+		Convey("While a well-formed batch is sent and queued", func() {
+			added, existed, errAdd := client.Add([]*Job{valid}, env, false)
+
+			So(errAdd, ShouldBeNil)
+			So(sock.serverErr, ShouldBeNil)
+			So(added, ShouldEqual, 1)
+			So(existed, ShouldEqual, 0)
+			So(server.q.Stats().Items, ShouldEqual, 1)
+		})
+	})
+}
+
+// malformedAddTests returns one case per check malformedAddJobMessage makes,
+// each with the exact Error.Item the caller must be given. jobs takes the valid
+// job the malformed one is batched with, so that a rejection can be seen to
+// discard the whole batch.
+func malformedAddTests() []struct {
+	name string
+	item string
+	jobs func(valid *Job) []*Job
+} {
+	return []struct {
+		name string
+		item string
+		jobs func(valid *Job) []*Job
+	}{
+		{
+			name: "a comma in a container mount path",
+			item: fmt.Sprintf("jobs[1].ContainerMounts %q is invalid: %q is not an absolute path; "+
+				"commas separate mounts, so a mount path containing a comma can't be expressed in this format",
+				containerMountsWithComma, "1"),
+			jobs: func(valid *Job) []*Job {
+				return []*Job{valid, containerMountsJob(containerMountsWithComma, containerMountsTestImage, "")}
+			},
+		},
+		{
+			name: "a relative container mount path",
+			item: fmt.Sprintf("jobs[1].ContainerMounts %q is invalid: %q is not an absolute path",
+				containerMountsRelative, "data"),
+			jobs: func(valid *Job) []*Job {
+				return []*Job{valid, containerMountsJob(containerMountsRelative, containerMountsTestImage, "")}
+			},
+		},
+		{
+			name: "a nil job",
+			item: "job at index 1 is nil",
+			jobs: func(valid *Job) []*Job { return []*Job{valid, nil} },
+		},
+		{
+			name: "a nil dependency",
+			item: "jobs[1].Dependencies[1] is nil",
+			jobs: func(valid *Job) []*Job {
+				malformed := containerMountsJob(containerMountsWellFormed, containerMountsTestImage, "")
+				malformed.Cmd = "echo nil dependency"
+				malformed.Dependencies = Dependencies{&Dependency{}, nil}
+
+				return []*Job{valid, malformed}
+			},
+		},
+		{
+			name: "a nil behaviour",
+			item: nilBehaviourItem,
+			jobs: func(valid *Job) []*Job {
+				malformed := containerMountsJob(containerMountsWellFormed, containerMountsTestImage, "")
+				malformed.Cmd = "echo nil behaviour"
+				malformed.Behaviours = Behaviours{&Behaviour{When: OnSuccess, Do: Nothing}, nil}
+
+				return []*Job{valid, malformed}
+			},
+		},
+	}
+}
+
+// clientAddVariants returns every public Add entry point that funnels through
+// the two Client methods the check was added to.
+func clientAddVariants(client *Client, env []string) []struct {
+	name string
+	add  func(jobs []*Job) error
+} {
+	return []struct {
+		name string
+		add  func(jobs []*Job) error
+	}{
+		{
+			name: "Add",
+			add: func(jobs []*Job) error {
+				_, _, err := client.Add(jobs, env, false)
+
+				return err
+			},
+		},
+		{
+			name: "AddWithWarnings",
+			add: func(jobs []*Job) error {
+				_, _, _, err := client.AddWithWarnings(jobs, env, false)
+
+				return err
+			},
+		},
+		{
+			name: "AddAndReturnIDs",
+			add: func(jobs []*Job) error {
+				_, err := client.AddAndReturnIDs(jobs, env, false)
+
+				return err
+			},
+		},
+		{
+			name: "AddAndReturnIDsWithWarnings",
+			add: func(jobs []*Job) error {
+				_, _, err := client.AddAndReturnIDsWithWarnings(jobs, env, false)
+
+				return err
+			},
+		},
 	}
 }
 
@@ -949,9 +1165,10 @@ func TestServerRejectsAddWithNilBehaviour(t *testing.T) {
 			var jqErr Error
 
 			So(errors.As(err, &jqErr), ShouldBeTrue)
-			So(jqErr, ShouldResemble, Error{Op: requestMethodAdd, Err: ErrBadRequest})
-			So(sock.serverErr, ShouldNotBeNil)
-			So(sock.serverErr.Error(), ShouldContainSubstring, "jobs[1].Behaviours[1] is nil")
+			So(jqErr, ShouldResemble, Error{
+				Op: requestMethodAdd, Item: nilBehaviourItem, Err: ErrBadRequest,
+			})
+			So(sock.sent, ShouldBeNil)
 			So(server.q.Stats().Items, ShouldEqual, 0)
 			So(valid.EnvKey, ShouldBeBlank)
 			So(malformed.EnvKey, ShouldBeBlank)
@@ -974,7 +1191,7 @@ func TestServerRejectsAddWithNilBehaviour(t *testing.T) {
 
 			So(errors.As(err, &detailedErr), ShouldBeTrue)
 			So(detailedErr, ShouldResemble, Error{
-				Op: requestMethodAdd, Err: "jobs[1].Behaviours[1] is nil",
+				Op: requestMethodAdd, Err: nilBehaviourItem,
 			})
 			So(sock.response().Err, ShouldEqual, ErrBadRequest)
 			So(server.q.Stats().Items, ShouldEqual, 0)

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1272,6 +1272,47 @@ func containerMountsInvalidMessage(containerMounts, path string) string {
 		"can't be expressed in this format"
 }
 
+// addValidationError rejects a batch of jobs that can't be added, as a bad
+// request Error naming the problem.
+//
+// Client.Add* calls this before sending, because Server.replyError sends the
+// client only the bare ErrBadRequest and keeps the detail for the manager log:
+// checking client-side is the only way the reason reaches a `wr add` user. The
+// server checks again for any other client, so the check has to stay callable
+// from both sides.
+func addValidationError(jobs []*Job) (Error, bool) {
+	message := malformedAddJobMessage(jobs)
+	if message == "" {
+		return Error{}, false
+	}
+
+	return Error{Op: requestMethodAdd, Item: message, Err: ErrBadRequest}, true
+}
+
+// malformedAddJobMessage returns a message describing why the given jobs can't
+// be added, or "" if they can be.
+func malformedAddJobMessage(jobs []*Job) string {
+	for jobIndex, job := range jobs {
+		if job == nil {
+			return fmt.Sprintf("job at index %d is nil", jobIndex)
+		}
+
+		if dependencyIndex := slices.Index(job.Dependencies, nil); dependencyIndex >= 0 {
+			return fmt.Sprintf("jobs[%d].Dependencies[%d] is nil", jobIndex, dependencyIndex)
+		}
+
+		if behaviourIndex := slices.Index(job.Behaviours, nil); behaviourIndex >= 0 {
+			return fmt.Sprintf("jobs[%d].Behaviours[%d] is nil", jobIndex, behaviourIndex)
+		}
+
+		if message := job.containerMountsMessage(); message != "" {
+			return fmt.Sprintf("jobs[%d].%s", jobIndex, message)
+		}
+	}
+
+	return ""
+}
+
 // resolveCacheDir resolves a target's CacheDir relative to defaultCacheBase. An
 // unset CacheDir (muxfys then chooses its own dir inside the CacheBase) or an
 // absolute one is returned as given.
@@ -2163,7 +2204,17 @@ func (j *JobModifier) validationError() (Error, bool) {
 //
 // Every Job is checked before Modify changes any of them, so a rejected
 // modification leaves the whole batch untouched.
+//
+// Only a modification that could change whether the mounts are live is checked.
+// Nothing validates ContainerMounts on database recovery, so a Job persisted by
+// a pre-fix wr can already hold an image alongside comma-broken mounts, and an
+// unrelated `wr mod --priority 7` over its rep group must not be rejected
+// wholesale for a value it does not touch.
 func (j *JobModifier) jobsValidationError(jobs []*Job) (Error, bool) {
+	if !j.WithDockerSet && !j.WithSingularitySet && !j.ContainerMountsSet {
+		return Error{}, false
+	}
+
 	for _, job := range jobs {
 		if message := j.modifiedContainerMountsMessage(job); message != "" {
 			return modifyValidationError(message)
@@ -2179,6 +2230,10 @@ func (j *JobModifier) jobsValidationError(jobs []*Job) (Error, bool) {
 //
 // It uses overrideKeyContainer to preview the modification, the same way
 // modifiedKey does, so that what would be applied is worked out in one place.
+// The locking is not the same: this takes job's read lock itself, so the caller
+// must hold neither of job's locks (jobsValidationError, running before the
+// modifyJob loop, holds neither), while modifiedKey requires the caller's write
+// lock.
 func (j *JobModifier) modifiedContainerMountsMessage(job *Job) string {
 	job.RLock()
 	defer job.RUnlock()

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -205,6 +205,18 @@ func (j *Job) dropImpossibleCleanups() {
 	j.Behaviours = j.Behaviours.withoutCleanups()
 }
 
+// containerMountsMessage returns a message describing why this Job's
+// ContainerMounts cannot be used, or "" if it can be. ContainerMounts is
+// ignored unless a container image is in use, so an unused value is never
+// rejected.
+func (j *Job) containerMountsMessage() string {
+	if j.WithDocker == "" && j.WithSingularity == "" {
+		return ""
+	}
+
+	return containerMountsMessage(j.ContainerMounts)
+}
+
 // cwdLeaf returns the part of cwd below cwdBase, prefixed with "/", for display
 // alongside cwdBase as a Job's working directory. It is the single projection
 // used for both a stored Job's JStatus and a live Job's JobUpdate, so that
@@ -361,6 +373,24 @@ func (j *Job) lostForLocked() time.Duration {
 	}
 
 	return time.Since(j.EndTime)
+}
+
+// nilEntryMessage returns a message naming the first nil entry in an explicitly
+// set pointer collection, or "" if there isn't one.
+func (j *JobModifier) nilEntryMessage() string {
+	if j.DependenciesSet {
+		if index := slices.Index(j.Dependencies, nil); index >= 0 {
+			return fmt.Sprintf("modifier.Dependencies[%d] is nil", index)
+		}
+	}
+
+	if j.BehavioursSet {
+		if index := slices.Index(j.Behaviours, nil); index >= 0 {
+			return fmt.Sprintf("modifier.Behaviours[%d] is nil", index)
+		}
+	}
+
+	return ""
 }
 
 // mergeBehaviours returns existing with, for each trigger that modifications
@@ -1196,6 +1226,34 @@ func (ms *mountState) buildRemoteConfigs(mc MountConfig, defaultCacheBase string
 	}
 
 	return rcs, nil
+}
+
+// containerMountsMessage returns a message describing why the given
+// ContainerMounts value cannot be used, or "" if it can be.
+//
+// Commas separate mounts, which is also how docker separates the options of its
+// own --mount argument, so a mount path containing a comma gets split in to 2
+// malformed mounts before the container runtime ever sees it. Quoting can't fix
+// that, but the detectable symptom is a resulting path that isn't absolute,
+// which a bind mount path has to be anyway.
+func containerMountsMessage(containerMounts string) string {
+	if containerMounts == "" {
+		return ""
+	}
+
+	for _, spec := range strings.Split(containerMounts, ",") {
+		local, inContainer := container.MountSpecPaths(spec)
+
+		for _, path := range []string{local, inContainer} {
+			if !filepath.IsAbs(path) {
+				return fmt.Sprintf("ContainerMounts %q is invalid: %q is not an absolute path; commas "+
+					"separate mounts, so a mount path containing a comma can't be expressed in this format",
+					containerMounts, path)
+			}
+		}
+	}
+
+	return ""
 }
 
 // resolveCacheDir resolves a target's CacheDir relative to defaultCacheBase. An
@@ -2086,16 +2144,19 @@ func (j *JobModifier) validationMessage() string {
 		return "modifier is nil"
 	}
 
-	if j.DependenciesSet {
-		if index := slices.Index(j.Dependencies, nil); index >= 0 {
-			return fmt.Sprintf("modifier.Dependencies[%d] is nil", index)
-		}
+	if message := j.nilEntryMessage(); message != "" {
+		return message
 	}
 
-	if j.BehavioursSet {
-		if index := slices.Index(j.Behaviours, nil); index >= 0 {
-			return fmt.Sprintf("modifier.Behaviours[%d] is nil", index)
-		}
+	// unlike a Job, whose ContainerMounts may be a value it never uses, a
+	// modifier only carries the field when the user explicitly asked to set
+	// it, and it can't see the images of the Jobs it will be applied to.
+	if !j.ContainerMountsSet {
+		return ""
+	}
+
+	if message := containerMountsMessage(j.ContainerMounts); message != "" {
+		return "modifier." + message
 	}
 
 	return ""

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1246,14 +1246,30 @@ func containerMountsMessage(containerMounts string) string {
 
 		for _, path := range []string{local, inContainer} {
 			if !filepath.IsAbs(path) {
-				return fmt.Sprintf("ContainerMounts %q is invalid: %q is not an absolute path; commas "+
-					"separate mounts, so a mount path containing a comma can't be expressed in this format",
-					containerMounts, path)
+				return containerMountsInvalidMessage(containerMounts, path)
 			}
 		}
 	}
 
 	return ""
+}
+
+// containerMountsInvalidMessage describes a ContainerMounts value rejected
+// because path isn't absolute.
+//
+// The comma advice is only appended when the value actually contains a comma,
+// where it names the likely cause. For a value like "data:/data" the user simply
+// gave a relative path, and the advice would be irrelevant and confusing.
+func containerMountsInvalidMessage(containerMounts, path string) string {
+	message := fmt.Sprintf("ContainerMounts %q is invalid: %q is not an absolute path",
+		containerMounts, path)
+
+	if !strings.Contains(containerMounts, ",") {
+		return message
+	}
+
+	return message + "; commas separate mounts, so a mount path containing a comma " +
+		"can't be expressed in this format"
 }
 
 // resolveCacheDir resolves a target's CacheDir relative to defaultCacheBase. An
@@ -2128,10 +2144,64 @@ func (j *JobModifier) SetContainerMounts(newVal string) {
 	j.ContainerMountsSet = true
 }
 
-// validationError rejects nil entries in explicitly set pointer collections.
+// validationError rejects nil entries in explicitly set pointer collections and
+// an explicitly set ContainerMounts value that can't be used. It sees only the
+// modifier itself, not the Jobs it will be applied to; jobsValidationError
+// covers those.
 func (j *JobModifier) validationError() (Error, bool) {
-	message := j.validationMessage()
+	return modifyValidationError(j.validationMessage())
+}
 
+// jobsValidationError rejects a modification that would leave any of jobs with
+// container mounts it can't use.
+//
+// A Job's ContainerMounts is ignored unless it has a container image, so a
+// malformed value is accepted at add time when there is no image. Setting an
+// image later makes those mounts live, which is why each Job has to be checked
+// as it would be after the modification, and not just the modifier's own
+// explicitly set values.
+//
+// Every Job is checked before Modify changes any of them, so a rejected
+// modification leaves the whole batch untouched.
+func (j *JobModifier) jobsValidationError(jobs []*Job) (Error, bool) {
+	for _, job := range jobs {
+		if message := j.modifiedContainerMountsMessage(job); message != "" {
+			return modifyValidationError(message)
+		}
+	}
+
+	return Error{}, false
+}
+
+// modifiedContainerMountsMessage returns a message, naming job, describing why
+// the container mounts job would have after modification can't be used, or "" if
+// they can be.
+//
+// It uses overrideKeyContainer to preview the modification, the same way
+// modifiedKey does, so that what would be applied is worked out in one place.
+func (j *JobModifier) modifiedContainerMountsMessage(job *Job) string {
+	job.RLock()
+	defer job.RUnlock()
+
+	newJob := &Job{
+		WithDocker:      job.WithDocker,
+		WithSingularity: job.WithSingularity,
+		ContainerMounts: job.ContainerMounts,
+	}
+
+	j.overrideKeyContainer(newJob)
+
+	message := newJob.containerMountsMessage()
+	if message == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("job %q: %s", job.Cmd, message)
+}
+
+// modifyValidationError turns a non-empty modify validation message in to a bad
+// request Error.
+func modifyValidationError(message string) (Error, bool) {
 	if message == "" {
 		return Error{}, false
 	}
@@ -2175,6 +2245,10 @@ func (j *JobModifier) validationMessage() string {
 // Returns a REVERSE mapping of new to old Job keys.
 func (j *JobModifier) Modify(jobs []*Job, server *Server) (map[string]string, error) {
 	if validationErr, invalid := j.validationError(); invalid {
+		return nil, validationErr
+	}
+
+	if validationErr, invalid := j.jobsValidationError(jobs); invalid {
 		return nil, validationErr
 	}
 

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -523,7 +523,7 @@ func TestJob(t *testing.T) {
 
 			So(cmd, ShouldStartWith, "cat ")
 
-			dockerPrefix := " | docker run --rm --name %s -w $PWD --mount type=bind,source=$PWD,target=$PWD"
+			dockerPrefix := ` | docker run --rm --name %s -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`
 			dockerSuffix := " -i %s /bin/sh"
 			So(cmd, ShouldEndWith, fmt.Sprintf(dockerPrefix+dockerSuffix, job.Key(), image))
 			So(job.MonitorDocker, ShouldEqual, job.Key())

--- a/jobqueue/modify_validation_test.go
+++ b/jobqueue/modify_validation_test.go
@@ -47,7 +47,14 @@ import (
 	"go.nanomsg.org/mangos/v3"
 )
 
-const modifierValidationRepGroup = "modifier-validation"
+const (
+	modifierValidationRepGroup = "modifier-validation"
+
+	// modifierValidationDepGroup is the dep group every validation job waits
+	// on. Nothing is ever a member of it, so an add of these jobs warns that it
+	// has never been seen.
+	modifierValidationDepGroup = "original-dependency"
+)
 
 func TestClientModifyRejectsCommaInContainerMountPath(t *testing.T) {
 	if runnermode || servermode {
@@ -302,6 +309,42 @@ func TestServerRejectsModifyThatMakesContainerMountsLive(t *testing.T) {
 			So(harness.sock.serverErr, ShouldBeNil)
 			So(modified, ShouldHaveLength, len(harness.jobs))
 		})
+
+		Convey("While a modification that can't make the mounts live is accepted even for a job "+
+			"that already has an image and broken mounts", func() {
+			preFix := harness.addUnvalidatedJob(containerMountsWithComma, containerMountsTestImage)
+
+			modifier = NewJobModifer()
+			modifier.SetPriority(7)
+
+			modified, err = harness.client.Modify(jobsToJobEssenses([]*Job{preFix}), modifier)
+
+			So(err, ShouldBeNil)
+			So(harness.sock.serverErr, ShouldBeNil)
+			So(modified, ShouldHaveLength, 1)
+
+			queued, errg := harness.client.GetByRepGroup(modifierValidationRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+
+			index := slices.IndexFunc(queued, func(job *Job) bool { return job.Cmd == preFix.Cmd })
+			So(index, ShouldBeGreaterThanOrEqualTo, 0)
+			So(queued[index].Priority, ShouldEqual, 7)
+			So(queued[index].WithDocker, ShouldEqual, containerMountsTestImage)
+			So(queued[index].ContainerMounts, ShouldEqual, containerMountsWithComma)
+
+			Convey("But one that could still is rejected", func() {
+				modifier = NewJobModifer()
+				modifier.SetWithSingularity(containerMountsTestImage + ".sif")
+
+				modified, err = harness.client.Modify(jobsToJobEssenses([]*Job{preFix}), modifier)
+
+				var jqErr Error
+
+				So(modified, ShouldBeNil)
+				So(errors.As(err, &jqErr), ShouldBeTrue)
+				So(jqErr.Err, ShouldEqual, ErrBadRequest)
+			})
+		})
 	})
 }
 
@@ -381,7 +424,7 @@ func validationJobsWithMounts(containerMounts ...string) []*Job {
 				Other: map[string]string{"original": strconv.Itoa(i)},
 			},
 			Priority: 2, DepGroups: []string{"original-index"},
-			Dependencies: Dependencies{NewDepGroupDependency("original-dependency")},
+			Dependencies: Dependencies{NewDepGroupDependency(modifierValidationDepGroup)},
 			Behaviours: Behaviours{
 				&Behaviour{When: OnExit, Do: Nothing},
 			},
@@ -403,6 +446,34 @@ type modifierValidationHarness struct {
 func (h *modifierValidationHarness) close() {
 	h.cancel()
 	So(h.db.close(context.Background()), ShouldBeNil)
+}
+
+// addUnvalidatedJob queues a job with the given ContainerMounts and docker image
+// through Server.createJobs, which is what handleAdd calls after
+// malformedAddJobMessage has passed, so no add validation sees it. That models a
+// Job persisted by a pre-fix wr: database recovery puts such a Job back in the
+// queue without checking ContainerMounts at all, so a modification has to cope
+// with an image and broken mounts already being live together.
+func (h *modifierValidationHarness) addUnvalidatedJob(containerMounts, image string) *Job {
+	job := validationJobsWithMounts(containerMounts)[0]
+	job.Cmd = "echo pre-fix " + containerMounts
+	job.WithDocker = image
+
+	envkey, err := h.db.storeEnv([]byte("MODIFIER_VALIDATION=1"))
+	So(err, ShouldBeNil)
+
+	added, dups, complete, warnings, srerr, err := h.server.createJobs(
+		context.Background(), []*Job{job}, envkey, false)
+	So(err, ShouldBeNil)
+	So(srerr, ShouldBeBlank)
+	So(added, ShouldEqual, 1)
+	So(dups, ShouldEqual, 0)
+	So(complete, ShouldEqual, 0)
+	So(warnings, ShouldResemble, AddWarnings{
+		NeverSeenDepGroups: []string{modifierValidationDepGroup},
+	})
+
+	return job
 }
 
 func (h *modifierValidationHarness) rawModify(modifier *JobModifier) (panicValue any, err error) {

--- a/jobqueue/modify_validation_test.go
+++ b/jobqueue/modify_validation_test.go
@@ -49,6 +49,61 @@ import (
 
 const modifierValidationRepGroup = "modifier-validation"
 
+func TestClientModifyRejectsCommaInContainerMountPath(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Client Modify rejects a container_mounts path containing a comma before sending it", t, func() {
+		client, sock := newCaptureClient()
+		untouched := []*JobEssence{{Cmd: "echo untouched"}}
+		modifier := NewJobModifer()
+		modifier.SetContainerMounts(containerMountsWithComma)
+
+		modified, err := client.Modify(untouched, modifier)
+
+		var jqErr Error
+
+		So(modified, ShouldBeNil)
+		So(errors.As(err, &jqErr), ShouldBeTrue)
+		So(jqErr, ShouldResemble, Error{
+			Op: requestMethodModify,
+			Item: `modifier.ContainerMounts "/data/set,1:/data" is invalid: "1" is not an absolute path; ` +
+				`commas separate mounts, so a mount path containing a comma can't be expressed in this format`,
+			Err: ErrBadRequest,
+		})
+		So(sock.sent, ShouldBeNil)
+
+		Convey("While well-formed mounts are sent", func() {
+			modifier = NewJobModifer()
+			modifier.SetContainerMounts(containerMountsWellFormed)
+
+			_, err = client.Modify(untouched, modifier)
+			So(err, ShouldBeNil)
+			So(sock.request().Modifier.ContainerMounts, ShouldEqual, containerMountsWellFormed)
+		})
+
+		Convey("While clearing the mounts is sent", func() {
+			modifier = NewJobModifer()
+			modifier.SetContainerMounts("")
+
+			_, err = client.Modify(untouched, modifier)
+			So(err, ShouldBeNil)
+			So(sock.request().Modifier.ContainerMountsSet, ShouldBeTrue)
+			So(sock.request().Modifier.ContainerMounts, ShouldBeBlank)
+		})
+
+		Convey("While a value that was never set is sent untouched", func() {
+			modifier = &JobModifier{ContainerMounts: containerMountsWithComma}
+			modifier.SetPriority(7)
+
+			_, err = client.Modify(untouched, modifier)
+			So(err, ShouldBeNil)
+			So(sock.request().Modifier.Priority, ShouldEqual, 7)
+		})
+	})
+}
+
 type modifierJobSnapshot struct {
 	key          string
 	cmd          string

--- a/jobqueue/modify_validation_test.go
+++ b/jobqueue/modify_validation_test.go
@@ -211,6 +211,100 @@ func TestServerRejectsModifyWithNilNestedEntriesAtomically(t *testing.T) {
 	}
 }
 
+func TestServerRejectsModifyThatMakesContainerMountsLive(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Giving an image to a job whose container_mounts has a comma is rejected", t, func() {
+		// neither job has an image, so job 1's comma-broken mounts are ignored
+		// and accepted at add time.
+		harness := newModifierValidationHarnessForJobs(t,
+			validationJobsWithMounts(containerMountsWellFormed, containerMountsWithComma))
+		defer harness.close()
+
+		beforeQueue := harness.queueSnapshot()
+		beforeDB := harness.dbSnapshot()
+
+		modifier := NewJobModifer()
+		modifier.SetWithDocker(containerMountsTestImage)
+
+		modified, err := harness.client.Modify(jobsToJobEssenses(harness.jobs), modifier)
+
+		var jqErr Error
+
+		So(modified, ShouldBeNil)
+		So(errors.As(err, &jqErr), ShouldBeTrue)
+		So(jqErr.Err, ShouldEqual, ErrBadRequest)
+		So(harness.sock.serverErr, ShouldNotBeNil)
+		So(harness.sock.serverErr.Error(), ShouldContainSubstring, fmt.Sprintf(
+			`job "echo original 1": ContainerMounts %q is invalid: %q is not an absolute path`,
+			containerMountsWithComma, "1"))
+
+		Convey("And the whole batch is left untouched, including its well-formed job", func() {
+			So(harness.queueSnapshot(), ShouldResemble, beforeQueue)
+			So(harness.dbSnapshot(), ShouldResemble, beforeDB)
+			So(harness.serverMode(), ShouldResemble, modifierServerMode{mode: ServerModeNormal})
+
+			queued, errg := harness.client.GetByRepGroup(modifierValidationRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(queued, ShouldHaveLength, len(harness.jobs))
+
+			sort.Slice(queued, func(i, j int) bool { return queued[i].Cmd < queued[j].Cmd })
+
+			So(queued[0].WithDocker, ShouldBeBlank)
+			So(queued[0].ContainerMounts, ShouldEqual, containerMountsWellFormed)
+			So(queued[1].WithDocker, ShouldBeBlank)
+			So(queued[1].ContainerMounts, ShouldEqual, containerMountsWithComma)
+
+			harness.assertSubsequentValidModifications()
+		})
+
+		Convey("While giving an image to the well-formed job alone is accepted", func() {
+			modifier = NewJobModifer()
+			modifier.SetWithDocker(containerMountsTestImage)
+
+			modified, err = harness.client.Modify(jobsToJobEssenses(harness.jobs[:1]), modifier)
+
+			So(err, ShouldBeNil)
+			So(harness.sock.serverErr, ShouldBeNil)
+			So(modified, ShouldHaveLength, 1)
+		})
+
+		Convey("While replacing the broken mounts as the image is set is accepted", func() {
+			modifier = NewJobModifer()
+			modifier.SetWithDocker(containerMountsTestImage)
+			modifier.SetContainerMounts(containerMountsWellFormed)
+
+			modified, err = harness.client.Modify(jobsToJobEssenses(harness.jobs), modifier)
+
+			So(err, ShouldBeNil)
+			So(harness.sock.serverErr, ShouldBeNil)
+			So(modified, ShouldHaveLength, len(harness.jobs))
+
+			queued, errg := harness.client.GetByRepGroup(modifierValidationRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(queued, ShouldHaveLength, len(harness.jobs))
+
+			for _, job := range queued {
+				So(job.WithDocker, ShouldEqual, containerMountsTestImage)
+				So(job.ContainerMounts, ShouldEqual, containerMountsWellFormed)
+			}
+		})
+
+		Convey("While a modification that leaves the mounts unused is accepted", func() {
+			modifier = NewJobModifer()
+			modifier.SetPriority(7)
+
+			modified, err = harness.client.Modify(jobsToJobEssenses(harness.jobs), modifier)
+
+			So(err, ShouldBeNil)
+			So(harness.sock.serverErr, ShouldBeNil)
+			So(modified, ShouldHaveLength, len(harness.jobs))
+		})
+	})
+}
+
 func atomicMalformedModifier() *JobModifier {
 	modifier := NewJobModifer()
 	modifier.SetCwd("/modified")
@@ -225,6 +319,12 @@ func atomicMalformedModifier() *JobModifier {
 }
 
 func newModifierValidationHarness(t *testing.T) *modifierValidationHarness {
+	t.Helper()
+
+	return newModifierValidationHarnessForJobs(t, validationJobs())
+}
+
+func newModifierValidationHarnessForJobs(t *testing.T, jobs []*Job) *modifierValidationHarness {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -252,7 +352,7 @@ func newModifierValidationHarness(t *testing.T) *modifierValidationHarness {
 	harness := &modifierValidationHarness{
 		cancel: cancel, db: testDB, server: server, sock: sock, client: client,
 	}
-	harness.jobs = validationJobs()
+	harness.jobs = jobs
 	added, existed, err := client.Add(harness.jobs, []string{"MODIFIER_VALIDATION=1"}, false)
 	So(err, ShouldBeNil)
 	So(added, ShouldEqual, len(harness.jobs))
@@ -263,10 +363,18 @@ func newModifierValidationHarness(t *testing.T) *modifierValidationHarness {
 }
 
 func validationJobs() []*Job {
-	jobs := make([]*Job, 0, 2)
-	for i := range 2 {
+	return validationJobsWithMounts("", "")
+}
+
+// validationJobsWithMounts creates one job per given ContainerMounts value, all
+// otherwise identical apart from their command and resource requirements. No job
+// has a container image, so a malformed ContainerMounts value is accepted.
+func validationJobsWithMounts(containerMounts ...string) []*Job {
+	jobs := make([]*Job, 0, len(containerMounts))
+	for i, mounts := range containerMounts {
 		jobs = append(jobs, &Job{
 			Cmd: fmt.Sprintf("echo original %d", i), Cwd: "/original", CwdMatters: true,
+			ContainerMounts: mounts,
 			RepGroup: modifierValidationRepGroup, ReqGroup: modifierValidationRepGroup,
 			Requirements: &scheduler.Requirements{
 				RAM: 100 + i, Time: 10 * time.Second, Cores: 1, Disk: 1,

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -458,6 +458,83 @@ func TestRESTJobModificationEndpoint(t *testing.T) {
 	})
 }
 
+func TestRESTAddContainerMountsValidation(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+	config, serverConfig, addr, _, clientConnectTime := jobqueueTestInit(true)
+
+	const restCMRepGroup = "rest-container-mounts"
+
+	Convey("Once the REST add server is up", t, func() {
+		server, _, token, errs := serve(ctx, serverConfig)
+		So(errs, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		handler := restJobs(ctx, server)
+		bearer := "Bearer " + string(token)
+
+		postJobs := func(jvjs []*JobViaJSON) (int, string) {
+			jsonValue, errm := json.Marshal(jvjs)
+			So(errm, ShouldBeNil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(ctx, http.MethodPost, restJobsEndpoint, bytes.NewReader(jsonValue))
+			r.Header.Set("Authorization", bearer)
+			r.Header.Set("Content-Type", "application/json")
+
+			handler(w, r)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			responseData, errr := io.ReadAll(resp.Body)
+			So(errr, ShouldBeNil)
+
+			return resp.StatusCode, string(responseData)
+		}
+
+		Convey("POST rejects a container_mounts path containing a comma", func() {
+			status, body := postJobs([]*JobViaJSON{{
+				Cmd: "echo rest comma mount", Cwd: testCwd, RepGrp: restCMRepGroup,
+				WithDocker: containerMountsTestImage, ContainerMounts: containerMountsWithComma,
+			}})
+
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldContainSubstring, "there was a problem with your job: ContainerMounts "+
+				`"`+containerMountsWithComma+`" is invalid: "1" is not an absolute path`)
+			So(body, ShouldContainSubstring,
+				"commas separate mounts, so a mount path containing a comma can't be expressed in this format")
+
+			jobs, errg := jq.GetByRepGroup(restCMRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(jobs, ShouldBeEmpty)
+		})
+
+		Convey("POST accepts well-formed container_mounts", func() {
+			status, _ := postJobs([]*JobViaJSON{{
+				Cmd: "echo rest good mount", Cwd: testCwd, RepGrp: restCMRepGroup,
+				WithDocker: containerMountsTestImage, ContainerMounts: containerMountsWellFormed,
+			}})
+
+			So(status, ShouldEqual, http.StatusCreated)
+
+			jobs, errg := jq.GetByRepGroup(restCMRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(jobs, ShouldHaveLength, 1)
+			So(jobs[0].ContainerMounts, ShouldEqual, containerMountsWellFormed)
+		})
+	})
+}
+
 func TestRESTJobModificationValidation(t *testing.T) {
 	if runnermode || servermode {
 		return

--- a/jobqueue/rest_test.go
+++ b/jobqueue/rest_test.go
@@ -509,10 +509,28 @@ func TestRESTAddContainerMountsValidation(t *testing.T) {
 			}})
 
 			So(status, ShouldEqual, http.StatusBadRequest)
-			So(body, ShouldContainSubstring, "there was a problem with your job: ContainerMounts "+
+			So(body, ShouldContainSubstring, "there was a problem with your job: jobs[0].ContainerMounts "+
 				`"`+containerMountsWithComma+`" is invalid: "1" is not an absolute path`)
 			So(body, ShouldContainSubstring,
 				"commas separate mounts, so a mount path containing a comma can't be expressed in this format")
+
+			jobs, errg := jq.GetByRepGroup(restCMRepGroup, false, 0, "", false, false)
+			So(errg, ShouldBeNil)
+			So(jobs, ShouldBeEmpty)
+		})
+
+		Convey("POST names the index of the rejected job", func() {
+			status, body := postJobs([]*JobViaJSON{{
+				Cmd: "echo rest good mount first", Cwd: testCwd, RepGrp: restCMRepGroup,
+				WithDocker: containerMountsTestImage, ContainerMounts: containerMountsWellFormed,
+			}, {
+				Cmd: "echo rest comma mount second", Cwd: testCwd, RepGrp: restCMRepGroup,
+				WithDocker: containerMountsTestImage, ContainerMounts: containerMountsWithComma,
+			}})
+
+			So(status, ShouldEqual, http.StatusBadRequest)
+			So(body, ShouldContainSubstring, "there was a problem with your job: jobs[1].ContainerMounts "+
+				`"`+containerMountsWithComma+`" is invalid: "1" is not an absolute path`)
 
 			jobs, errg := jq.GetByRepGroup(restCMRepGroup, false, 0, "", false, false)
 			So(errg, ShouldBeNil)

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -417,6 +417,10 @@ func malformedAddJobMessage(jobs []*Job) string {
 		if behaviourIndex := slices.Index(job.Behaviours, nil); behaviourIndex >= 0 {
 			return fmt.Sprintf("jobs[%d].Behaviours[%d] is nil", jobIndex, behaviourIndex)
 		}
+
+		if message := job.containerMountsMessage(); message != "" {
+			return fmt.Sprintf("jobs[%d].%s", jobIndex, message)
+		}
 	}
 
 	return ""

--- a/jobqueue/serverCLI.go
+++ b/jobqueue/serverCLI.go
@@ -33,7 +33,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"sort"
 	"strconv"
@@ -402,28 +401,6 @@ func applyLiveSnapshot(job *Job, jes *JobEndState) {
 	if len(jes.Stderr) != 0 {
 		job.StdErrC = jes.Stderr
 	}
-}
-
-func malformedAddJobMessage(jobs []*Job) string {
-	for jobIndex, job := range jobs {
-		if job == nil {
-			return fmt.Sprintf("job at index %d is nil", jobIndex)
-		}
-
-		if dependencyIndex := slices.Index(job.Dependencies, nil); dependencyIndex >= 0 {
-			return fmt.Sprintf("jobs[%d].Dependencies[%d] is nil", jobIndex, dependencyIndex)
-		}
-
-		if behaviourIndex := slices.Index(job.Behaviours, nil); behaviourIndex >= 0 {
-			return fmt.Sprintf("jobs[%d].Behaviours[%d] is nil", jobIndex, behaviourIndex)
-		}
-
-		if message := job.containerMountsMessage(); message != "" {
-			return fmt.Sprintf("jobs[%d].%s", jobIndex, message)
-		}
-	}
-
-	return ""
 }
 
 // warnIfSlowRequest warns when one client RPC took longer than

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -1663,7 +1663,7 @@ func decodeAndConvertJobs(r *http.Request, jd *JobDefaults) ([]*Job, int, error)
 
 	inputJobs := make([]*Job, 0, len(jvjs))
 
-	for _, jvj := range jvjs {
+	for jobIndex, jvj := range jvjs {
 		job, err := jvj.Convert(jd)
 		if err != nil {
 			return nil, http.StatusBadRequest, fmt.Errorf("there was a problem interpreting your job: %w", err)
@@ -1671,9 +1671,10 @@ func decodeAndConvertJobs(r *http.Request, jd *JobDefaults) ([]*Job, int, error)
 
 		// this endpoint does not go through handleAdd, so it has to make the
 		// same check that malformedAddJobMessage makes for every other way of
-		// adding a job.
+		// adding a job, naming the offending job by index the same way, so a
+		// multi-job POST says which one was rejected.
 		if message := job.containerMountsMessage(); message != "" {
-			return nil, http.StatusBadRequest, fmt.Errorf("%w: %s", errRESTUnusableJob, message)
+			return nil, http.StatusBadRequest, fmt.Errorf("%w: jobs[%d].%s", errRESTUnusableJob, jobIndex, message)
 		}
 
 		inputJobs = append(inputJobs, job)

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -85,6 +85,7 @@ var (
 	errRESTModifyNotFound        = errors.New("job not found")
 	errRESTCmdNotSpecified       = errors.New("cmd was not specified")
 	errRESTCancelStateRequired   = errors.New("state must be supplied as one of running|lost|deletable")
+	errRESTUnusableJob           = errors.New("there was a problem with your job")
 )
 
 type restRangeError struct {
@@ -1666,6 +1667,13 @@ func decodeAndConvertJobs(r *http.Request, jd *JobDefaults) ([]*Job, int, error)
 		job, err := jvj.Convert(jd)
 		if err != nil {
 			return nil, http.StatusBadRequest, fmt.Errorf("there was a problem interpreting your job: %w", err)
+		}
+
+		// this endpoint does not go through handleAdd, so it has to make the
+		// same check that malformedAddJobMessage makes for every other way of
+		// adding a job.
+		if message := job.containerMountsMessage(); message != "" {
+			return nil, http.StatusBadRequest, fmt.Errorf("%w: %s", errRESTUnusableJob, message)
 		}
 
 		inputJobs = append(inputJobs, job)


### PR DESCRIPTION
`DockerRunCmd` and `SingularityRunCmd` built a shell command line by string
concatenation, with every value interpolated **unquoted**, and the whole line
went through `/bin/sh`.

```go
return fmt.Sprintf("cat %s | docker run --rm --name %s%s%s -i %s /bin/sh",
    cmdFile, name, mountArgs, envArgs, image)
```

A mount path containing a space broke the shell word and docker's `--mount`
parse; a shell metacharacter was executed; and **`$PWD` was unquoted too**, so a
working directory with a space produced a wrong bind mount *with no user input
at all*. Paths with spaces are ordinary on shared filesystems.

What docker actually saw, with a cwd of `/tmp/.../home dir`:

```
Unable to find image 'dir:latest' locally
```

The tail of the path was parsed as the image name.

## The quoting

Everything user-influenced now goes through `shellquote.Join` — already a direct
dependency, already used this way at `jobqueue/job.go:346`:

- `cmdFile` — `os.CreateTemp` honours `TMPDIR`, so a user's `TMPDIR` reaches the line
- `image` — straight user input via `Job.WithDocker`/`WithSingularity`
- docker mount `source`/`target` — quoted as one whole `type=bind,source=…,target=…`
  word, so a space inside a field survives docker's own csv parse
- singularity `-B` specs, and each `-e` env name
- `name` — provably safe in-repo (always an MD5 hex `Job.Key()`), quoted anyway
  because `DockerRunCmd` is exported; `shellquote.Join` leaves hex untouched

**`$PWD` is the exception** and cannot go through `shellquote.Join`, which would
emit `'$PWD'` and kill the expansion. It is emitted as
`-w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`: double quotes keep
the run-time expansion, and an expansion's *result* inside double quotes is not
re-scanned for word splitting, so a cwd with a space stays one word. Adjacent
shell quoting concatenates the pieces into a single `--mount` argument.

`SingularityRunCmd` shared the whole defect and is fixed the same way, proven by
real execution (singularity-ce 4.1.1).

## Comma validation, and a bug found by asking where the user sees it

`Job.containerMounts` splits `ContainerMounts` on `","`, which is also docker's
`--mount` separator, so a path containing a comma is split into two malformed
mounts before docker sees it. The format cannot express such a path, so it is
now **rejected with a clear message** rather than silently producing a wrong
mount. The format itself is unchanged.

Checking *where the user sees that message* exposed two further defects, each
recorded and fixed as its own item:

- **The message never reached the CLI user.** `Server.replyError` sends the
  client only `serverResponse{Err: srerr}`, so the detail went to the manager log
  and `wr add` printed `bad request (missing arguments?)`. Fixed by validating
  client-side, as `Client.Modify` already did, leaving the wire protocol alone.
- **`wr mod --with_docker` could make a previously-ignored broken value live** in
  two user steps. Closed by a pre-pass in `JobModifier.Modify`.
- `POST /rest/v1/jobs/` needed its own hook: `restJobsAdd` calls `createJobs`
  directly and never reaches `handleAdd`, so without it the endpoint returned
  201 for a malformed value. Now HTTP 400 naming `jobs[N]`.

## Evidence

The red command drives **real docker and real singularity**, asserting observable
behaviour — `pwd` inside the container, files really visible at their mount
targets — for directory names containing a space *and* shell metacharacters
(`mnt B;rm -rf x&*'q'`). Not a string comparison: `run_test.go`'s exact-string
assertion was updated and extended, not made the only evidence.

- Pre-fix: 4 assertions, 2 failures, **3/3 reproduction**, both `exit status 125`.
- The skip guard was verified rather than assumed: built the test binary and ran
  it under `env -i` with neither binary on PATH. It skips **visibly**, so a
  docker-less CI reports a skip, not a silent pass.

Six mutations, each `go vet ./container/ ./jobqueue/ ./cmd/` clean first so it
provably compiled, each reverted:

| Mutation | Verdict |
| --- | --- |
| un-quote docker `--mount` value | red, exit 127 |
| un-quote `$PWD` alone | red, exit 125 — the exact recorded symptom |
| un-quote singularity `-B` | red, exit 127 |
| `containerMountsMessage` -> no-op | all 3 validation tests red, so each call site is separately load-bearing |
| `jobsValidationError(nil)` | red, the modify succeeded |
| narrowing early return deleted | red |

Gates: `make test` and `make race` both `625 passed · 13 skipped`, zero race
reports; `make lint` `0 issues.`

## One user-visible change worth a release note

`~/data:/data` used to work for singularity, by accidental tilde expansion of an
unquoted `-B`. It is now quoted and rejected as non-absolute. It never worked for
docker and the documented format is absolute, so this is a net improvement — but
it is a behaviour change for anyone relying on it.

## Recorded, deliberately not changed

- A **colon** in a mount path is still silently unexpressible: `/data/a:b:/mnt`
  yields `local == inContainer == "/data/a"`, dropping the rest, and validation
  accepts it because both halves are absolute. Fixing it means rejecting
  multi-colon specs or changing the format.
- `Server.replyError` still drops `qerr` for every other handler; this PR routed
  around it for add and modify rather than changing every handler's
  client-visible error text.
