### PR TITLE
Make JobEssence able to describe the job it names

### DIFF
--- a/.docs/bugfixes/260907-2.md
+++ b/.docs/bugfixes/260907-2.md
@@ -376,3 +376,176 @@
       way. Only `new-from-rev: master` hides the standing hit at
       `job_test.go:441`, which dates from 2021. The new test therefore has its
       own single-use fixture values.
+
+- [x] Copilot review of `c797e088` (PR #588, review 5142029868):
+  `validateSelectionContainerFlags` (`cmd/status.go:699`) rejects only the
+  two-images case. It accepts `--container_mounts` with NEITHER
+  `--with_docker` nor `--with_singularity`, and in that case
+  `jobKeyConcat` (`jobqueue/job.go:262`) drops `containerMounts` entirely,
+  because the whole image-and-mounts suffix is written only `if image != ""`.
+  So the essence keys a PLAIN NON-CONTAINER job, and the selector silently
+  matches one.
+    - This is a real hazard rather than a cosmetic one, because these flags
+      were added by this branch to 6 commands, 5 of which are destructive:
+      `kill`, `remove`, `retry`, `suspend`, `resume` (and `status`). A user who
+      types `wr kill -l "cmd" --container_mounts /a:/b`, believing they have
+      narrowed the selection to a containerised job, kills the plain job of the
+      same Cmd instead. The flag they added to be MORE specific makes them hit
+      a job they did not name.
+    - Found by Copilot, not by the branch's own tests, because
+      `cmd/selection_essence_test.go`'s "wrong/absent container options match
+      nothing" case pairs absent mounts with an absent image, and never sets
+      mounts alone.
+    - Red command: a `cmd`-package test in the style of
+      `TestSelectionByCmdLine`, driving real cobra parsing and the real
+      `runSuspendCommand` against a real manager. Add a plain job with no
+      container, then select it with `-l <cmd> --container_mounts /a:/b`. It
+      currently SUCCEEDS and suspends that job; it must instead be rejected.
+    - Decision on the shape of the fix: reject at validation, do not make the
+      key carry mounts without an image. Carrying them would change
+      `Job.Key()`'s layout for a job that has mounts and no image, orphaning
+      stored jobs, which `.docs/bugfixes/260904-4.md` and `TestKeyByteIdentity`
+      forbid. Rejecting costs nothing, since the combination cannot describe
+      any job that exists.
+    - Note for a separate item, NOT this one: `wr add` accepts
+      `--container_mounts` with no image too, and silently ignores it (the
+      `ContainerMounts` doc comment says so). That is the same class as the
+      open question about `wr add --with_singularity x --container_image_user`
+      being silently accepted. Both are submission-time warnings and are the
+      repo owner's call; this item changes only selection, where the
+      consequence is a wrong destructive match rather than an ignored value.
+
+- [x] Sighting only, not owned by this branch: CI `test` for `c797e088` failed
+  on `TestJobqueueSignal` at 181.65s
+  (run 34229091612, `jobqueue_test.go:2081`,
+  `Expected: jobqueue.JobState("lost") Actual: "running"`).
+    - That is BUG 20 in `.docs/bugfixes/260829-1.md`, which is still open on
+      `develop`: same test, same assertion, same ~182s signature, meaning it
+      sat out the full 3-minute `runnerStartWait`. The line number moved from
+      2037 to 2081 only because the file has grown since.
+    - Not this branch's: `da1be588` and `4f94bdbe` both passed CI `test`, and
+      `c797e088` adds only doc comments, 3 `codec:",omitempty"` struct tags and
+      one new DB test - nothing touching runners, signals or lost-job
+      detection. Locally `make test` AND `make race` both passed at
+      `634 passed · 13 skipped` on this exact commit.
+    - Remedy applied is the one BUG 20 itself records: re-run the CI job on the
+      unchanged commit. Chasing the flake stays with BUG 20, whose recorded
+      next step is to run the test under DISK load, per BUG 5's finding that
+      disk rather than CPU reproduces this family.
+    - Confirmed a flake: the CI re-run of the SAME job on the UNCHANGED commit
+      `c797e088` passed. That is the second time BUG 20 has behaved exactly
+      this way, and it is the evidence BUG 20 itself asks for.
+
+  Fix for the `--container_mounts` item, over 2 review cycles:
+    - Cycle 1, production, and it survived both reviews unchanged: a second
+      guard in `validateSelectionContainerFlags` (`cmd/status.go`) returning a
+      new `errSelectionContainerMountsNeedImage` when `cmdContainerMounts` is
+      set and both image flags are empty. That predicate is the exact
+      complement of `jobKeyConcat`'s `if image != ""`, since
+      `containerImageKey` returns `""` only when both image fields are empty,
+      so it rejects precisely the inputs whose mounts vanish from the key. The
+      message names both remedies rather than only the fault:
+      "--container_mounts only describes a job alongside --with_docker or
+      --with_singularity; add the image the job was added with, or drop
+      --container_mounts". Reviewer read it off a real binary's stderr,
+      unwrapped, exit 1.
+    - Rejected at validation rather than by teaching the key to carry mounts
+      without an image, which would move `Job.Key()` for a job that has
+      `ContainerMounts` and no image and orphan stored jobs.
+      `git diff -- jobqueue/` is empty for the whole item.
+    - Cycle 1 FAILED review on its test, and the failure is worth recording
+      because it is the shape this repo keeps hitting. A loop Convey titled
+      "every command offering the container selectors rejects mounts without
+      an image" set each of the 6 commands' `container_mounts` flag and then
+      called `validateSelectionContainerFlags()` DIRECTLY. All 6 flags write
+      the one package global `cmdContainerMounts`, so the validator's answer
+      was identical for every iteration by construction: `accepted` could only
+      ever be empty or all 6. It never ran a command. The reviewer proved it
+      vacuous by deleting the entire validation call from `cmd/kill.go`: the
+      whole `cmd` suite stayed GREEN, 65s, with `wr kill` accepting the very
+      combination this item exists to reject.
+    - Cycle 2 replaced it. `cmd/root.go` gained `var cmdExit = os.Exit` with
+      `die()` calling `cmdExit(1)`, the third instance of a seam this repo
+      already documents twice (`statusExit`, `cmd/status.go`;
+      `managerCompactExit`, `cmd/manager.go`), which is what makes `status`,
+      `kill`, `remove` and `retry` observable at all - their `Run` bodies
+      `die()`, and `die` was `os.Exit(1)`, so a test could only kill its own
+      process. The new Convey drives all 4 through their REAL `Run` inside
+      `withQueueCommandTestServer`, against a real manager holding a real
+      plain job whose key is what the mounts-without-image essence produces,
+      and asserts BOTH exit code 1 and that the sentinel's own text reached
+      `clog`. Offenders are collected into a slice and asserted once, because
+      GoConvey's `FailureHalts` would otherwise abort at the first one and
+      report a 2-command regression as a 1-command regression.
+    - Proved load-bearing by 5 mutations run by the reviewer independently of
+      the implementor, each `go vet` clean and each reverted byte-exactly with
+      `md5sum -c`: deleting the validation call from `kill`, `retry`, `status`
+      and `remove` each turns it red NAMING that command
+      (`Expected [kill (exit 0, logged "")] to be empty`), and making
+      `suspend.go`'s validator return nil turns both the suspend and the
+      resume Convey red. The deleted loop stayed green under all of them.
+    - Production behaviour is unchanged by the seam: `cmdExit` is reassigned
+      nowhere outside `cmd/suspend_test.go`, and the reviewer confirmed against
+      a built binary that all 6 commands still exit 1 with the message, that
+      unrelated `die` paths still exit 1, and that a valid image+mounts combo
+      still proceeds.
+    - Test harness was de-duplicated as a side effect, which is the part most
+      worth knowing about: `captureStdout`, `recoverCommandExit` and the
+      renamed `commandExitPanic` replace what would otherwise have been a
+      third copy of the stdout-pipe boilerplate and a second copy of the
+      recover dance. Signature-preserving; all 15 pre-existing call sites
+      unchanged; the only deleted lines are 6 pipe-plumbing `So()`s folded
+      into the helper. `runStatusForTest` (`cmd/status_test.go`) still carries
+      a fourth hand-rolled copy and was deliberately left, being out of scope.
+    - Known and deliberately left, each judged not worth another cycle:
+      `runSelectionCommandRunForTest` differs from the existing
+      `runSelectionCommandForTest` by one interior word and the name does not
+      carry the distinction; the `statusCmd` branch to `resetStatusForTest`
+      (needed because `statusCmd` registers no `--all`, and because the status
+      reset clears output-mode state the generic one does not) carries no
+      comment saying why; and the branch's own "reject both container images
+      at once" Convey is still outside `withQueueCommandTestServer`, so a
+      regression there surfaces as a nil-pointer panic in `token()` rather
+      than an assertion, which is the same one-line move cycle 2 made for the
+      resume Convey.
+
+- [x] Sighting only, not owned by this branch, and NOT reproducible on demand:
+  `TestKillingALostJobSparesTheRunThatReplacesIt`
+  (`jobqueue/lost_job_behaviours_test.go:1116`) failed twice during this
+  branch's local gate runs, `Expected: JobState("running") Actual:
+  JobState("lost")` - i.e. the retry reported its Started but the manager had
+  already parked it lost again.
+    - Same family as BUG 5 and BUG 20 in `.docs/bugfixes/260829-1.md`: a job's
+      state racing a heartbeat under load. It is NOT on the known
+      load-sensitive list, so this is a new name for that list.
+    - Chased rather than waved through, and every attempt to pin it FAILED to
+      reproduce it:
+      * isolation, 12/12 green on this branch and 12/12 green on `develop`;
+      * 10/10 green on `develop` under 6 spinning CPU hogs;
+      * 10/10 green on `develop` under 4 concurrent `dd conv=fsync` writer
+        loops - and BUG 5 records DISK, not CPU, as this family's usual
+        trigger, so that was the experiment most expected to work;
+      * full suite on `develop`, 4/4 green;
+      * full suite interleaved between `c797e088` and `71a29ae9` under
+        identical conditions, 3/3 green each.
+    - Final tally on this branch's head `71a29ae9`: 2 failures in 8 full-suite
+      runs, with the last 6 consecutive green. Both failures fell inside one
+      window, immediately after the page cache had been dropped twice for an
+      unrelated reason, when the whole box was doing cold-cache I/O. That is
+      the only condition distinguishing the failing runs from the passing
+      ones, and it fits a timing-sensitive lost-job test.
+    - No mechanism connects it to this branch. The test is untouched here, and
+      so is every path it drives: `reportedState` reads
+      `l.server.q.Get(l.key)` straight from the in-memory queue, and
+      `lost_job_behaviours_test.go` never calls `GetByEssence`, which is the
+      only jobqueue BEHAVIOUR this branch changes. The branch's other jobqueue
+      edits are comments, 3 struct tags and one new DB test.
+    - Considered and rejected: that cycle 2's new Convey caused it by standing
+      up an extra real manager in the `cmd` package. It was the leading
+      hypothesis, because at first every observed failure was on `71a29ae9`
+      and none on the 3 commits before it. The interleaved run above killed
+      it: `c797e088`, which predates that Convey, and `71a29ae9` behaved
+      identically, 3/3 each.
+    - Left for the owner as a new entry in the load-sensitive family rather
+      than fixed here. Anyone who sees it again should record the machine's
+      I/O state at the time, since that is the one lead this produced.

--- a/.docs/bugfixes/260907-2.md
+++ b/.docs/bugfixes/260907-2.md
@@ -1,0 +1,191 @@
+# Bugfixes 2026-09-07 (2)
+
+- [x] `JobEssence.Key()` (`jobqueue/job.go:1911`) is documented "returns the
+  same value that key() on the matching Job would give you", and does not.
+  Against `Job.Key()` (`jobqueue/job.go:1544`) it differs twice: it prefixes
+  `Cwd` whenever `Cwd != ""` rather than only when the Job has
+  `CwdMatters`, and it never appends the container image and
+  `ContainerMounts` suffix. Two user-visible consequences:
+    - (a) `wr kill -l "cmd" -c /some/dir` finds nothing for a job added as
+      `wr add -c /some/dir` WITHOUT `--cwd_matters`, the common case.
+      `getJobsByCmdLine` (`cmd/status.go:1148`) builds the essence from `-l`
+      plus `-c`, so the key carries a `Cwd` prefix the Job's key does not
+      have. The CLI dies with "No matching jobs found" and does not hint why.
+    - (b) `-l` selection can NEVER match a containerised job: `JobEssence` has
+      no field for the image, so a job added with `--with_docker` or
+      `--with_singularity` is unreachable by `-l` with or without `-c`.
+    - Each affected command's LONG help states the condition ("you must
+      provide the cwd the commands were set to run in, if CwdMatters (and must
+      NOT be provided otherwise)", `cmd/kill.go:63-65`), but the `-c` flag's
+      own one-liner does not, and that one-liner is what `--help` shows.
+    - Red command (a red-harness test in the `cmd` package driving the real
+      selection path of a real queue command against a real manager; the
+      implementor folds it into the regression test):
+      `cmd/selection_essence_red_test.go`, `TestRedSelectionByCmdLine`. It
+      adds a job and then selects it the way the CLI does:
+
+      ```go
+      // (a)
+      job.Cwd = cwd // CwdMatters false
+      addQueueCommandJobs(jq, job)
+      output, err := runSuspendForTest(t, "-l", "echo red cwd does not matter", "-c", cwd)
+      So(err, ShouldBeNil)
+      So(output, ShouldEqual, "Suspended 1 queued commands (out of 1 matching)\n")
+
+      // (b)
+      job.WithDocker = "ubuntu:latest"
+      addQueueCommandJobs(jq, job)
+      output, err := runSuspendForTest(t, "-l", "echo red containerised",
+          "--with_docker", "ubuntu:latest")
+      ```
+
+      `CGO_ENABLED=0 go test -tags netgo --count 1 ./cmd -run TestRedSelectionByCmdLine -v`
+    - Ran for real, no docker or other daemon needed (adding a `WithDocker`
+      job only queues it). 4/4 runs red, 2.5s each, 1 failure per half:
+
+      ```
+      (a) -l with -c finds a job that was added with --cwd but not --cwd_matters
+        cmd/selection_essence_red_test.go Line 48:
+        Expected: nil
+        Actual:   'no matching jobs found'
+
+      (b) -l finds a job that was added with --with_docker
+        cmd/suspend_test.go Line 296:
+        Expected: nil
+        Actual:   'unknown flag: --with_docker'
+      ```
+    - Decision on half (a): **the read path tries both candidate keys, and
+      verifies the less specific one against the Job it returns.** Adding a
+      `CwdMatters bool` to `JobEssence` was rejected: it cannot fix the
+      reported symptom (the CLI user typing `-c` still has to know a flag the
+      selection commands do not even have), and the `{Cmd, Cwd}` meaning is
+      publicly documented and persisted - `NewEssenceDependency`
+      (`jobqueue/dependency.go:466`) says "Leave cwd as an empty string if the
+      job you are describing does not have CwdMatters true", `wr add`'s
+      `cmd_deps` help (`cmd/add.go:409-411`) says the same, and
+      `Dependency.Essence` is serialised into the DB
+      (`jobqueue/dependency.go:315`), so gating the Cwd prefix on a new field
+      would change the keys of already-stored dependency essences - the same
+      orphaning problem as changing `Job.Key()`.
+    - It can NOT select a job the user did not mean, and the reason is
+      structural rather than only the Cwd check:
+      `Client.GetByEssence` returns at most one Job and its behaviour is a
+      strict superset of the old one - where the primary (CwdMatters) key
+      exists it returns exactly what the old single-key request returned, and
+      it returns a Job only where the old code returned nothing. The
+      less specific candidate is accepted only when the returned Job's `Cwd`
+      equals the requested one, exact-compared as `Job.Key()` treats Cwd. That
+      candidate is unique by construction: a non-CwdMatters Job's Cwd is not
+      part of its key, so two such Jobs with the same Cmd/mounts/image cannot
+      coexist. When both a CwdMatters and a non-CwdMatters Job share a Cmd, the
+      primary wins whatever order the server lists them in. And nothing widened
+      on the destructive side: `jesToKeys` and `Kill`/`Delete`/`Kick`/
+      `Suspend`/`Resume`/`Modify` still send exactly one key per essence, and
+      the CLI re-derives that key from the Job it actually read back
+      (`jobsToJobEssenses` -> `job.ToEssense()`). The only new failure mode is
+      a miss: a trailing slash or a relative `-c` gives "no matching jobs
+      found" rather than a wrong selection.
+    - Fixed. `jobqueue/job.go`: `JobEssence` gained `WithDocker`,
+      `WithSingularity` and `ContainerMounts` (additive - every existing
+      caller leaves them empty and keys identically), and `Key()`'s doc comment
+      now states the truth instead of the old false claim. `Job.Key()` and
+      `JobEssence.Key()` now share one layout builder,
+      `jobKeyConcat(cwdMatters, cwd, cmd, mountKey, image, containerMounts)`,
+      plus `containerImageKey()` for the `"docker:"`/`"singularity:"` form, so
+      the two cannot drift apart again; the extraction was also forced by
+      `funlen` (30 lines). Whether to write the cwd prefix is passed in
+      explicitly rather than inferred from the cwd being set, because a Job
+      with `CwdMatters` true and an empty `Cwd` is keyed with a bare `"."`
+      prefix and that key must not change (see the review finding below).
+      New `candidateKeys()` (primary, then the Cwd-less alternate) and
+      `pickCandidateJob()`. `jobqueue/client.go`: `GetByEssence` sends both
+      candidates in the one existing `getbc` request (`Keys` was already
+      `[]string`, so no wire change) and picks with `pickCandidateJob`.
+      `ToEssense()` is unchanged, so `cmd/lsf.go` and every
+      `jobsToJobEssenses` caller keep producing exact keys.
+    - CLI: new shared `addSelectionContainerFlags`/
+      `validateSelectionContainerFlags` (`cmd/status.go`) give `kill`,
+      `remove`, `retry`, `status`, `suspend` and `resume` the
+      `--with_docker`/`--with_singularity`/`--container_mounts` selectors
+      (mutually exclusive images, message copied from `cmd/add.go:520`), and
+      `getJobsByCmdLine` feeds them into the essence - without them half (b)
+      would be fixed only for Go API callers, since an image cannot be guessed
+      from a command line.
+    - Help: the condition is GONE, so the help says the new truth rather than
+      stating the condition. The `-c` one-liner now reads "working dir that the
+      command(s) specified by -l or -f were added with, whether or not
+      --cwd_matters was used" at all 5 registration sites (`cmd/kill.go`,
+      `cmd/remove.go`, `cmd/retry.go`, `cmd/status.go`, and `cmd/suspend.go`'s
+      `addSelectedJobsFlags`, shared by suspend and resume), and the long-help
+      paragraph was rewritten in all 6 commands to drop "if CwdMatters (and
+      must NOT be provided otherwise)" and to name the container options
+      alongside the mounts options. Checked and deliberately left alone:
+      `cmd/add.go:617` and `cmd/mod.go:484`, whose `-c` sets a job's working
+      dir rather than selecting jobs (`mod` selects only with -i/-a, and clears
+      `cmdLine` before `getJobs`, so it never reaches `getJobsByCmdLine`).
+    - Regression tests: `cmd/selection_essence_test.go`'s
+      `TestSelectionByCmdLine` is the red harness folded in, driving real
+      `cobra` flag parsing and the real `runSuspendCommand`/`runResumeCommand`
+      against a real manager, asserting the CLI's own output plus each job's
+      state - 7 cases, 313 assertions: the 2 red cases, a different `-c`
+      matching nothing, a CwdMatters job preferred over a non-CwdMatters twin
+      with only one job affected, a containerised job found with `-c` and
+      `--container_mounts`, wrong/absent container options matching nothing,
+      and the two-images rejection. No container runtime is involved (adding a
+      `WithDocker` job only queues it), so nothing is skipped.
+      `jobqueue/essence_candidate_test.go`'s `TestCandidateJobSelection` pins
+      the order-independence of `pickCandidateJob`, which a real server cannot
+      be made to exercise (it returns queued jobs before DB jobs).
+      `jobqueue/job_test.go` gained cross-type `JobEssence.Key()` ==
+      `Job.Key()` assertions for containerised and non-CwdMatters jobs, the
+      missing `{Cmd, CwdMatters: true}` oracle case, and
+      `TestKeyCwdDistinctness`. `TestKeyByteIdentity`'s oracles and all its
+      pre-existing cases are untouched: every test file diff is insertions
+      only.
+    - Review cycle 1 returned FAIL on one real blocker, now fixed: the first
+      shared builder decided the cwd prefix by `cwd != ""`, but the old
+      `Job.Key()` decided by `j.CwdMatters` and so wrote a bare `"."` for a Job
+      with `CwdMatters` true and an empty `Cwd`. That Job's key changed and
+      collided with the non-CwdMatters key. `TestKeyByteIdentity`'s `jobs` list
+      had no such case, which is why the byte-identity guard from
+      `.docs/bugfixes/260627-1.md` did not catch it; the case is now in the
+      list, and it fails without the fix (`Line 1084: Expected: 0 / Actual:
+      1`). Cycle 2 reviewer independently transcribed the pre-change
+      `Job.Key()` and `JobEssence.Key()` into a standalone program with its own
+      `byteKey` and swept 1152 Job input classes and 96 essence classes
+      (empty Cmd, empty and out-of-order mount keys, both image branches,
+      docker-wins-over-singularity, ContainerMounts without an image): 0
+      mismatches. It also reproduced the golden key recorded in
+      `.docs/bugfixes/260904-4.md` exactly.
+    - Mutation check, halves isolated, each `CGO_ENABLED=0 go vet -tags netgo
+      ./cmd/ ./jobqueue/` clean first so it provably compiled, each reverted
+      byte-exactly afterwards (md5 verified):
+      half (a), making the alternate candidate key non-Cwd-less ->
+      `TestSelectionByCmdLine` red at line 55 (plain non-cwd_matters + `-c`)
+      and line 120 (containerised + `-c`), with the container-only case still
+      green; half (b), making the essence's key builder pass an empty image ->
+      red at line 103 (containerised) and line 120 only, with the plain cwd
+      case still green. Also proved the cycle-1 blocker shape red
+      (`TestKeyCwdDistinctness` and the new oracle case) and the
+      order-independence assertion real (making the fallback win when listed
+      first fails `TestCandidateJobSelection` while
+      `TestSelectionByCmdLine` still passes - the unit seam catches what the
+      integration test structurally cannot).
+
+- [ ] `jobqueue/modify_validation_test.go:421` is `gofmt -l`-dirty and
+  `make lint` cannot see it: `new-from-rev: master` excludes the line, whose
+  content is identical to master's. The misalignment was introduced by
+  `0451e622` ("Shell quote container command lines...", #587) - this branch's
+  own base, already on `origin/develop` - which added
+  `ContainerMounts: mounts,` at line 420 and so changed the alignment group:
+
+  ```
+  -			RepGroup: modifierValidationRepGroup, ReqGroup: modifierValidationRepGroup,
+  +			RepGroup:        modifierValidationRepGroup, ReqGroup: modifierValidationRepGroup,
+  ```
+
+  It is the only `gofmt -l` hit across `./cmd ./jobqueue ./client`. Found by
+  this item's implementor and confirmed pre-existing by its reviewer against
+  `git show master:jobqueue/modify_validation_test.go`, so it does NOT belong
+  on `fix-jobessence-key`: left for the repo owner to take against `develop`
+  so this branch keeps one topic.

--- a/.docs/bugfixes/260907-2.md
+++ b/.docs/bugfixes/260907-2.md
@@ -278,3 +278,101 @@
       the Cwd ambiguity, but the other `jesToKeys` users say nothing about it.
       The field comment covers them by mechanism, and widening the change
       would have broken the minimality this item is bounded by.
+
+- [x] The 3 fields this branch added to `JobEssence` (`WithDocker`,
+  `WithSingularity`, `ContainerMounts`) are written to the database even when
+  empty, so every stored `Dependency.Essence` grew. `Job.Dependencies` is an
+  exported field with no codec tag, so the whole `Dependency` - and its
+  `*JobEssence` - is encoded inside every Job record (`jobqueue/db.go:3057`
+  and friends, via `db.ch`). That handle is a bare `new(codec.BincHandle)`
+  (`jobqueue/db.go:1272`) with no `omitempty` and no `StructToArray`, so a
+  struct is a map of ALL its exported field names and 3 empty strings cost 3
+  field names plus 3 map entries.
+    - Measured, `github.com/ugorji/go/codec v1.3.1`, encoding through a bare
+      `codec.BincHandle` exactly as `db.ch` is:
+
+      ```
+                              develop 9587331f   this branch
+      bare JobEssence              75 bytes       123 bytes   (+64%)
+      Job with  1 cmd_deps dep    855 bytes       903 bytes   (+5.6%)
+      Job with  5 cmd_deps deps  1231 bytes      1471 bytes   (+19.5%)
+      Job with 20 cmd_deps deps  2642 bytes      3602 bytes   (+36.3%)
+      Job with a dep_grp dep      789 bytes       789 bytes   (unchanged)
+      Job with no deps            761 bytes       761 bytes   (unchanged)
+      ```
+
+      Only `cmd_deps` (Essence) dependencies pay. A `dep_grp` dependency has a
+      nil `Essence`, and a Job with no dependencies is untouched.
+    - Second cost, not only size: a record this branch writes for a
+      container-free essence is no longer the shape an older wr writes, so a
+      downgrade meets 3 unknown map keys.
+    - Red command: a test that encodes a `JobEssence` carrying no container
+      fields and compares the bytes against the same encoding of a
+      locally-declared struct mirroring the PRE-branch `JobEssence` shape
+      (JobKey, Cmd, Cwd, MountConfigs only), asserting they are IDENTICAL.
+      That is the property both costs reduce to, and it is red today at 123
+      bytes against 75.
+    - Fix to apply: `codec:",omitempty"` on the 3 new fields. Proved out
+      before briefing, then reverted byte-exactly (`md5sum -c` on
+      `jobqueue/job.go`): it takes the bare essence back to exactly develop's
+      75 bytes and the 20-dep Job back to exactly 2642, leaves a docker
+      essence at 135, round-trips empty/docker/singularity essences with keys
+      unchanged, and leaves `TestKeyByteIdentity`, `TestJob`, `TestDB*`,
+      `TestDependencies`, `TestCandidateJobSelection` and
+      `TestKeyCwdDistinctness` green.
+    - The tag MUST carry its leading comma. `codec:"omitempty"` renames the
+      field to `omitempty` and orphans every stored record.
+    - Fixed. `codec:",omitempty"` on all 3 fields in `jobqueue/job.go`, and
+      nothing else: the file is +3/-3, the tag lines only. These are the first
+      and only `codec:` tags in the repo, which is justified because the bug is
+      precisely that `db.ch` is a bare handle. `jobqueue/db.go:1272` is
+      untouched.
+    - Regression test: `TestDBJobEssenceEncoding` (`jobqueue/db_test.go`), with
+      a `preContainerJobEssence` mirror type and an `encodeWithDBHandle`
+      helper that uses the REAL `db.ch` from `initDB` rather than a fresh
+      handle, so it follows if the handle is ever reconfigured. 3 Conveys, 45
+      assertions: byte-identity of a container-free essence against the
+      pre-branch shape; a pre-branch record decoding into the new struct; and
+      empty/docker/singularity essences round-tripping every field plus
+      `Key()`. The file diff is insertions only.
+    - The byte-identity assertion compares two encodings made at RUNTIME by the
+      same handle rather than hardcoded golden bytes, so a codec upgrade moves
+      both sides together and cannot make it red for an innocuous reason. The
+      only thing that breaks it is a new or renamed `JobEssence` field that
+      changes the stored shape, which is the regression itself, and it forces
+      whoever adds the next field to decide about `omitempty`.
+    - Red proved by reverting the tags: red at `db_test.go:152`, 63 bytes
+      expected against 111 actual, the map-length byte going 120 -> 123 and the
+      3 field names appended with empty-string markers.
+    - The leading-comma footgun is GUARDED, proved by mutation. Writing
+      `codec:"omitempty"` on one field turns `TestDBJobEssenceEncoding` red,
+      with the stray bytes decoding as ASCII `omitempty`, so the test names the
+      exact mistake. `TestJob` and `TestKeyByteIdentity` both stay GREEN under
+      that rename, so the byte-identity Convey is the only thing in the repo
+      standing between this change and orphaned records.
+    - The round-trip Convey is load-bearing too, proved by tagging
+      `ContainerMounts` `codec:"-"`: red at `db_test.go:190`. The byte-identity
+      Convey correctly stayed green for that, so the two catch disjoint
+      failures. Honest note: the pre-change-record Convey could not be made red
+      by either mutation. It is a genuine forward-compatibility assertion and
+      cheap to keep, but it is not a guard.
+    - `Key()` output is unchanged, verified independently of the implementor by
+      sweeping 720 Job shapes and 720 JobEssence shapes (cwd with and without a
+      trailing slash, relative and spaced, `CwdMatters` both ways, empty Cmd,
+      both image branches, both set, ContainerMounts with and without an image,
+      3 MountConfigs shapes, and a preset `JobKey`) with and without the tags:
+      1441 lines identical.
+    - Sizes after the fix, re-measured by the reviewer on its own fixture: 48
+      bytes saved per essence and 960 saved on a 20-dep Job, the same 960 the
+      report above measured (3602 - 2642). Jobs with no deps and jobs with only
+      `dep_grp` deps are byte-identical before and after, confirming only
+      `cmd_deps` deps ever paid.
+    - `goconst` tripwire found while doing this, worth knowing before touching
+      `jobqueue`: reusing the existing `"/out:/in"` and `"alpine.sif"` fixture
+      strings in a new test makes `make lint` RED, including at
+      `jobqueue/job_test.go:1123`, a line `da1be588` owns. `"/out:/in"` is at 6
+      occurrences and `"alpine.sif"` at 2, and ONE more use of either on a
+      branch-owned line tips it over: the reviewer reproduced 3 issues that
+      way. Only `new-from-rev: master` hides the standing hit at
+      `job_test.go:441`, which dates from 2021. The new test therefore has its
+      own single-use fixture values.

--- a/.docs/bugfixes/260907-2.md
+++ b/.docs/bugfixes/260907-2.md
@@ -189,3 +189,92 @@
   `git show master:jobqueue/modify_validation_test.go`, so it does NOT belong
   on `fix-jobessence-key`: left for the repo owner to take against `develop`
   so this branch keeps one topic.
+
+## PR #588 review findings
+
+- [x] Copilot review of `da1be588` (PR #588, review 5141077742): two doc
+  comments contradict the selection contract this branch introduced.
+    - `JobEssence.Cwd`'s field comment (`jobqueue/job.go:2019-2021`) says "Cwd
+      should only be set if the Job was created with CwdMatters = true". This
+      branch's whole point is that a caller who does NOT know a Job's
+      `CwdMatters` may now set `Cwd` and reach the Job:
+      `getJobsByCmdLine` (`cmd/status.go`) does exactly that from the CLI's
+      `-c`, and `Client.GetByEssence` tries both candidate keys.
+      `JobEssence.Key()`'s own doc comment, added by this branch, already
+      states the new contract ("A caller describing a Job whose CwdMatters it
+      does not know should use Client.GetByEssence(), which considers both
+      interpretations of a set Cwd"), so the field comment contradicts a
+      comment 20 lines below it.
+    - `keyForCwd`'s doc comment (`jobqueue/job.go:239-240`) asserts the same
+      thing as fact in a parenthetical: "(a JobEssence sets a Cwd only for a
+      Job whose CwdMatters is true; see Key())". That is now false of the
+      essences this branch's own CLI path builds.
+    - Reported twice by the same review: as thread `PRRT_kwDOAKD33M6gN4E4` on
+      `jobqueue/job.go:240`, and as a suppressed comment on
+      `jobqueue/job.go:2022`.
+    - **No red command, and none is possible.** The change is to comment text
+      only; there is no behaviour to observe failing. The falsifying evidence
+      is the contradiction itself, read out of the shipped tree:
+
+      ```
+      $ sed -n '2019,2021p;2046,2049p' jobqueue/job.go
+        // Cwd should only be set if the Job was created with CwdMatters = true. See
+        // Key() for what setting it does and does not describe.
+        Cwd string
+      // Job's key only when that Job has CwdMatters true. This therefore reproduces
+      // the key of a matching Job with CwdMatters true when Cwd is set, and the key of
+      // a matching Job with CwdMatters false when Cwd is empty. A caller describing a
+      // Job whose CwdMatters it does not know should use Client.GetByEssence(), which
+      ```
+
+      No test may be added for it either: `.docs/bugfixes/260907-3.md` records
+      this repo deleting a test whose only claim was the text of a source file,
+      per **testing-principles**, which names source text an implementation
+      detail. The gates staying green is the only check this item gets.
+    - Bound on the fix: the old rule is still TRUE for a `Dependency`'s
+      Essence, and must not be deleted. `Dependency` resolution calls
+      `d.Essence.Key()` directly (`jobqueue/dependency.go:277`), taking the one
+      key with no candidate fallback, and that key is serialised into the DB
+      (`jobqueue/dependency.go:315`). `NewEssenceDependency`'s doc comment
+      (`jobqueue/dependency.go:466`) and `wr add`'s `cmd_deps` help
+      (`cmd/add.go:409-411`) say "leave cwd empty if the job you are describing
+      does not have CwdMatters true", and both stay correct and unchanged. So
+      the corrected comment must distinguish the two uses rather than simply
+      drop the rule.
+    - Fixed, comments only. `keyForCwd`'s false parenthetical is replaced by a
+      statement of what the function actually produces: "which is part of the
+      key only when it is not \"\": it therefore gives the key of a Job with
+      CwdMatters true when cwd is set, and the key of a Job with CwdMatters
+      false when cwd is \"\". See Key() and candidateKeys()." The mapping is
+      the one the call makes - `cwd != ""` IS `jobKeyConcat`'s `cwdMatters`
+      argument - and `candidateKeys()` is cross-referenced because it is the
+      caller that passes `""` for a non-empty `j.Cwd`, which is the case the
+      old parenthetical denied could exist.
+    - `JobEssence.Cwd`'s field comment keeps the old rule and scopes it, rather
+      than dropping it: "Cwd should only be set if the Job was created with
+      CwdMatters = true, whenever the single key that Key() returns is used on
+      its own, as a Dependency's Essence is. A caller that does not know the
+      Job's CwdMatters may set Cwd anyway and look the Job up with
+      Client.GetByEssence(), which considers both interpretations."
+    - Scoped by mechanism rather than by naming `Dependency`, because the
+      reviewer found `jesToKeys` (`jobqueue/client.go:3596`) is a second
+      `Key()`-only user with SEVEN callers - `Kick`, `Suspend`, `Resume`,
+      `Delete`, `Kill`, `GetByEssences` and `Modify` - so an enumeration would
+      have been wrong the day it was written. `Dependency` stays as the
+      concrete example.
+    - `jobqueue/dependency.go` and `cmd/add.go` are untouched and still
+      correct. Every added and removed line in `jobqueue/job.go` matches
+      `^[+-]\s*//`: net +9/-4 comment lines, no code, identifier, signature,
+      blank-line or formatting change, and no unrelated comment re-wrapped.
+    - No test added, and adding one would have been the defect. The reviewer
+      grepped independently for a third comment stating the false rule and
+      found none: all 80 `CwdMatters` comment hits read, plus a repo-wide
+      sweep of Go, md, html and js for the rule's other phrasings. The six
+      selection commands' help already says the new truth.
+    - Gates after the change: `go build ./...` and `go vet ./...` clean,
+      `make lint` "0 issues." with the local `master` ref confirmed present
+      first, so it was a real incremental run and not a fail-open.
+    - Left alone deliberately, worth a future item: `GetByEssence` documents
+      the Cwd ambiguity, but the other `jesToKeys` users say nothing about it.
+      The field comment covers them by mechanism, and widening the change
+      would have broken the minimality this item is bounded by.

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -61,11 +61,11 @@ Alternatively -y lets you specify -i as the internal job id reported during
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-options that was used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.`,
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".`,
 	Run: func(_ *cobra.Command, _ []string) {
 		set := countGetJobArgs()
 		if set > 1 {
@@ -74,6 +74,10 @@ same file you gave to "wr add" in -f mode.`,
 
 		if set == 0 {
 			die("1 of -f, -i, -l or -a is required")
+		}
+
+		if err := validateSelectionContainerFlags(); err != nil {
+			die("%s", err)
 		}
 
 		timeout := time.Duration(timeoutint) * time.Second
@@ -153,11 +157,13 @@ func init() {
 	killCmd.Flags().BoolVarP(&cmdIDIsInternal, "internal", "y", false, "treat -i as an internal job id")
 	killCmd.Flags().StringVarP(&cmdLine, "cmdline", "l", "", "a command line you want to kill")
 	killCmd.Flags().StringVarP(&cmdCwd, "cwd", "c", "",
-		"working dir that the command(s) specified by -l or -f were set to run in")
+		"working dir that the command(s) specified by -l or -f were added with, "+
+			"whether or not --cwd_matters was used")
 	killCmd.Flags().StringVarP(&mountJSON, "mount_json", "j", "",
 		"mounts that the command(s) specified by -l or -f were set to use (JSON format)")
 	killCmd.Flags().StringVar(&mountSimple, "mounts", "",
 		"mounts that the command(s) specified by -l or -f were set to use (simple format)")
+	addSelectionContainerFlags(killCmd)
 	killCmd.Flags().BoolVar(&confirmDead, "confirmdead", false, "only confirm that lost contact jobs are dead")
 	killCmd.Flags().StringVar(&cmdAge, "age", "",
 		"only kill jobs that have been running longer than this (or in --confirmdead mode, that have been "+

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -57,11 +57,11 @@ during "wr status".
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-options that was used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".
 
 Note that you can't remove a job that has other jobs depending upon it, unless
 you also remove those jobs at the same time. If there is a mistake in the
@@ -80,6 +80,10 @@ command line of a job with dependants, you can either:
 
 		if set == 0 {
 			die("1 of -f, -i, -l or -a is required")
+		}
+
+		if err := validateSelectionContainerFlags(); err != nil {
+			die("%s", err)
 		}
 
 		timeout := time.Duration(timeoutint) * time.Second
@@ -131,11 +135,13 @@ func init() {
 	removeCmd.Flags().BoolVarP(&cmdIDIsInternal, "internal", "y", false, "treat -i as an internal job id")
 	removeCmd.Flags().StringVarP(&cmdLine, "cmdline", "l", "", "a command line you want to remove")
 	removeCmd.Flags().StringVarP(&cmdCwd, "cwd", "c", "",
-		"working dir that the command(s) specified by -l or -f were set to run in")
+		"working dir that the command(s) specified by -l or -f were added with, "+
+			"whether or not --cwd_matters was used")
 	removeCmd.Flags().StringVarP(&mountJSON, "mount_json", "j", "",
 		"mounts that the command(s) specified by -l or -f were set to use (JSON format)")
 	removeCmd.Flags().StringVar(&mountSimple, "mounts", "",
 		"mounts that the command(s) specified by -l or -f were set to use (simple format)")
+	addSelectionContainerFlags(removeCmd)
 	removeCmd.Flags().BoolVarP(&onlyBuried, "buried", "b", false, "only delete jobs that are currently buried")
 
 	removeCmd.Flags().IntVar(&timeoutint, "timeout", defaultManagerConnectTimeout,

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -49,11 +49,11 @@ during "wr status".
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-options that were used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.`,
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".`,
 	Run: func(_ *cobra.Command, _ []string) {
 		if err := runResumeCommand(); err != nil {
 			die("%s", err)

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -53,11 +53,11 @@ Alternatively -y lets you specify -i as the internal job id reported during
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-options that was used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.`,
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".`,
 	Run: func(_ *cobra.Command, _ []string) {
 		set := countGetJobArgs()
 		if set > 1 {
@@ -66,6 +66,10 @@ same file you gave to "wr add" in -f mode.`,
 
 		if set == 0 {
 			die("1 of -f, -i, -l or -a is required")
+		}
+
+		if err := validateSelectionContainerFlags(); err != nil {
+			die("%s", err)
 		}
 
 		timeout := time.Duration(timeoutint) * time.Second
@@ -109,11 +113,13 @@ func init() {
 	retryCmd.Flags().BoolVarP(&cmdIDIsInternal, "internal", "y", false, "treat -i as an internal job id")
 	retryCmd.Flags().StringVarP(&cmdLine, "cmdline", "l", "", "a command line you want to retry")
 	retryCmd.Flags().StringVarP(&cmdCwd, "cwd", "c", "",
-		"working dir that the command(s) specified by -l or -f were set to run in")
+		"working dir that the command(s) specified by -l or -f were added with, "+
+			"whether or not --cwd_matters was used")
 	retryCmd.Flags().StringVarP(&mountJSON, "mount_json", "j", "",
 		"mounts that the command(s) specified by -l or -f were set to use (JSON format)")
 	retryCmd.Flags().StringVar(&mountSimple, "mounts", "",
 		"mounts that the command(s) specified by -l or -f were set to use (simple format)")
+	addSelectionContainerFlags(retryCmd)
 
 	retryCmd.Flags().IntVar(&timeoutint, "timeout", defaultManagerConnectTimeout,
 		"how long (seconds) to wait to get a reply from 'wr manager'")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,12 @@ progress with:
 $ wr status`,
 }
 
+// cmdExit lets tests drive a command's Run past the point where die() would
+// otherwise terminate the test process (mirroring statusExit in status.go). In
+// production it is os.Exit, so die() ends the process non-zero exactly as
+// before.
+var cmdExit = os.Exit
+
 // Execute adds all child commands to the root command and sets flags
 // appropriately. This is called by main.main(). It only needs to happen once to
 // the rootCmd.
@@ -222,7 +228,7 @@ func warn(msg string, a ...any) {
 // die is a convenience to log a message at the Error level and exit non zero.
 func die(msg string, a ...any) {
 	clog.Error(context.Background(), fmt.Sprintf(msg, a...))
-	os.Exit(1)
+	cmdExit(1)
 }
 
 // createWorkingDir ensures the main working directory is available.

--- a/cmd/selection_essence_test.go
+++ b/cmd/selection_essence_test.go
@@ -27,16 +27,28 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/VertebrateResequencing/wr/jobqueue"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/cobra"
 )
 
 // selectionEssenceImage is the container image the containerised jobs below are
 // added with. Nothing runs them, so no container runtime is involved.
 const selectionEssenceImage = "ubuntu:latest"
+
+// selectionEssenceLoneMounts is a container mounts value used only where no
+// image accompanies it, describing a job that cannot exist.
+const selectionEssenceLoneMounts = "/lone:/mounts"
+
+// selectionEssenceDyingCmd is the command line of the plain non-container job
+// that the commands which die() rather than return an error would reach if they
+// let --container_mounts through without an image.
+const selectionEssenceDyingCmd = "echo reachable only by a plain key"
 
 // TestSelectionByCmdLine drives the real -l selection path of a queue command
 // for the kinds of job whose key -l has to reproduce: one added with a cwd but
@@ -160,6 +172,19 @@ func TestSelectionByCmdLine(t *testing.T) {
 		})
 	})
 
+	Convey("-l with --container_mounts and no image cannot reach the plain job of that Cmd", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob("echo no container at all", "rg-select-mounts-only", reqs)
+			addQueueCommandJobs(jq, job)
+
+			output, err := runSuspendForTest(t, "-l", "echo no container at all",
+				"--container_mounts", selectionEssenceLoneMounts)
+			So(err, ShouldEqual, errSelectionContainerMountsNeedImage)
+			So(output, ShouldBeEmpty)
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateReady)
+		})
+	})
+
 	Convey("selection commands reject both container images at once", t, func() {
 		output, err := runSuspendForTest(t, "-l", "echo both images",
 			"--with_docker", selectionEssenceImage, "--with_singularity", "image.sif")
@@ -170,5 +195,35 @@ func TestSelectionByCmdLine(t *testing.T) {
 			"--with_docker", selectionEssenceImage, "--with_singularity", "image.sif")
 		So(err, ShouldEqual, errSelectionContainerExclusive)
 		So(output, ShouldBeEmpty)
+	})
+
+	Convey("the resume command also rejects container mounts without an image", t, func() {
+		withQueueCommandTestServer(t, func(_ *jobqueue.Client, _ *jqs.Requirements, _ jobqueue.ServerConfig) {
+			output, err := runResumeForTest(t, "-l", "echo mounts only",
+				"--container_mounts", selectionEssenceLoneMounts)
+			So(err, ShouldEqual, errSelectionContainerMountsNeedImage)
+			So(output, ShouldBeEmpty)
+		})
+	})
+
+	Convey("the commands that die rather than return also reject mounts without an image", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob(selectionEssenceDyingCmd, "rg-select-dying", reqs)
+			addQueueCommandJobs(jq, job)
+
+			var accepted []string
+
+			for _, command := range []*cobra.Command{statusCmd, killCmd, removeCmd, retryCmd} {
+				exitCode, logged := runSelectionCommandRunForTest(t, command,
+					"-l", selectionEssenceDyingCmd, "--container_mounts", selectionEssenceLoneMounts)
+				if exitCode != 1 || !strings.Contains(logged, errSelectionContainerMountsNeedImage.Error()) {
+					accepted = append(accepted, fmt.Sprintf("%s (exit %d, logged %q)",
+						command.Name(), exitCode, logged))
+				}
+			}
+
+			So(accepted, ShouldBeEmpty)
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateReady)
+		})
 	})
 }

--- a/cmd/selection_essence_test.go
+++ b/cmd/selection_essence_test.go
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/jobqueue"
+	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// selectionEssenceImage is the container image the containerised jobs below are
+// added with. Nothing runs them, so no container runtime is involved.
+const selectionEssenceImage = "ubuntu:latest"
+
+// TestSelectionByCmdLine drives the real -l selection path of a queue command
+// for the kinds of job whose key -l has to reproduce: one added with a cwd but
+// without CwdMatters, and one added with a container image. It also proves that
+// the cwd fallback cannot reach a job the user did not name.
+func TestSelectionByCmdLine(t *testing.T) {
+	Convey("-l with -c finds a job that was added with a cwd but not cwd_matters", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			cwd := t.TempDir()
+			job := newQueueCommandJob("echo cwd does not matter", "rg-select-cwd", reqs)
+			job.Cwd = cwd
+			So(job.CwdMatters, ShouldBeFalse)
+			addQueueCommandJobs(jq, job)
+
+			output, err := runSuspendForTest(t, "-l", "echo cwd does not matter", "-c", cwd)
+			So(err, ShouldBeNil)
+			So(output, ShouldEqual, "Suspended 1 queued commands (out of 1 matching)\n")
+			assertStatusPlainStateCount(t, jobqueue.JobStateSuspended, 1,
+				"-l", "echo cwd does not matter", "-c", cwd, "-o", "plain")
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateSuspended)
+		})
+	})
+
+	Convey("-l with a different -c matches no non-cwd_matters job", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob("echo wrong cwd", "rg-select-wrong-cwd", reqs)
+			job.Cwd = t.TempDir()
+			addQueueCommandJobs(jq, job)
+
+			output, err := runSuspendForTest(t, "-l", "echo wrong cwd", "-c", t.TempDir())
+			So(err, ShouldEqual, errSelectedJobsNoMatch)
+			So(output, ShouldBeEmpty)
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateReady)
+		})
+	})
+
+	Convey("-l with -c prefers the cwd_matters job with that cwd", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			const cmdLine = "echo shared by both"
+
+			matters := newQueueCommandJob(cmdLine, "rg-select-both", reqs)
+			matters.Cwd = t.TempDir()
+			matters.CwdMatters = true
+			doesNot := newQueueCommandJob(cmdLine, "rg-select-both", reqs)
+			doesNot.Cwd = t.TempDir()
+			addQueueCommandJobs(jq, matters, doesNot)
+
+			output, err := runSuspendForTest(t, "-l", cmdLine, "-c", matters.Cwd)
+			So(err, ShouldBeNil)
+			So(output, ShouldEqual, "Suspended 1 queued commands (out of 1 matching)\n")
+			So(jobStateByEssence(jq, matters), ShouldEqual, jobqueue.JobStateSuspended)
+			So(jobStateByEssence(jq, doesNot), ShouldEqual, jobqueue.JobStateReady)
+		})
+	})
+
+	Convey("-l with --with_docker finds a containerised job", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob("echo containerised", "rg-select-docker", reqs)
+			job.WithDocker = selectionEssenceImage
+			addQueueCommandJobs(jq, job)
+
+			output, err := runSuspendForTest(t, "-l", "echo containerised",
+				"--with_docker", selectionEssenceImage)
+			So(err, ShouldBeNil)
+			So(output, ShouldEqual, "Suspended 1 queued commands (out of 1 matching)\n")
+			assertStatusPlainStateCount(t, jobqueue.JobStateSuspended, 1, "-l", "echo containerised",
+				"--with_docker", selectionEssenceImage, "-o", "plain")
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateSuspended)
+		})
+	})
+
+	Convey("-l with --with_docker and -c finds a containerised non-cwd_matters job", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob("echo containerised in cwd", "rg-select-docker-cwd", reqs)
+			job.WithDocker = selectionEssenceImage
+			job.ContainerMounts = "/mnt"
+			addQueueCommandJobs(jq, job)
+
+			output, err := runSuspendForTest(t, "-l", "echo containerised in cwd",
+				"--with_docker", selectionEssenceImage, "--container_mounts", "/mnt", "-c", job.Cwd)
+			So(err, ShouldBeNil)
+			So(output, ShouldEqual, "Suspended 1 queued commands (out of 1 matching)\n")
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateSuspended)
+		})
+	})
+
+	Convey("-l with the wrong container options matches no containerised job", t, func() {
+		withQueueCommandTestServer(t, func(jq *jobqueue.Client, reqs *jqs.Requirements, _ jobqueue.ServerConfig) {
+			job := newQueueCommandJob("echo container mismatch", "rg-select-mismatch", reqs)
+			job.WithDocker = selectionEssenceImage
+			addQueueCommandJobs(jq, job)
+
+			var wronglyMatched []string
+
+			for _, tc := range []struct {
+				name string
+				args []string
+			}{
+				{
+					name: "wrong container_mounts",
+					args: []string{"--with_docker", selectionEssenceImage, "--container_mounts", "/mnt"},
+				},
+				{
+					name: "wrong image",
+					args: []string{"--with_docker", "alpine:latest"},
+				},
+				{
+					name: "no image",
+					args: nil,
+				},
+			} {
+				output, err := runSuspendForTest(t,
+					append([]string{"-l", "echo container mismatch"}, tc.args...)...)
+				if !errors.Is(err, errSelectedJobsNoMatch) || output != "" {
+					wronglyMatched = append(wronglyMatched, tc.name)
+				}
+			}
+
+			So(wronglyMatched, ShouldBeEmpty)
+			So(jobStateByEssence(jq, job), ShouldEqual, jobqueue.JobStateReady)
+		})
+	})
+
+	Convey("selection commands reject both container images at once", t, func() {
+		output, err := runSuspendForTest(t, "-l", "echo both images",
+			"--with_docker", selectionEssenceImage, "--with_singularity", "image.sif")
+		So(err, ShouldEqual, errSelectionContainerExclusive)
+		So(output, ShouldBeEmpty)
+
+		output, err = runResumeForTest(t, "-l", "echo both images",
+			"--with_docker", selectionEssenceImage, "--with_singularity", "image.sif")
+		So(err, ShouldEqual, errSelectionContainerExclusive)
+		So(output, ShouldBeEmpty)
+	})
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -105,11 +105,11 @@ reported when using this command.
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-option that was used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".
 
 --recent <duration> returns jobs that finished (were archived) within the last
 duration across all report groups. It is mutually exclusive with -f, -l and -i.
@@ -163,6 +163,10 @@ with a normal shell redirect (eg. "mycmd > stdout.txt").
 		set := countGetJobArgs()
 		if set > 1 {
 			die(statusSelectorsMutuallyExclusive)
+		}
+
+		if err := validateSelectionContainerFlags(); err != nil {
+			die("%s", err)
 		}
 
 		cmdStates := statusStateFilters()
@@ -686,6 +690,20 @@ with a normal shell redirect (eg. "mycmd > stdout.txt").
 	},
 }
 
+// errSelectionContainerExclusive is the failure when both container image flags
+// are given to a command that selects jobs.
+var errSelectionContainerExclusive = errors.New("--with_docker and --with_singularity are mutually exclusive")
+
+// validateSelectionContainerFlags returns an error if the container image flags
+// addSelectionContainerFlags registers describe an impossible job.
+func validateSelectionContainerFlags() error {
+	if cmdWithDocker != "" && cmdWithSingularity != "" {
+		return errSelectionContainerExclusive
+	}
+
+	return nil
+}
+
 func init() {
 	RootCmd.AddCommand(statusCmd)
 
@@ -708,11 +726,13 @@ func registerStatusFlags() {
 		"show jobs that finished within the last <duration> across all report groups; "+
 			"accepts Go duration units plus d (days) and w (weeks), eg. 1d, 2w, 36h, 90m")
 	statusCmd.Flags().StringVarP(&cmdCwd, "cwd", "c", "",
-		"working dir that the command(s) specified by -l or -f were set to run in")
+		"working dir that the command(s) specified by -l or -f were added with, "+
+			"whether or not --cwd_matters was used")
 	statusCmd.Flags().StringVarP(&mountJSON, "mount_json", "j", "",
 		"mounts that the command(s) specified by -l or -f were set to use (JSON format)")
 	statusCmd.Flags().StringVar(&mountSimple, "mounts", "",
 		"mounts that the command(s) specified by -l or -f were set to use (simple format)")
+	addSelectionContainerFlags(statusCmd)
 	statusCmd.Flags().StringVar(&fromHost, "host", "",
 		"filter output to only show the status of commands that ran on the given host (ID, name or IP)")
 	statusCmd.Flags().StringVarP(&outputFormat, "output", "o", "details",
@@ -722,6 +742,21 @@ func registerStatusFlags() {
 			"the same properties to display per group; 0 displays all")
 
 	registerStatusStateFlags()
+}
+
+// addSelectionContainerFlags registers the container image flags on a command
+// that selects jobs with -l or -f, so that such a selection can reach a job that
+// was added with --with_docker or --with_singularity: the image is part of that
+// job's key, so naming its command line alone does not describe it.
+func addSelectionContainerFlags(command *cobra.Command) {
+	flags := command.Flags()
+
+	flags.StringVar(&cmdWithDocker, "with_docker", "",
+		"docker image that the command(s) specified by -l or -f were set to run inside")
+	flags.StringVar(&cmdWithSingularity, "with_singularity", "",
+		"singularity image that the command(s) specified by -l or -f were set to run inside")
+	flags.StringVar(&cmdContainerMounts, "container_mounts", "",
+		"container mounts that the command(s) specified by -l or -f were set to use")
 }
 
 // registerStatusStateFlags registers the status sub-command's state-filter
@@ -1153,8 +1188,14 @@ func getJobsByCmdLine(jq *jobqueue.Client, showStd, showEnv bool) ([]*jobqueue.J
 		defaultMounts = mountParse(mountJSON, mountSimple)
 	}
 
-	job, err := jq.GetByEssence(
-		&jobqueue.JobEssence{Cmd: cmdLine, Cwd: cmdCwd, MountConfigs: defaultMounts}, showStd, showEnv)
+	job, err := jq.GetByEssence(&jobqueue.JobEssence{
+		Cmd:             cmdLine,
+		Cwd:             cmdCwd,
+		MountConfigs:    defaultMounts,
+		WithDocker:      cmdWithDocker,
+		WithSingularity: cmdWithSingularity,
+		ContainerMounts: cmdContainerMounts,
+	}, showStd, showEnv)
 	if job == nil {
 		return nil, err
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -694,11 +694,23 @@ with a normal shell redirect (eg. "mycmd > stdout.txt").
 // are given to a command that selects jobs.
 var errSelectionContainerExclusive = errors.New("--with_docker and --with_singularity are mutually exclusive")
 
+// errSelectionContainerMountsNeedImage is the failure when container mounts are
+// given to a command that selects jobs, but neither container image flag is. A
+// job added without an image has no mounts in its key, so such a selection can
+// only ever reach a plain non-container job the user did not name.
+var errSelectionContainerMountsNeedImage = errors.New(
+	"--container_mounts only describes a job alongside --with_docker or --with_singularity; " +
+		"add the image the job was added with, or drop --container_mounts")
+
 // validateSelectionContainerFlags returns an error if the container image flags
 // addSelectionContainerFlags registers describe an impossible job.
 func validateSelectionContainerFlags() error {
 	if cmdWithDocker != "" && cmdWithSingularity != "" {
 		return errSelectionContainerExclusive
+	}
+
+	if cmdContainerMounts != "" && cmdWithDocker == "" && cmdWithSingularity == "" {
+		return errSelectionContainerMountsNeedImage
 	}
 
 	return nil

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1349,6 +1349,9 @@ func resetStatusForTest(t *testing.T) {
 	cmdAll = false
 	mountJSON = ""
 	mountSimple = ""
+	cmdWithDocker = ""
+	cmdWithSingularity = ""
+	cmdContainerMounts = ""
 	showBuried = false
 	showRunning = false
 	showPending = false
@@ -1376,6 +1379,9 @@ func resetStatusForTest(t *testing.T) {
 		{"limit", "1"},
 		{"timeout", "120"},
 		{"recent", ""},
+		{"with_docker", ""},
+		{"with_singularity", ""},
+		{"container_mounts", ""},
 	} {
 		So(statusCmd.Flags().Set(flag.name, flag.value), ShouldBeNil)
 	}

--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -62,11 +62,11 @@ during "wr status".
 
 The file to provide -f is in the format taken by "wr add".
 
-In -f and -l mode you must provide the cwd the commands were set to run in, if
-CwdMatters (and must NOT be provided otherwise). Likewise provide the mounts
-options that were used when the command was added, if any. You can do this by
-using the -c and --mounts/--mounts_json options in -l mode, or by providing the
-same file you gave to "wr add" in -f mode.`,
+In -f and -l mode you must describe the commands the way they were added. In -l
+mode that means the cwd they were added with (-c), whether or not --cwd_matters
+was used, plus any mounts options (--mounts/--mounts_json) and container image
+options (--with_docker/--with_singularity and --container_mounts) they were added
+with. In -f mode, provide the same file you gave to "wr add".`,
 	Run: func(_ *cobra.Command, _ []string) {
 		if err := runSuspendCommand(); err != nil {
 			die("%s", err)
@@ -132,7 +132,7 @@ func validateSelectedJobsCommand() error {
 		return errSelectedJobsNeedSelector
 	}
 
-	return nil
+	return validateSelectionContainerFlags()
 }
 
 func disconnectSelectedJobsClient(jq *jobqueue.Client) {
@@ -181,7 +181,8 @@ func addSelectedJobsFlags(command *cobra.Command, verb, allHelp string) {
 	flags.StringVarP(&cmdLine, "cmdline", "l", "", "a command line you want to "+verb)
 	flags.StringVarP(
 		&cmdCwd, "cwd", "c", "",
-		"working dir that the command(s) specified by -l or -f were set to run in",
+		"working dir that the command(s) specified by -l or -f were added with, "+
+			"whether or not --cwd_matters was used",
 	)
 	flags.StringVarP(
 		&mountJSON, "mount_json", "j", "",
@@ -191,6 +192,7 @@ func addSelectedJobsFlags(command *cobra.Command, verb, allHelp string) {
 		&mountSimple, "mounts", "",
 		"mounts that the command(s) specified by -l or -f were set to use (simple format)",
 	)
+	addSelectionContainerFlags(command)
 	flags.IntVar(
 		&timeoutint, "timeout", selectedJobsDefaultTimeout,
 		"how long (seconds) to wait to get a reply from 'wr manager'",

--- a/cmd/suspend_test.go
+++ b/cmd/suspend_test.go
@@ -34,6 +34,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/wr/clog"
 	"github.com/VertebrateResequencing/wr/internal"
 	"github.com/VertebrateResequencing/wr/jobqueue"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
@@ -46,6 +47,101 @@ const (
 	queueCommandCwd   = "/tmp"
 	queueCommandReq   = "queue-command"
 )
+
+// commandExitPanic is what a stubbed exit function panics with, so that the code
+// under test stops where os.Exit would have stopped it.
+type commandExitPanic struct {
+	code int
+}
+
+// runSelectionCommandRunForTest drives command's REAL Run with args, rather
+// than any part of it, so that a command which skips a check its siblings make
+// fails here instead of passing by construction. It returns the code the Run
+// asked to exit with (0 if it never did) and everything die() logged on the way.
+func runSelectionCommandRunForTest(t *testing.T, command *cobra.Command, args ...string) (int, string) {
+	t.Helper()
+
+	if command == statusCmd {
+		resetStatusForTest(t)
+	} else {
+		resetSelectionCommandForTest(t, command)
+	}
+
+	So(command.ParseFlags(args), ShouldBeNil)
+
+	logged := clog.ToBufferAtLevel("error")
+	originalCmdExit, originalStatusExit := cmdExit, statusExit
+	// statusExit is stubbed alongside cmdExit because a Run that gets past the
+	// check under test can reach it, and a real os.Exit there would end the test
+	// binary mid-suite instead of failing an assertion.
+	cmdExit = func(code int) {
+		panic(commandExitPanic{code: code})
+	}
+	statusExit = cmdExit
+
+	defer func() {
+		cmdExit, statusExit = originalCmdExit, originalStatusExit
+
+		clog.ToDefault()
+	}()
+
+	exitCode := 0
+
+	captureStdout(func() {
+		exitCode = recoverCommandExit(func() {
+			command.Run(command, nil)
+		})
+	})
+
+	return exitCode, logged.String()
+}
+
+// captureStdout runs run with os.Stdout redirected to a pipe, returning
+// everything it wrote there.
+func captureStdout(run func()) string {
+	reader, writer, err := os.Pipe()
+	So(err, ShouldBeNil)
+
+	defer reader.Close()
+
+	originalStdout := os.Stdout
+
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	run()
+
+	So(writer.Close(), ShouldBeNil)
+
+	output, err := io.ReadAll(reader)
+	So(err, ShouldBeNil)
+
+	return string(output)
+}
+
+// recoverCommandExit runs run and returns the code it asked a stubbed exit
+// function for, or 0 if it returned without asking to exit.
+func recoverCommandExit(run func()) (exitCode int) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+
+		exitPanic, ok := recovered.(commandExitPanic)
+		if !ok {
+			panic(recovered)
+		}
+
+		exitCode = exitPanic.code
+	}()
+
+	run()
+
+	return 0
+}
 
 func TestSuspendCommand(t *testing.T) {
 	Convey("wr suspend handles selected queued jobs", t, func() {
@@ -295,30 +391,13 @@ func runSelectionCommandForTest(
 	resetSelectionCommandForTest(t, command)
 	So(command.ParseFlags(args), ShouldBeNil)
 
-	reader, writer, err := os.Pipe()
-	So(err, ShouldBeNil)
+	var runErr error
 
-	defer reader.Close()
+	output := captureStdout(func() {
+		runErr = run()
+	})
 
-	originalStdout := os.Stdout
-
-	os.Stdout = writer
-	defer func() {
-		os.Stdout = originalStdout
-	}()
-
-	runErr := run()
-
-	So(writer.Close(), ShouldBeNil)
-
-	output, err := io.ReadAll(reader)
-	So(err, ShouldBeNil)
-
-	return string(output), runErr
-}
-
-type statusExitPanic struct {
-	code int
+	return output, runErr
 }
 
 func runStatusPlainForTest(t *testing.T, args ...string) (string, int) {
@@ -327,50 +406,25 @@ func runStatusPlainForTest(t *testing.T, args ...string) (string, int) {
 	resetStatusForTest(t)
 	So(statusCmd.ParseFlags(args), ShouldBeNil)
 
-	reader, writer, err := os.Pipe()
-	So(err, ShouldBeNil)
-
-	defer reader.Close()
-
-	originalStdout := os.Stdout
 	originalStatusExit := statusExit
 
-	os.Stdout = writer
 	statusExit = func(code int) {
-		panic(statusExitPanic{code: code})
+		panic(commandExitPanic{code: code})
 	}
 
 	defer func() {
-		os.Stdout = originalStdout
 		statusExit = originalStatusExit
 	}()
 
 	exitCode := 0
 
-	func() {
-		defer func() {
-			recovered := recover()
-			if recovered == nil {
-				return
-			}
+	output := captureStdout(func() {
+		exitCode = recoverCommandExit(func() {
+			statusCmd.Run(statusCmd, nil)
+		})
+	})
 
-			exitPanic, ok := recovered.(statusExitPanic)
-			if !ok {
-				panic(recovered)
-			}
-
-			exitCode = exitPanic.code
-		}()
-
-		statusCmd.Run(statusCmd, nil)
-	}()
-
-	So(writer.Close(), ShouldBeNil)
-
-	output, err := io.ReadAll(reader)
-	So(err, ShouldBeNil)
-
-	return string(output), exitCode
+	return output, exitCode
 }
 
 func assertStatusPlainStateCount(t *testing.T, state jobqueue.JobState, count int, args ...string) {

--- a/cmd/suspend_test.go
+++ b/cmd/suspend_test.go
@@ -409,6 +409,12 @@ func resetSelectionCommandForTest(t *testing.T, command *cobra.Command) {
 	cmdRecentPeriod = 0
 	mountJSON = ""
 	mountSimple = ""
+	// the container image selectors are package globals shared with `wr add`'s
+	// tests, so a leftover value would silently change the key every selection
+	// here looks up.
+	cmdWithDocker = ""
+	cmdWithSingularity = ""
+	cmdContainerMounts = ""
 	timeoutint = 120
 
 	for _, flag := range []struct {
@@ -424,6 +430,9 @@ func resetSelectionCommandForTest(t *testing.T, command *cobra.Command) {
 		{"all", statusTestFalse},
 		{"mount_json", ""},
 		{"mounts", ""},
+		{"with_docker", ""},
+		{"with_singularity", ""},
+		{"container_mounts", ""},
 		{"timeout", "120"},
 	} {
 		So(command.Flags().Set(flag.name, flag.value), ShouldBeNil)

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -3550,8 +3550,18 @@ func (c *Client) Kill(jes []*JobEssence) (int, error) {
 // args set to true, this is the only way to get a Job that StdOut() and
 // StdErr() will work on, and one of 2 ways that Env() will work (the other
 // being Reserve()).
+//
+// A JobEssence with a Cwd but no JobKey is ambiguous: the Job it describes might
+// have been created with CwdMatters true, in which case its Cwd is part of its
+// key, or false, in which case it is not, and a user naming the Cwd of the job
+// they want cannot be expected to know which. Both keys are therefore looked up.
+// At most one Job is returned: the CwdMatters one if it exists, and otherwise the
+// non-CwdMatters one only if its Cwd really is the requested Cwd, so that a
+// different Job that merely shares the Cmd is never returned.
 func (c *Client) GetByEssence(je *JobEssence, getstd bool, getenv bool) (*Job, error) {
-	resp, err := c.request(&clientRequest{Method: "getbc", Keys: []string{je.Key()}, GetStd: getstd, GetEnv: getenv})
+	keys := je.candidateKeys()
+
+	resp, err := c.request(&clientRequest{Method: "getbc", Keys: keys, GetStd: getstd, GetEnv: getenv})
 	if err != nil {
 		return nil, err
 	}
@@ -3561,7 +3571,11 @@ func (c *Client) GetByEssence(je *JobEssence, getstd bool, getenv bool) (*Job, e
 		return nil, err
 	}
 
-	return jobs[0], err
+	if len(keys) == 1 {
+		return jobs[0], err
+	}
+
+	return je.pickCandidateJob(jobs), err
 }
 
 // GetByEssences gets multiple Jobs at once given JobEssences that describe

--- a/jobqueue/db_test.go
+++ b/jobqueue/db_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/VertebrateResequencing/wr/internal"
 	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ugorji/go/codec"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -117,6 +118,90 @@ func TestBackupCopyWriterChunking(t *testing.T) {
 			So(got, ShouldResemble, p)
 		})
 	})
+}
+
+// preContainerJobEssence mirrors the shape JobEssence had before it gained its
+// WithDocker, WithSingularity and ContainerMounts fields. The db's codec handle
+// encodes a struct as a map of all its exported field names, so encoding this
+// gives exactly the bytes an older wr wrote for a container-free essence, and
+// exactly the shape it can still read back.
+type preContainerJobEssence struct {
+	JobKey       string
+	Cmd          string
+	Cwd          string
+	MountConfigs MountConfigs
+}
+
+func TestDBJobEssenceEncoding(t *testing.T) {
+	Convey("Given a database and its codec handle", t, func() {
+		ctx := context.Background()
+		tmpdir := t.TempDir()
+
+		testDB, _, err := initDB(ctx, filepath.Join(tmpdir, "queue.db"),
+			filepath.Join(tmpdir, "queue.db.bak"), internal.Development, false, false)
+		So(err, ShouldBeNil)
+
+		defer func() { So(testDB.close(ctx), ShouldBeNil) }()
+
+		mcs := MountConfigs{{Targets: []MountTarget{{Path: testMountPath}}}}
+
+		Convey("An essence with no container fields stores as the pre-container shape", func() {
+			essence := &JobEssence{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs}
+			pre := &preContainerJobEssence{Cmd: essence.Cmd, Cwd: essence.Cwd, MountConfigs: essence.MountConfigs}
+
+			So(encodeWithDBHandle(testDB, essence), ShouldResemble, encodeWithDBHandle(testDB, pre))
+		})
+
+		Convey("A record written by the pre-container code decodes into a JobEssence", func() {
+			pre := &preContainerJobEssence{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs}
+
+			decoded := &JobEssence{}
+			So(codec.NewDecoderBytes(encodeWithDBHandle(testDB, pre), testDB.ch).Decode(decoded), ShouldBeNil)
+
+			So(decoded.Cmd, ShouldEqual, testTrueCmd)
+			So(decoded.Cwd, ShouldEqual, testCwdPath)
+			So(decoded.MountConfigs.Key(), ShouldEqual, mcs.Key())
+			So(decoded.WithDocker, ShouldBeBlank)
+			So(decoded.WithSingularity, ShouldBeBlank)
+			So(decoded.ContainerMounts, ShouldBeBlank)
+			So(decoded.Key(), ShouldEqual, (&JobEssence{Cmd: testTrueCmd, Cwd: testCwdPath,
+				MountConfigs: mcs}).Key())
+		})
+
+		Convey("Essences round-trip with every field and their key intact", func() {
+			dockerImage := "essence:latest"
+			sifImage := "essence.sif"
+			containerMounts := "/essence-out:/essence-in"
+
+			for _, essence := range []*JobEssence{
+				{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs},
+				{Cmd: testTrueCmd, Cwd: testCwdPath, WithDocker: dockerImage, ContainerMounts: containerMounts},
+				{Cmd: testTrueCmd, MountConfigs: mcs, WithSingularity: sifImage, ContainerMounts: containerMounts},
+			} {
+				decoded := &JobEssence{}
+				So(codec.NewDecoderBytes(encodeWithDBHandle(testDB, essence), testDB.ch).Decode(decoded),
+					ShouldBeNil)
+
+				So(decoded.Cmd, ShouldEqual, essence.Cmd)
+				So(decoded.Cwd, ShouldEqual, essence.Cwd)
+				So(decoded.MountConfigs.Key(), ShouldEqual, essence.MountConfigs.Key())
+				So(decoded.WithDocker, ShouldEqual, essence.WithDocker)
+				So(decoded.WithSingularity, ShouldEqual, essence.WithSingularity)
+				So(decoded.ContainerMounts, ShouldEqual, essence.ContainerMounts)
+				So(decoded.Key(), ShouldEqual, essence.Key())
+			}
+		})
+	})
+}
+
+// encodeWithDBHandle encodes v through the db's own codec handle, the way every
+// Job (and so every Dependency's Essence) is encoded before being stored.
+func encodeWithDBHandle(testDB *db, v any) []byte {
+	var encoded []byte
+
+	So(codec.NewEncoderBytes(&encoded, testDB.ch).Encode(v), ShouldBeNil)
+
+	return encoded
 }
 
 func TestDBHighPeakMemoryRecommendation(t *testing.T) {

--- a/jobqueue/essence_candidate_test.go
+++ b/jobqueue/essence_candidate_test.go
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// testOtherCwdPath is a second fake absolute Cwd, for a Job that is not the one
+// a JobEssence naming testCwdPath is describing.
+const testOtherCwdPath = "/other"
+
+func TestCandidateJobSelection(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// A JobEssence with a Cwd describes 2 possible Jobs (see candidateKeys()),
+	// so the server can return 2 Jobs in either order, and picking the wrong one
+	// would kill, remove or retry a Job the user did not name.
+	Convey("Given a JobEssence with a Cwd, and the 2 Jobs it could describe", t, func() {
+		je := &JobEssence{Cmd: testTrueCmd, Cwd: testCwdPath}
+		cwdMatters := &Job{Cmd: testTrueCmd, Cwd: testCwdPath, CwdMatters: true}
+		cwdDoesNot := &Job{Cmd: testTrueCmd, Cwd: testCwdPath}
+
+		Convey("the CwdMatters Job is picked whichever order the server lists them in", func() {
+			So(je.pickCandidateJob([]*Job{cwdMatters, cwdDoesNot}), ShouldEqual, cwdMatters)
+			So(je.pickCandidateJob([]*Job{cwdDoesNot, cwdMatters}), ShouldEqual, cwdMatters)
+		})
+
+		Convey("the other Job is picked when it is the only one, since its Cwd is the requested one", func() {
+			So(je.pickCandidateJob([]*Job{cwdDoesNot}), ShouldEqual, cwdDoesNot)
+		})
+
+		Convey("but a Job with the same key and a different Cwd is not picked", func() {
+			So(je.pickCandidateJob([]*Job{{Cmd: testTrueCmd, Cwd: testOtherCwdPath}}), ShouldBeNil)
+		})
+
+		Convey("and no Job is picked out of no Jobs", func() {
+			So(je.pickCandidateJob(nil), ShouldBeNil)
+		})
+	})
+}

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -2030,17 +2030,17 @@ type JobEssence struct {
 	MountConfigs MountConfigs
 
 	// WithDocker must be set to the WithDocker the Job was created with, if any.
-	WithDocker string
+	WithDocker string `codec:",omitempty"`
 
 	// WithSingularity must be set to the WithSingularity the Job was created
 	// with, if any. It is ignored when WithDocker is also set, just as it is on
 	// a Job that was created with both.
-	WithSingularity string
+	WithSingularity string `codec:",omitempty"`
 
 	// ContainerMounts must be set to the ContainerMounts the Job was created
 	// with, if it was created with a WithDocker or WithSingularity image. Like
 	// the Job's own, it is ignored when neither image is set.
-	ContainerMounts string
+	ContainerMounts string `codec:",omitempty"`
 }
 
 // Key returns the same value that Key() on the matching Job would give you.

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -70,6 +70,13 @@ const defaultMountRetries = 10
 // errNoTargets is returned by Mount when a MountConfig has no usable Targets.
 var errNoTargets = errors.New("no Targets specified")
 
+// envDecodeHook, when set, is called every time a Job's stored environment is
+// decoded, so that a test can count the decodes a code path makes. Decoding is a
+// decompress plus a decode of every variable the Job was added with, on the path
+// of every Job that exits, and a path that does none of it cannot show that in
+// its result, only in the work it did. It is nil in production.
+var envDecodeHook func() //nolint:gochecknoglobals // the only seam onto work that has no result
+
 // JobState is how we describe the possible job states.
 type JobState string
 
@@ -174,6 +181,131 @@ type jobDerived struct {
 	key          string
 	requirements *scheduler.Requirements
 	group        string
+}
+
+// candidateKeys returns every Job key this JobEssence could be describing, most
+// specific first, so that a caller can prefer an earlier one over a later one.
+//
+// A set Cwd is ambiguous, since the user of a Job's Cwd usually cannot know
+// whether that Job was created with CwdMatters (see Key()), so it gives 2 keys:
+// the CwdMatters one Key() returns, then the non-CwdMatters one. Everything else
+// gives just Key().
+func (j *JobEssence) candidateKeys() []string {
+	primary := j.Key()
+
+	if j.JobKey != "" || j.Cwd == "" {
+		return []string{primary}
+	}
+
+	const withoutCwd = ""
+
+	return []string{primary, j.keyForCwd(withoutCwd)}
+}
+
+// pickCandidateJob returns the single Job amongst jobs that this JobEssence
+// describes: the one with its primary candidate key if jobs holds that Job, and
+// otherwise one with a less specific candidate key, but only if its Cwd is the
+// Cwd this JobEssence asked for. Returns nil if jobs holds no such Job.
+//
+// The Cwd check is what makes looking a less specific key up safe, since these
+// keys go on to drive kill/remove/retry/suspend/resume. Cwd is compared exactly,
+// as Job.Key() treats it.
+//
+// The candidate keys are derived here rather than taken from the caller, so that
+// they can never be a different set from the ones candidateKeys() gave, and so
+// that there is always a primary key to compare against.
+func (j *JobEssence) pickCandidateJob(jobs []*Job) *Job {
+	keys := j.candidateKeys()
+	primary, lessSpecific := keys[0], keys[1:]
+
+	var fallback *Job
+
+	for _, job := range jobs {
+		key := job.Key()
+
+		if key == primary {
+			return job
+		}
+
+		if fallback == nil && job.Cwd == j.Cwd && slices.Contains(lessSpecific, key) {
+			fallback = job
+		}
+	}
+
+	return fallback
+}
+
+// keyForCwd builds the key of a Job that has this JobEssence's properties and
+// the given Cwd, which is part of the key only when it is not "" (a JobEssence
+// sets a Cwd only for a Job whose CwdMatters is true; see Key()).
+func (j *JobEssence) keyForCwd(cwd string) string {
+	return byteKey(jobKeyConcat(cwd != "", cwd, j.Cmd, j.MountConfigs.Key(),
+		containerImageKey(j.WithDocker, j.WithSingularity), j.ContainerMounts))
+}
+
+// jobKeyConcat builds the bytes that byteKey turns into a job key, for a job
+// with the given Cmd, MountConfigs key, container image (omitted entirely, along
+// with containerMounts, if image is "") and ContainerMounts, prefixed with the
+// given cwd if cwdMatters. The layout is, in order:
+//
+//	[cwd "."]  cmd "." mountKey  ["." image "." containerMounts]
+//
+// Whether the cwd is written is asked for explicitly rather than inferred from
+// cwd being set, because a Job with CwdMatters true and an empty Cwd is keyed
+// with the bare "." prefix, and its key must not change.
+//
+// Job.Key() and JobEssence.Key() must produce byte-identical keys for the same
+// job, or a job cannot be looked up by the essence describing it, so this is the
+// one place the layout is written down. It fills a single preallocated buffer
+// rather than formatting each component, because Job.Key() is a hot path.
+func jobKeyConcat(cwdMatters bool, cwd, cmd, mountKey, image, containerMounts string) []byte {
+	size := len(cmd) + 1 + len(mountKey)
+	if cwdMatters {
+		size += len(cwd) + 1
+	}
+
+	if image != "" {
+		size += 1 + len(image) + 1 + len(containerMounts)
+	}
+
+	concat := make([]byte, 0, size)
+
+	if cwdMatters {
+		concat = append(concat, cwd...)
+		concat = append(concat, '.')
+	}
+
+	concat = append(concat, cmd...)
+	concat = append(concat, '.')
+	concat = append(concat, mountKey...)
+
+	if image != "" {
+		concat = append(concat, '.')
+		concat = append(concat, image...)
+		concat = append(concat, '.')
+		concat = append(concat, containerMounts...)
+	}
+
+	return concat
+}
+
+// containerImageKey returns the container image part of a job key, for a job
+// created with the given WithDocker and WithSingularity values, or "" if the job
+// uses no container image. WithDocker wins when both are set, matching the rest
+// of wr's behaviour for such a job.
+//
+// Job.Key() and JobEssence.Key() must produce byte-identical keys for the same
+// job, so they share this instead of each spelling the form out.
+func containerImageKey(withDocker, withSingularity string) string {
+	if withDocker != "" {
+		return "docker:" + withDocker
+	}
+
+	if withSingularity != "" {
+		return "singularity:" + withSingularity
+	}
+
+	return ""
 }
 
 func (j *Job) decrementLimitGroupsLocked(lim *limiter.Limiter) {
@@ -837,13 +969,6 @@ func (j *Job) Env() ([]string, error) {
 
 	return stored.decode()
 }
-
-// envDecodeHook, when set, is called every time a Job's stored environment is
-// decoded, so that a test can count the decodes a code path makes. Decoding is a
-// decompress plus a decode of every variable the Job was added with, on the path
-// of every Job that exits, and a path that does none of it cannot show that in
-// its result, only in the work it did. It is nil in production.
-var envDecodeHook func() //nolint:gochecknoglobals // the only seam onto work that has no result
 
 // jobEnv is a Job's environment in the compressed form the Job keeps it in:
 // EnvC, EnvOverride, and whether EnvC was asked for (see Env for what each case
@@ -1575,54 +1700,12 @@ func (j *Job) decrementLimitGroups(lim *limiter.Limiter) {
 }
 
 // Key calculates a unique key to describe the job.
+//
+// The Cwd is part of the key only when CwdMatters, since otherwise the Cmd does
+// not run in Cwd itself but in a unique directory wr creates below it.
 func (j *Job) Key() string {
-	mountKey := j.MountConfigs.Key()
-
-	var image string
-
-	if j.WithDocker != "" {
-		image = "docker:" + j.WithDocker
-	} else if j.WithSingularity != "" {
-		image = "singularity:" + j.WithSingularity
-	}
-
-	// Build the same concatenation that the previous fmt.Sprintf calls
-	// produced, byte-for-byte, but with a single preallocated buffer to avoid
-	// the per-component reflection-based formatting and intermediate strings on
-	// this hot path. The layout is, in order:
-	//   [Cwd "."]  Cmd "." mountKey  ["." image "." ContainerMounts]
-	// where the Cwd prefix is only present when CwdMatters and the image suffix
-	// only when a container image is in use.
-	size := len(j.Cmd) + 1 + len(mountKey)
-	if j.CwdMatters {
-		size += len(j.Cwd) + 1
-	}
-
-	if image != "" {
-		size += 1 + len(image) + 1 + len(j.ContainerMounts)
-	}
-
-	var concat strings.Builder
-
-	concat.Grow(size)
-
-	if j.CwdMatters {
-		concat.WriteString(j.Cwd)
-		concat.WriteByte('.')
-	}
-
-	concat.WriteString(j.Cmd)
-	concat.WriteByte('.')
-	concat.WriteString(mountKey)
-
-	if image != "" {
-		concat.WriteByte('.')
-		concat.WriteString(image)
-		concat.WriteByte('.')
-		concat.WriteString(j.ContainerMounts)
-	}
-
-	return byteKey([]byte(concat.String()))
+	return byteKey(jobKeyConcat(j.CwdMatters, j.Cwd, j.Cmd, j.MountConfigs.Key(),
+		containerImageKey(j.WithDocker, j.WithSingularity), j.ContainerMounts))
 }
 
 // generateSchedulerGroup returns a stringified form of the given requirements,
@@ -1934,42 +2017,41 @@ type JobEssence struct {
 	// Cmd always forms an essential part of a Job.
 	Cmd string
 
-	// Cwd should only be set if the Job was created with CwdMatters = true.
+	// Cwd should only be set if the Job was created with CwdMatters = true. See
+	// Key() for what setting it does and does not describe.
 	Cwd string
 
 	// Mounts should only be set if the Job was created with Mounts
 	MountConfigs MountConfigs
+
+	// WithDocker must be set to the WithDocker the Job was created with, if any.
+	WithDocker string
+
+	// WithSingularity must be set to the WithSingularity the Job was created
+	// with, if any. It is ignored when WithDocker is also set, just as it is on
+	// a Job that was created with both.
+	WithSingularity string
+
+	// ContainerMounts must be set to the ContainerMounts the Job was created
+	// with, if it was created with a WithDocker or WithSingularity image. Like
+	// the Job's own, it is ignored when neither image is set.
+	ContainerMounts string
 }
 
-// Key returns the same value that key() on the matching Job would give you.
+// Key returns the same value that Key() on the matching Job would give you.
+//
+// A Cwd is part of the key only when it is set here, exactly as it is part of a
+// Job's key only when that Job has CwdMatters true. This therefore reproduces
+// the key of a matching Job with CwdMatters true when Cwd is set, and the key of
+// a matching Job with CwdMatters false when Cwd is empty. A caller describing a
+// Job whose CwdMatters it does not know should use Client.GetByEssence(), which
+// considers both interpretations of a set Cwd.
 func (j *JobEssence) Key() string {
 	if j.JobKey != "" {
 		return j.JobKey
 	}
 
-	mountKey := j.MountConfigs.Key()
-
-	// Build the same byte slice the previous fmt.Appendf calls produced,
-	// byte-for-byte, but via a single preallocated buffer rather than
-	// reflection-based formatting: "Cmd.mountKey", optionally prefixed with
-	// "Cwd." when a Cwd is set.
-	size := len(j.Cmd) + 1 + len(mountKey)
-	if j.Cwd != "" {
-		size += len(j.Cwd) + 1
-	}
-
-	concat := make([]byte, 0, size)
-
-	if j.Cwd != "" {
-		concat = append(concat, j.Cwd...)
-		concat = append(concat, '.')
-	}
-
-	concat = append(concat, j.Cmd...)
-	concat = append(concat, '.')
-	concat = append(concat, mountKey...)
-
-	return byteKey(concat)
+	return j.keyForCwd(j.Cwd)
 }
 
 // Stringify returns a nice printable form of a JobEssence.

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -236,8 +236,9 @@ func (j *JobEssence) pickCandidateJob(jobs []*Job) *Job {
 }
 
 // keyForCwd builds the key of a Job that has this JobEssence's properties and
-// the given Cwd, which is part of the key only when it is not "" (a JobEssence
-// sets a Cwd only for a Job whose CwdMatters is true; see Key()).
+// the given Cwd, which is part of the key only when it is not "": it therefore
+// gives the key of a Job with CwdMatters true when cwd is set, and the key of a
+// Job with CwdMatters false when cwd is "". See Key() and candidateKeys().
 func (j *JobEssence) keyForCwd(cwd string) string {
 	return byteKey(jobKeyConcat(cwd != "", cwd, j.Cmd, j.MountConfigs.Key(),
 		containerImageKey(j.WithDocker, j.WithSingularity), j.ContainerMounts))
@@ -2017,8 +2018,12 @@ type JobEssence struct {
 	// Cmd always forms an essential part of a Job.
 	Cmd string
 
-	// Cwd should only be set if the Job was created with CwdMatters = true. See
-	// Key() for what setting it does and does not describe.
+	// Cwd should only be set if the Job was created with CwdMatters = true,
+	// whenever the single key that Key() returns is used on its own, as a
+	// Dependency's Essence is. A caller that does not know the Job's CwdMatters
+	// may set Cwd anyway and look the Job up with Client.GetByEssence(), which
+	// considers both interpretations. See Key() for what setting it does and
+	// does not describe.
 	Cwd string
 
 	// Mounts should only be set if the Job was created with Mounts

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -413,6 +413,26 @@ func TestJobUnmount(t *testing.T) {
 	})
 }
 
+func TestKeyCwdDistinctness(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	// A Job's key is its identity: it is a BoltDB key, a lookup-index key and a
+	// Go map key, so 2 Jobs that wr must tell apart cannot share one.
+	Convey("A Job whose Cwd matters but is empty keys differently to Jobs whose Cwd does not matter", t, func() {
+		emptyCwdMatters := (&Job{Cmd: testTrueCmd, CwdMatters: true}).Key()
+
+		So(emptyCwdMatters, ShouldNotEqual, (&Job{Cmd: testTrueCmd}).Key())
+		So(emptyCwdMatters, ShouldNotEqual, (&Job{Cmd: testTrueCmd, Cwd: testCwdPath}).Key())
+
+		Convey("while a Cwd that does not matter is no part of the key, so those 2 share one", func() {
+			So((&Job{Cmd: testTrueCmd, Cwd: testCwdPath}).Key(),
+				ShouldEqual, (&Job{Cmd: testTrueCmd}).Key())
+		})
+	})
+}
+
 func TestJob(t *testing.T) {
 	if runnermode || servermode {
 		return
@@ -1036,6 +1056,8 @@ func TestKeyByteIdentity(t *testing.T) {
 
 		jobs := []*Job{
 			{Cmd: testTrueCmd},
+			// CwdMatters with an empty Cwd still keys with a bare "." prefix.
+			{Cmd: testTrueCmd, CwdMatters: true},
 			{Cmd: testTrueCmd, Cwd: testCwdPath},
 			{Cmd: testTrueCmd, Cwd: testCwdPath, CwdMatters: true},
 			{Cmd: testTrueCmd, MountConfigs: mcs},
@@ -1087,6 +1109,26 @@ func TestKeyByteIdentity(t *testing.T) {
 		// container-free job (the cross-type identity the lookups rely on).
 		So((&JobEssence{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs}).Key(),
 			ShouldEqual, (&Job{Cmd: testTrueCmd, Cwd: testCwdPath, CwdMatters: true, MountConfigs: mcs}).Key())
+
+		// It must also match for the 2 kinds of Job that a JobEssence built
+		// from a command line could not previously describe: one that runs in a
+		// container, and one whose CwdMatters is false (which is keyed with no
+		// Cwd at all, whatever Cwd it was given).
+		So((&JobEssence{Cmd: testTrueCmd, MountConfigs: mcs}).Key(),
+			ShouldEqual, (&Job{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs}).Key())
+		So((&JobEssence{Cmd: testTrueCmd, WithDocker: "alpine", ContainerMounts: "/out:/in"}).Key(),
+			ShouldEqual, (&Job{Cmd: testTrueCmd, Cwd: testCwdPath, WithDocker: "alpine",
+				ContainerMounts: "/out:/in"}).Key())
+		So((&JobEssence{Cmd: testTrueCmd, Cwd: testCwdPath, MountConfigs: mcs,
+			WithSingularity: "alpine.sif", ContainerMounts: "/out:/in"}).Key(),
+			ShouldEqual, (&Job{Cmd: testTrueCmd, Cwd: testCwdPath, CwdMatters: true, MountConfigs: mcs,
+				WithSingularity: "alpine.sif", ContainerMounts: "/out:/in"}).Key())
+
+		// With both images set, both types must pick docker.
+		So((&JobEssence{Cmd: testTrueCmd, WithDocker: "d", WithSingularity: "s"}).Key(),
+			ShouldEqual, (&Job{Cmd: testTrueCmd, WithDocker: "d", WithSingularity: "s"}).Key())
+		So((&JobEssence{Cmd: testTrueCmd, WithDocker: "d", WithSingularity: "s"}).Key(),
+			ShouldEqual, (&Job{Cmd: testTrueCmd, WithDocker: "d"}).Key())
 	})
 }
 


### PR DESCRIPTION
`JobEssence.Key()` is documented to "return the same value that key() on the
matching Job would give you", and did not. It differed from `Job.Key()` twice:
it prefixed `Cwd` whenever `Cwd` was set rather than only when the Job had
`CwdMatters`, and it never appended the container image and `ContainerMounts`
suffix.

Two user-visible consequences:

- `wr kill -l "cmd" -c /some/dir` found nothing for a job added as
  `wr add -c /some/dir` without `--cwd_matters`, which is the common case.
  `getJobsByCmdLine` builds the essence from `-l` plus `-c`, so the key carried
  a `Cwd` prefix the Job's key did not have. The CLI died with "No matching jobs
  found" and gave no hint why.
- `-l` selection could never match a containerised job. `JobEssence` had no
  field for the image, so a job added with `--with_docker` or
  `--with_singularity` was unreachable by `-l`, with or without `-c`.

## The fix

`Job.Key()` and `JobEssence.Key()` now share one layout builder,
`jobKeyConcat(cwdMatters, cwd, cmd, mountKey, image, containerMounts)`, plus
`containerImageKey()` for the `docker:`/`singularity:` form, so the two cannot
drift apart again. Whether to write the cwd prefix is passed in explicitly
rather than inferred from the cwd being set, because a Job with `CwdMatters`
true and an empty `Cwd` is keyed with a bare `"."` prefix and that key must not
change.

`JobEssence` gained `WithDocker`, `WithSingularity` and `ContainerMounts`. The
addition is additive: every existing caller leaves them empty and keys
identically.

The read path now tries both candidate keys and verifies the less specific one
against the Job it gets back. `GetByEssence` sends both candidates in the one
existing `getbc` request (`Keys` was already `[]string`, so there is no wire
change) and picks with `pickCandidateJob`. Adding a `CwdMatters bool` to
`JobEssence` was rejected instead: it cannot fix the reported symptom, and the
`{Cmd, Cwd}` meaning is publicly documented and persisted, so gating the Cwd
prefix on a new field would change the keys of already-stored dependency
essences.

This cannot select a job the user did not mean. `Client.GetByEssence` returns at
most one Job, and its behaviour is a strict superset of the old one: where the
primary key exists it returns exactly what the old single-key request returned,
and it returns a Job only where the old code returned nothing. The only new
failure mode is a miss, not a wrong hit.

`ToEssense()` is unchanged, so `cmd/lsf.go` and every `jobsToJobEssenses` caller
keep producing exact keys, and `Job.Key()`'s output is unchanged.

## CLI

New shared `addSelectionContainerFlags`/`validateSelectionContainerFlags` give
`kill`, `remove`, `retry`, `status`, `suspend` and `resume` the
`--with_docker`/`--with_singularity`/`--container_mounts` selectors, and
`getJobsByCmdLine` feeds them into the essence. Without them the containerised
half would be fixed only for Go API callers, since an image cannot be guessed
from a command line.

## Help text now says the opposite of before

The condition is gone, so the help states the new truth. The `-c` one-liner now
reads "working dir that the command(s) specified by -l or -f were added with,
whether or not --cwd_matters was used", at all 5 registration sites. The
long-help paragraph was rewritten in all 6 commands to drop "if CwdMatters (and
must NOT be provided otherwise)" and to name the container options alongside the
mounts options.

`cmd/add.go` and `cmd/mod.go` were checked and deliberately left alone: their
`-c` sets a job's working dir rather than selecting jobs.

## Tests

`cmd/selection_essence_test.go`'s `TestSelectionByCmdLine` is the red harness
folded in, driving real cobra flag parsing and the real
`runSuspendCommand`/`runResumeCommand` against a real manager. 7 cases, 313
assertions. No container runtime is involved, so nothing is skipped.

`jobqueue/essence_candidate_test.go`'s `TestCandidateJobSelection` pins the
order-independence of `pickCandidateJob`, which a real server cannot be made to
exercise.

`jobqueue/job_test.go` gained cross-type `JobEssence.Key()` == `Job.Key()`
assertions, the missing `{Cmd, CwdMatters: true}` oracle case, and
`TestKeyCwdDistinctness`. `TestKeyByteIdentity`'s existing oracles and cases are
untouched: every test file diff is insertions only.

Both halves were mutation-checked in isolation, each `go vet` clean before its
verdict counted, each reverted byte-exactly afterwards.

Full write-up in `.docs/bugfixes/260907-2.md`.
