### PR TITLE
Refuse to adopt an ambiguous docker container

### DIFF
--- a/.docs/bugfixes/260907-4.md
+++ b/.docs/bugfixes/260907-4.md
@@ -1,0 +1,235 @@
+# Bugfixes 2026-09-07
+
+fix-container-adoption
+
+- [x] With `MonitorDocker == "?"`, `findContainerID`
+  (`jobqueue/client.go:1589-1598`) adopts the FIRST container that has appeared
+  since `setupDockerMonitor` remembered the daemon's containers, with no test of
+  ownership. `GetNewContainers` diffs daemon-wide, so any container started by
+  anyone on that host during the job's run can be adopted - including one wr
+  itself started for a different job. The adopted id is then charged to the job
+  (`resolveContainerMem`) and SIGKILLed on every kill path (out of time, out of
+  memory, out of disk, signalled, killed by the manager) via `killCmd` ->
+  `dm.killContainer` (`jobqueue/client.go:1580-1585`). There is no ancestry to
+  test: a container's processes are children of the docker daemon, not of the
+  job's command.
+
+  The repo owner's decision is C + A: refuse to adopt when the choice is
+  ambiguous, and where wr starts the container itself set a label and match on
+  it, preferring a label match over the diff. Also decide and state what happens
+  when NO container appeared, and prove an empty/unset id can never kill
+  anything. Do not change what `--monitor_docker <name>` or
+  `--monitor_docker <id>` do, and do not change `Job.Key()`'s output.
+    - Red command (a throwaway harness in the `jobqueue` package, using the
+      `fakeInteractor` that `jobqueue/docker_monitor_test.go` already has, so
+      the ambiguity is deterministic and needs no docker; the implementor folds
+      it into that file's `TestDockerMonitorAdoption` and deletes the harness):
+
+      `CGO_ENABLED=1 go test -tags netgo --count 1 ./jobqueue -run TestRedContainerAdoption -v`
+
+    - Ran for real (no docker needed, nothing skipped). 3/3 runs red in 0.011s.
+      14 total assertions, 4 failures:
+
+      ```
+      Given a '?' monitor and 2 containers appearing during the job's run
+        Nothing is adopted, so no container is killed
+        Line 39: Expected [cotenants] to be empty (but it wasn't)!
+        And no other container's memory is charged to the job
+        Line 43: Expected: 100  Actual: 900
+
+      Given a '?' monitor and no container appearing during the job's run
+        And a kill request made anyway kills nothing
+        Line 64: Expected [] to be empty (but it wasn't)!
+
+      The docker run cmd line wr builds identifies the container as this job's
+        Line 70: Expected 'cat /path/to/cmds | docker run --rm --name thejobskey
+          -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage
+          /bin/sh' to contain substring '--label' (but it didn't)!
+      ```
+
+      Line 39 is the bug as reported: the co-tenant's container `cotenants` (the
+      first of the two to appear) is the one that gets killed, and line 43 shows
+      its 900 MB charged to the job as its peak RAM. Line 64 is the other half of
+      the papered-over ambiguity: with nothing adopted, `dm.containerID` is `""`
+      and `killContainer` still issues `ContainerKill(ctx, "")` to the daemon -
+      the fake recorded a kill of the empty id. `Execute`'s `killCmd` happens to
+      guard `dm.containerID != ""` today, so the empty id does not reach docker
+      by that route, but `killContainer` itself has no guard and one added call
+      site would restore the hazard.
+    - Fixed, in the two halves the owner asked for.
+
+      **A - label the containers wr starts itself.** The one place wr starts a
+      container is `container.DockerRunCmd` (`container/run.go`), reached from
+      `Job.containerRunCmd` (`jobqueue/job.go`) when `Job.WithDocker` is set;
+      its `name` argument is already `Job.Key()`, and that path also sets
+      `job.MonitorDocker = j.Key()`. It now also emits
+      `--label uk.ac.sanger.wr.job-key=<name>`, shell-quoted through
+      `shellquote.Join` like every other interpolated value in that function
+      (per `260907-1.md`). `container.JobKeyLabel` holds the key,
+      `container.Container` gained `Labels` and
+      `Label(key) (string, bool)` - value and set-ness are returned separately
+      so a container carrying no claim can be told from one another job's label
+      claims - and `container/docker`'s `Interactor.ContainerList` carries
+      `Summary.Labels` through. `setupDockerMonitor` passes `job.Key()` into
+      `newDockerMonitor`, and `findContainerID` calls
+      `adoptLabelledNewContainer` first, whatever `MonitorDocker` is: only wr
+      sets that label, so a new container carrying this job's key in it is
+      unambiguously this job's. `Job.Key()`'s output is unchanged, and so is
+      what `--monitor_docker <name>` and `--monitor_docker <id>` do.
+
+      **C - refuse to adopt when the choice is ambiguous.**
+      `adoptUnambiguousNewContainer` first rules out any new container labelled
+      for a *different* job: wr started it for another job, so it demonstrably
+      is not this one's. This is what makes half A load-bearing in the `"?"`
+      path, and it is exactly the "containers swapped between two of wr's own
+      jobs" case in the report. Of what remains it adopts a container only if
+      **exactly one** candidate is left; on two or more it adopts nothing, so a
+      wrong kill becomes no kill. The refusal is **latched** in
+      `dm.diffAmbiguous`: if a rival exits later and leaves one candidate, that
+      survivor is no more identifiable than it was, and adopting it would be a
+      coin flip on a SIGKILL. A later label match can still win, being the one
+      unambiguous answer.
+
+      **When none appeared:** nothing is adopted, `dm.containerID` stays empty,
+      nothing is charged, nothing is killed, and nothing is logged.
+      `adoptUnambiguousNewContainer` runs on every poll of a running job, and
+      "no container yet" is what a job that has not got as far as starting its
+      container looks like, so a log there would be per-poll noise on a normal
+      run rather than a signal.
+
+      **An empty id can no longer kill anything.** `killContainer` now returns
+      nil without calling docker when `dm.containerID == ""`. Verified by
+      enumerating every call site with
+      `grep -rn "KillContainer\|killContainer\|ContainerKill" --include=*.go .`:
+      the only production route to `Operator.KillContainer` is
+      `dm.killContainer` (`jobqueue/client.go:1584`), whose only production
+      caller is the `killCmd` closure (`jobqueue/client.go:2345`), which keeps
+      its own `dm.containerID != ""` guard - the two are defence in depth, so
+      one added call site can no longer restore the hazard.
+
+      Correction to how this was first written up: the red command's
+      `ContainerKill(ctx, "")` came from calling `killContainer` directly, and
+      the reviewer established that `killCmd`'s guard is present on master too
+      and is the only production call site. So wr never sent an empty id to
+      docker on any production path. The guard is worth having - it puts the
+      rule in the function that owns it rather than only in its caller - but it
+      fixes no user-visible behaviour, and the CHANGELOG sentence claiming it
+      did was dropped.
+    - Losing monitoring is visible: `adoptUnambiguousNewContainer` logs
+      `clog.Warn` once per job, latched with the refusal so it is not repeated
+      on every poll, in the style `noteCallResult` already uses for the
+      comparable give-up condition. The literal line, from the regression
+      test's captured buffer:
+
+      ```
+      t=2026-09-07T10:08:46+0000 lvl=warn msg="not monitoring a job's docker
+      container; more than one container appeared while it ran and none of them
+      is identifiably the job's, so its usage will be under-reported and no
+      container will be killed with the job" container=? candidates="[cotenants
+      [someone_elses_tool] jobs[jobs_own]]" caller=clog.go:338
+      ```
+
+      The candidate ids and names are included so a user investigating "why is
+      my job's RAM 0" can see what wr could not choose between. The
+      `MonitorDocker` doc comment on `Job` was corrected too: it promised the
+      "first new docker container that appears" and warned that concurrent jobs
+      could get each other's stats, which was the bug written down as a feature.
+    - Regression test: 5 new scenarios in `TestDockerMonitorAdoption`
+      (`jobqueue/docker_monitor_test.go`), 66 assertions total, driven by the
+      `fakeInteractor` that file already had, so no docker and no timing. Each
+      asserts on WHICH container was killed via `fake.killedIDs()`, not merely
+      that a kill happened: 2 unlabelled new containers -> nothing adopted,
+      nothing killed, mem unchanged, warning logged; one labelled for another
+      job -> the other candidate adopted and it alone killed, no warning; one
+      labelled for this job -> adopted and killed alone, asserted in both
+      appearance orders so the match cannot depend on ordering; none appeared ->
+      nothing killed even when `killContainer` is called directly, no warning;
+      and the latch - after an ambiguous poll, `fake.remove()`ing one rival
+      still adopts nothing, with the warning appearing exactly once. The 4
+      original scenarios still pass unchanged. `container/docker`'s new
+      `TestDockerContainerLabels` proves the interactor really carries labels
+      through, using a fake unix-socket daemon rather than real docker;
+      `container/run_test.go`'s 3 exact-command-string assertions were extended
+      for the new `--label` arg rather than loosened.
+    - Mutation check by the orchestrator, each mutation `go vet ./cmd/
+      ./jobqueue/ ./container/` clean so it provably compiled, each reverted
+      afterwards with `sha256sum -c` confirming `jobqueue/client.go` was
+      restored byte-identical. All four halves are separately load-bearing;
+      none carries another:
+      - `len(candidates) == 1` relaxed to `>= 1` (the ambiguity refusal removed,
+        which is the old buggy behaviour) -> red at the 2-unlabelled case and
+        the latch case, `Line 543/646: Expected: 100  Actual: 900` - the
+        co-tenant's memory charged to the job. The label cases stayed green.
+      - `adoptLabelledNewContainer` forced to adopt nothing -> red at both
+        orderings of the this-job's-label case, `Line 672: Expected: 300
+        Actual: 100` (twice), and the ambiguity warning appears where the label
+        should have answered. Every other case stayed green.
+      - the other-job exclusion dropped from `adoptUnambiguousNewContainer` ->
+        red at the another-job's-label case alone, `Line 575: Expected: 300
+        Actual: 100`.
+      - the `killContainer` empty-id guard removed -> red at 3 assertions,
+        `Line 548/626/656: Expected [] to be empty (but it wasn't)!`.
+    - Cost noted, not a defect: `findContainerID` now calls `GetNewContainers`
+      on every poll for all 3 identification paths, where the name path
+      previously reached it only inside `GetNewContainerByName`. That is one
+      extra docker `ContainerList` per poll on the name and cidfile paths. Its
+      error is joined into every return path so an unresponsive daemon is still
+      noticed by `noteCallResult`.
+    - Review round (reviewer returned FAIL first time, then all findings taken):
+      - **Blocking, and a real gate failure this would have shipped:**
+        `jobqueue/job_test.go:526` asserts the whole `docker run` line that
+        `Job.CmdLine()` builds and had not been updated for the new `--label`
+        arg, so `TestJob` was red. `go vet` and `make lint` cannot see an
+        assertion, and the targeted test command used during the fix did not
+        run `TestJob`. Fixed by adding the arg to `dockerPrefix` with the label
+        key spelled out literally (interpolating `container.JobKeyLabel` would
+        make the assertion tautological) and `%[1]s`-indexing the job key,
+        which covers all 3 `fmt.Sprintf` call sites. `ShouldEndWith` kept.
+        Commit `0451e62` had updated this same line for its `$PWD` change, so
+        it is the `Job`-level counterpart of the `container/run_test.go`
+        strings that `260907-1.md` owns.
+      - The label match was being tried on every path, which made
+        `findContainerID` call `GetNewContainers` unconditionally and so cost
+        the name path a second `ContainerList` per poll (and the cidfile path a
+        third), once per `resourceTicker` second for as long as nothing had
+        been adopted - unbounded for a job whose container never appears, or
+        whose diff has latched. It also made `noteCallResult`'s warning carry
+        `Could not list the containers` twice, because `newErr` and `nameErr`
+        reported the same failure. Fixed by moving the listing and the label
+        match inside the `getFirstAppears` branch, restoring the name and
+        cidfile paths to master's logic and call counts. Nothing is lost:
+        `Job.CmdLine()` (`jobqueue/client.go:2104`) sets
+        `j.MonitorDocker = j.Key()` before `setupDockerMonitor`
+        (`jobqueue/client.go:2317`), so a `--with_docker` job's monitor is
+        never `"?"`, and `DockerRunCmd` gives the container that same key as
+        both `--name` and label value, so the by-name lookup already finds
+        exactly the container a label match would have. Measured with a
+        throwaway counting interactor, calls per `findContainerID`:
+        `?` 1 -> 1, name 1 -> 1, cidfile 2 -> 2, all equal to master.
+      - The ambiguity warning's test was titled "says the job's usage is
+        under-reported" but asserted only on "more than one container
+        appeared". It now also asserts the under-reported clause, the
+        no-kill clause, and both candidate descriptions, so deleting
+        `describeContainers` from the log call can no longer go unnoticed
+        (mutation-checked: it turns the case red).
+      - `adoptLabelledNewContainer`'s `dm.jobKey == ""` early return had no
+        counterpart in `adoptUnambiguousNewContainer`, so the two halves
+        disagreed about a container labelled with an empty value. Unreachable -
+        `Job.Key()` is a hash - but resolved by dropping the guard so both
+        halves agree, with a comment saying why. No test added for an
+        unreachable state.
+      - Reviewer's own honest finding, worth recording for the owner: **design
+        A's label _match_ is dead weight today, and design C's label
+        _exclusion_ is the part that actually fixes the bug.** Because
+        `WithDocker` overwrites `MonitorDocker` with the job key, wr never
+        starts a container for a job whose monitor is `"?"`, so the label match
+        can only fire for a container something else labelled with this job's
+        key. The exclusion, by contrast, is exactly what stops one wr job
+        adopting and killing another wr job's container, and it is the
+        mutation-proven half. The label match is kept because the owner asked
+        for label-first ordering and it is correct-by-construction if that
+        wiring ever changes, but it now costs nothing on the other paths.
+      - Not changed, deliberately: `killContainer`'s empty-id guard duplicates
+        `killCmd`'s. Two guards is the intent - the rule belongs in the
+        function that owns the kill, and the caller's guard is what makes the
+        production path safe today.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+### Fixed
+- With `--monitor_docker '?'`, wr could charge another container's RAM to your
+  job as its peak, and SIGKILL a container it never started, whenever more than
+  one container appeared while the job ran; on a shared machine that other
+  container could even belong to another of your wr jobs. When it cannot tell
+  which of the new containers is the job's, wr now monitors none of them rather
+  than guess, and logs a warning saying that the job's usage will be
+  under-reported and that no container will be killed with it. A container wr
+  started for the job itself (`--with_docker`) is still recognised whatever
+  else appears alongside it.
+
+
 ## [0.37.2] - 2026-09-01
 ### Added
 - New `wr manager compact` command, which rewrites wr's database into a

--- a/container/container.go
+++ b/container/container.go
@@ -33,10 +33,18 @@ import (
 	"strings"
 )
 
+// JobKeyLabel is the key of the label that DockerRunCmd puts on the container
+// it creates, with the container's name as its value. Since only we set it, a
+// container carrying it with a given name as its value is one we started for
+// the job of that name, which is how a caller can tell its own container apart
+// from every other container on the host.
+const JobKeyLabel = "uk.ac.sanger.wr.job-key"
+
 // Container struct represents a container type with specific properties.
 type Container struct {
 	ID     string
 	Names  []string
+	Labels map[string]string
 	client Interactor
 }
 
@@ -75,4 +83,14 @@ func (c *Container) TrimNamePrefixes() {
 // call the TrimNamePrefixes on the container before calling this function.
 func (c *Container) HasName(name string) bool {
 	return slices.Contains(c.Names, name)
+}
+
+// Label returns the value of this container's label with the given key, and
+// whether the container has that label at all. The 2 are distinguished so that
+// a caller can tell a container that another job's label claims from one that
+// carries no claim.
+func (c *Container) Label(key string) (string, bool) {
+	value, set := c.Labels[key]
+
+	return value, set
 }

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -94,6 +94,22 @@ func TestContainer(t *testing.T) {
 			So(newContainer.Names[1], ShouldEqual, "test_container1_new")
 		})
 
+		Convey("it can report the value of a label, and whether it is set", func() {
+			So(newContainer.Labels, ShouldBeNil)
+
+			_, set := newContainer.Label(JobKeyLabel)
+			So(set, ShouldBeFalse)
+
+			newContainer.Labels = map[string]string{JobKeyLabel: "somejobskey"}
+
+			value, set := newContainer.Label(JobKeyLabel)
+			So(set, ShouldBeTrue)
+			So(value, ShouldEqual, "somejobskey")
+
+			_, set = newContainer.Label("some.other.label")
+			So(set, ShouldBeFalse)
+		})
+
 		Convey("it can check if a given name is its valid name", func() {
 			// call TrimNamePrefixes on the container
 			newContainer.TrimNamePrefixes()

--- a/container/docker/docker.go
+++ b/container/docker/docker.go
@@ -60,7 +60,7 @@ func (i *Interactor) ContainerList(ctx context.Context) ([]*container.Container,
 	customCntrList := make([]*container.Container, len(containerList.Items))
 
 	for idx, cntr := range containerList.Items {
-		newCntr := &container.Container{ID: cntr.ID, Names: cntr.Names}
+		newCntr := &container.Container{ID: cntr.ID, Names: cntr.Names, Labels: cntr.Labels}
 		newCntr.TrimNamePrefixes()
 		customCntrList[idx] = newCntr
 	}

--- a/container/docker/docker_test.go
+++ b/container/docker/docker_test.go
@@ -28,11 +28,15 @@ package docker
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
+	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/VertebrateResequencing/wr/container"
 	cn "github.com/moby/moby/api/types/container"
@@ -43,6 +47,14 @@ import (
 )
 
 const linuxOS = "linux"
+
+// testAPIVersion is the docker API version our fake daemon serves; the moby
+// client asks for a pinned version directly instead of negotiating one.
+const testAPIVersion = "1.51"
+
+// testFakeDaemonBound is how long our fake daemon will wait for a client's
+// request headers before giving up on it.
+const testFakeDaemonBound = 30 * time.Second
 
 var errCloseStats = errors.New("close stats")
 
@@ -163,6 +175,81 @@ func TestDockerDecodeContainerStats(t *testing.T) {
 			So(stats, ShouldNotBeNil)
 			So(err, ShouldEqual, errCloseStats)
 			So(nonEmptyRC.closed, ShouldBeTrue)
+		})
+	})
+}
+
+// listingDockerSocket serves a fake docker API on a unix socket that answers
+// every container listing with the given containers, returning the DOCKER_HOST
+// value that addresses it. It lets a listing be tested without docker.
+func listingDockerSocket(t *testing.T, containers []cn.Summary) string {
+	t.Helper()
+
+	sock := filepath.Join(t.TempDir(), "docker.sock")
+
+	var listenConfig net.ListenConfig
+
+	listener, err := listenConfig.Listen(context.Background(), "unix", sock)
+	So(err, ShouldBeNil)
+
+	listing, err := json.Marshal(containers)
+	So(err, ShouldBeNil)
+
+	server := &http.Server{
+		ReadHeaderTimeout: testFakeDaemonBound,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			//nolint:errcheck // a client that has gone away is not this fake's problem.
+			w.Write(listing)
+		}),
+	}
+
+	go func() {
+		//nolint:errcheck // Serve only ever ends with the error from our Close below.
+		server.Serve(listener)
+	}()
+
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+
+	return "unix://" + sock
+}
+
+func TestDockerContainerLabels(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a docker daemon with a labelled and an unlabelled container", t, func() {
+		t.Setenv("DOCKER_HOST", listingDockerSocket(t, []cn.Summary{
+			{
+				ID:     "labelledid",
+				Names:  []string{"/thejobskey"},
+				Labels: map[string]string{container.JobKeyLabel: "thejobskey"},
+			},
+			{ID: "unlabelledid", Names: []string{"/someone_elses"}},
+		}))
+		t.Setenv("DOCKER_API_VERSION", testAPIVersion)
+
+		cli, err := client.New(client.FromEnv)
+		So(err, ShouldBeNil)
+
+		Convey("Listing them reports the labels, so a caller can recognise its own container", func() {
+			cntrs, err := NewInteractor(cli).ContainerList(ctx)
+			So(err, ShouldBeNil)
+			So(len(cntrs), ShouldEqual, 2)
+
+			So(cntrs[0].ID, ShouldEqual, "labelledid")
+			So(cntrs[0].Names, ShouldResemble, []string{"thejobskey"})
+
+			value, set := cntrs[0].Label(container.JobKeyLabel)
+			So(set, ShouldBeTrue)
+			So(value, ShouldEqual, "thejobskey")
+
+			So(cntrs[1].ID, ShouldEqual, "unlabelledid")
+
+			_, set = cntrs[1].Label(container.JobKeyLabel)
+			So(set, ShouldBeFalse)
 		})
 	})
 }

--- a/container/run.go
+++ b/container/run.go
@@ -114,14 +114,18 @@ func writeStringToFile(f *os.File, content string, cleanup func()) error {
 //     their values outside the container.
 //   - That will run the command in the given file (by piping the file contents
 //     to /bin/sh); use PrepareCmdFile() to create one.
+//   - That carries the JobKeyLabel label with the given name as its value, so
+//     that the container can later be identified as the one created here
+//     rather than by anyone else on the host.
 //
 // * Automatically remove the container when it exits.
 func DockerRunCmd(image, cmdFile, name string, mounts, env []string) string {
 	mountArgs := dockerMounts(mounts)
 	envArgs := dockerEnv(env)
 
-	return fmt.Sprintf("cat %s | docker run --rm --name %s%s%s -i %s /bin/sh",
-		shellquote.Join(cmdFile), shellquote.Join(name), mountArgs, envArgs, shellquote.Join(image))
+	return fmt.Sprintf("cat %s | docker run --rm --name %s --label %s%s%s -i %s /bin/sh",
+		shellquote.Join(cmdFile), shellquote.Join(name), shellquote.Join(JobKeyLabel+"="+name),
+		mountArgs, envArgs, shellquote.Join(image))
 }
 
 // dockerMounts takes a list of "/local/path[:/inside/container/path]" values

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -164,12 +164,14 @@ func TestRunDocker(t *testing.T) {
 		cmd := DockerRunCmd("myimage", "/path/to/cmds", "uniqueID", nil, nil)
 
 		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
+			" --label uk.ac.sanger.wr.job-key=uniqueID"+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage /bin/sh`)
 
 		cmd = DockerRunCmd("myimage", "/path/to/cmds", "uniqueID",
 			[]string{"/foo/bar:/bar", "/foo/car"}, []string{"A", "B"})
 
 		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
+			" --label uk.ac.sanger.wr.job-key=uniqueID"+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
 			" --mount type=bind,source=/foo/bar,target=/bar --mount type=bind,source=/foo/car,target=/foo/car"+
 			" -e A -e B -i myimage /bin/sh")
@@ -180,6 +182,7 @@ func TestRunDocker(t *testing.T) {
 			[]string{"/foo/b ar;rm -rf x:/b ar", "/foo/car"}, []string{"A B"})
 
 		So(cmd, ShouldEqual, "cat '/path to/cmds' | docker run --rm --name 'unique ID'"+
+			" --label 'uk.ac.sanger.wr.job-key=unique ID'"+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
 			" --mount 'type=bind,source=/foo/b ar;rm -rf x,target=/b ar'"+
 			" --mount type=bind,source=/foo/car,target=/foo/car"+

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -182,6 +182,14 @@ const (
 	// paying dockerCallTimeout on every check.
 	dockerFailureTolerance = 3
 
+	// ambiguousContainerMsg is logged when more than one container appeared
+	// during a job's run and none of them can be told to be the job's, so that
+	// a user wondering why their job reported no container usage can find out
+	// why.
+	ambiguousContainerMsg = "not monitoring a job's docker container; more than one container appeared while " +
+		"it ran and none of them is identifiably the job's, so its usage will be under-reported and no " +
+		"container will be killed with the job"
+
 	// checkingFinishTimeout is how long Execute() waits for its resource
 	// checking goroutine to confirm that it has stopped. It is a backstop for
 	// that goroutine blocking in something we don't control: a finished job
@@ -428,6 +436,97 @@ func (state *executeLiveState) snapshot() *JobEndState {
 		Stdout:   stdout,
 		Stderr:   stderr,
 	}
+}
+
+// adoptLabelledNewContainer adopts the new container that wr started for this
+// job, recognised by it carrying container.JobKeyLabel with this job's key,
+// and says if it adopted one.
+//
+// More than one container claiming to be this job's is as ambiguous as none,
+// so nothing is adopted then.
+//
+// jobKey is a Job.Key(), which is a hash and so is never empty; neither this
+// nor adoptUnambiguousNewContainer special-cases an empty one, so both agree
+// that a container labelled with an empty value is the container of a job
+// whose key is empty.
+func (dm *dockerMonitor) adoptLabelledNewContainer(newContainers []*container.Container) bool {
+	var ours *container.Container
+
+	for _, cntr := range newContainers {
+		if key, set := cntr.Label(container.JobKeyLabel); !set || key != dm.jobKey {
+			continue
+		}
+
+		if ours != nil {
+			return false
+		}
+
+		ours = cntr
+	}
+
+	if ours == nil {
+		return false
+	}
+
+	dm.containerID = ours.ID
+
+	return true
+}
+
+// adoptUnambiguousNewContainer adopts the one new container that could be this
+// job's, if exactly one could be.
+//
+// A container labelled as another job's demonstrably is not this job's, so it
+// is not a candidate. If 2 or more candidates remain there is no way to tell
+// which is this job's, and adopting the wrong one would charge its usage to
+// this job and SIGKILL it with this job - so nothing is adopted, and the
+// refusal is latched: a candidate that becomes the only one left later on (its
+// rival having exited) is no more identifiable than it was, and adopting it
+// would be a coin flip on a kill. A later label match can still win, being the
+// one unambiguous answer.
+//
+// Nothing is logged when there are no candidates at all: this runs on every
+// poll of a running job, and "no container yet" is what a job that has not got
+// as far as starting its container looks like.
+func (dm *dockerMonitor) adoptUnambiguousNewContainer(ctx context.Context, newContainers []*container.Container) {
+	if dm.diffAmbiguous {
+		return
+	}
+
+	var candidates []*container.Container
+
+	for _, cntr := range newContainers {
+		if key, set := cntr.Label(container.JobKeyLabel); set && key != dm.jobKey {
+			continue
+		}
+
+		candidates = append(candidates, cntr)
+	}
+
+	if len(candidates) == 1 {
+		dm.containerID = candidates[0].ID
+
+		return
+	}
+
+	if len(candidates) > 1 {
+		dm.diffAmbiguous = true
+
+		clog.Warn(ctx, ambiguousContainerMsg, "container", dm.monitorDocker,
+			"candidates", describeContainers(candidates))
+	}
+}
+
+// describeContainers renders containers as "id[name,name]" values, so that a
+// log message can say which containers it could not choose between.
+func describeContainers(containers []*container.Container) []string {
+	described := make([]string, len(containers))
+
+	for i, cntr := range containers {
+		described[i] = cntr.ID + "[" + strings.Join(cntr.Names, ",") + "]"
+	}
+
+	return described
 }
 
 // combineExecOutcomes folds the verdict that unmounting the job's mounts
@@ -1418,13 +1517,22 @@ type dockerMonitor struct {
 	interactor    container.Interactor
 	monitorDocker string
 
+	// jobKey is the Key() of the job we monitor for, which is the value of the
+	// container.JobKeyLabel label on a container wr started for that job.
+	jobKey string
+
 	// callTimeout is how long any single docker API call we make is allowed to
 	// take.
 	callTimeout     time.Duration
 	failures        int
 	getFirstAppears bool
 	givenUp         bool
-	containerID     string
+
+	// diffAmbiguous notes that more than one container we could not rule out
+	// appeared during this job's run, so no container can be adopted by
+	// appearance any more; see adoptUnambiguousNewContainer.
+	diffAmbiguous bool
+	containerID   string
 }
 
 // setupDockerMonitor creates the docker client used to monitor the job's
@@ -1440,7 +1548,7 @@ func (c *Client) setupDockerMonitor(ctx context.Context, job *Job) (*dockerMonit
 		return nil, c.buryWithCause(job, FailReasonDocker, err, "failed to create docker client")
 	}
 
-	dm, err := newDockerMonitor(ctx, job.MonitorDocker, interactor, dockerCallTimeout)
+	dm, err := newDockerMonitor(ctx, job.MonitorDocker, job.Key(), interactor, dockerCallTimeout)
 	if err != nil {
 		return nil, c.buryWithCause(job, FailReasonDocker, err, "failed to get docker containers")
 	}
@@ -1468,18 +1576,20 @@ func newDockerInteractor(timeout time.Duration) (container.Interactor, error) {
 // newDockerMonitor creates a dockerMonitor for the container identified by
 // monitorDocker (its --name, the path to its --cidfile, or "?" for the first
 // container to appear), monitored using the given interactor and allowing
-// timeout for each docker API call.
+// timeout for each docker API call. jobKey is the Key() of the job being
+// monitored, used to recognise a container that wr itself started for it.
 //
 // The containers that already exist are remembered, so that only a container
 // that appears after this call can be adopted - and so killed - by the job,
 // whichever way monitorDocker identifies it.
-func newDockerMonitor(ctx context.Context, monitorDocker string, interactor container.Interactor,
+func newDockerMonitor(ctx context.Context, monitorDocker, jobKey string, interactor container.Interactor,
 	timeout time.Duration,
 ) (*dockerMonitor, error) {
 	dm := &dockerMonitor{
 		operator:        container.NewOperator(interactor),
 		interactor:      interactor,
 		monitorDocker:   monitorDocker,
+		jobKey:          jobKey,
 		callTimeout:     timeout,
 		getFirstAppears: monitorDocker == "?",
 	}
@@ -1577,7 +1687,15 @@ func (dm *dockerMonitor) noteCallResult(ctx context.Context, err error) {
 // and does reach the job's outcome: a kill we were asked to do and could not
 // do leaves the user's container running, which is a real failure of this run
 // and not something a later check can make good.
+//
+// With no container adopted there is nothing to kill, so docker is not called
+// at all: an empty id is not a container the daemon would refuse, it is a
+// request we must not make.
 func (dm *dockerMonitor) killContainer(ctx context.Context) error {
+	if dm.containerID == "" {
+		return nil
+	}
+
 	callCtx, cancel := dm.callCtx(ctx)
 	defer cancel()
 
@@ -1586,14 +1704,27 @@ func (dm *dockerMonitor) killContainer(ctx context.Context) error {
 
 // findContainerID tries to identify the container to monitor, caching its id on
 // success.
+//
+// The label match is only consulted when monitorDocker is "?", ie. when we
+// would otherwise have to guess from the diff. It buys nothing on the other
+// paths and would cost them an extra listing per poll: a --with_docker job's
+// monitorDocker is never "?" but always its Key(), because Job.CmdLine() sets
+// it before Execute() gets as far as setupDockerMonitor, and DockerRunCmd
+// gives the container that same key as both its --name and its label value, so
+// the by-name lookup already finds exactly the container the label match would
+// have.
 func (dm *dockerMonitor) findContainerID(ctx context.Context, cmdDir string) error {
 	if dm.getFirstAppears {
-		containers, err := dm.operator.GetNewContainers(ctx)
-		if len(containers) > 0 {
-			dm.containerID = containers[0].ID
+		newContainers, newErr := dm.operator.GetNewContainers(ctx)
+
+		// a container labelled as this job's is the one unambiguous answer,
+		// since only wr sets that label and it says whose container this is,
+		// so the diff is only fallen back on when no container claims us.
+		if !dm.adoptLabelledNewContainer(newContainers) {
+			dm.adoptUnambiguousNewContainer(ctx, newContainers)
 		}
 
-		return err
+		return newErr
 	}
 
 	// monitorDocker might be the name of a new container

--- a/jobqueue/docker_monitor_test.go
+++ b/jobqueue/docker_monitor_test.go
@@ -39,6 +39,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/VertebrateResequencing/wr/clog"
 	"github.com/VertebrateResequencing/wr/container"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -61,6 +62,20 @@ const (
 	// dockerTestAPIVersion is the docker API version our fake daemon serves; the
 	// moby client asks for a pinned version directly instead of negotiating one.
 	dockerTestAPIVersion = "1.51"
+
+	// dockerTestJobKey stands in for the Key() of the job whose container is
+	// being monitored, which is the value wr labels a container it starts for
+	// that job with.
+	dockerTestJobKey = "thisjobskey"
+
+	// dockerTestOtherJobKey is the same for a different job, whose container
+	// must never be adopted by the job under test.
+	dockerTestOtherJobKey = "anotherjobskey"
+
+	// dockerTestJobsContainerID is the id the tests give the container that is
+	// the job's own, so that an assertion can name the only container that may
+	// be monitored, and killed, with that job.
+	dockerTestJobsContainerID = "jobs"
 )
 
 func TestCheckingRendezvous(t *testing.T) {
@@ -246,7 +261,7 @@ func TestDockerMonitorUnresponsiveDaemon(t *testing.T) {
 			errCh := make(chan error, 1)
 
 			go func() {
-				_, err := newDockerMonitor(ctx, "?", stalled, dockerTestCallTimeout)
+				_, err := newDockerMonitor(ctx, "?", dockerTestJobKey, stalled, dockerTestCallTimeout)
 				errCh <- err
 			}()
 
@@ -351,16 +366,42 @@ func newFakeInteractor() *fakeInteractor {
 }
 
 // add makes a container with the given id and name, using the given memory in
-// MB, exist.
+// MB, exist. It carries no labels, like a container started by anything other
+// than wr.
 func (f *fakeInteractor) add(id, name string, memMB int) {
+	f.addLabelled(id, name, memMB, nil)
+}
+
+// addForJob is like add, but the container carries the label wr puts on a
+// container it starts for the job with the given key.
+func (f *fakeInteractor) addForJob(id, name, jobKey string, memMB int) {
+	f.addLabelled(id, name, memMB, map[string]string{container.JobKeyLabel: jobKey})
+}
+
+// addLabelled makes a container with the given id, name and labels, using the
+// given memory in MB, exist.
+func (f *fakeInteractor) addLabelled(id, name string, memMB int, labels map[string]string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	cntr := &container.Container{ID: id, Names: []string{"/" + name}}
+	cntr := &container.Container{ID: id, Names: []string{"/" + name}, Labels: labels}
 	cntr.TrimNamePrefixes()
 
 	f.containers = append(f.containers, cntr)
 	f.mems[id] = memMB
+}
+
+// remove makes the container with the given id stop existing, as one that
+// exits during a job's run does.
+func (f *fakeInteractor) remove(id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.containers = slices.DeleteFunc(f.containers, func(cntr *container.Container) bool {
+		return cntr.ID == id
+	})
+
+	delete(f.mems, id)
 }
 
 // killedIDs returns the ids of the containers that have been killed.
@@ -406,7 +447,7 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		fake := newFakeInteractor()
 		fake.add("preexisting", "mytool", 500)
 
-		dm, err := newDockerMonitor(ctx, "mytool", fake, dockerTestCallTimeout)
+		dm, err := newDockerMonitor(ctx, "mytool", dockerTestJobKey, fake, dockerTestCallTimeout)
 		So(err, ShouldBeNil)
 
 		Convey("It is not monitored, so nothing of it can be killed", func() {
@@ -418,7 +459,7 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		})
 
 		Convey("But a container of that name that appears afterwards is monitored", func() {
-			fake.add("jobs", "mytool", 300)
+			fake.add(dockerTestJobsContainerID, "mytool", 300)
 
 			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
 			So(dm.failures, ShouldEqual, 0)
@@ -426,7 +467,7 @@ func TestDockerMonitorAdoption(t *testing.T) {
 
 			Convey("And a kill request kills only that container", func() {
 				So(dm.killContainer(ctx), ShouldBeNil)
-				So(fake.killedIDs(), ShouldResemble, []string{"jobs"})
+				So(fake.killedIDs(), ShouldResemble, []string{dockerTestJobsContainerID})
 			})
 		})
 	})
@@ -439,7 +480,7 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		cidPath := filepath.Join(dir, "job.cid")
 		So(os.WriteFile(cidPath, []byte("preexisting\n"), 0600), ShouldBeNil)
 
-		dm, err := newDockerMonitor(ctx, cidPath, fake, dockerTestCallTimeout)
+		dm, err := newDockerMonitor(ctx, cidPath, dockerTestJobKey, fake, dockerTestCallTimeout)
 		So(err, ShouldBeNil)
 
 		Convey("It is not monitored", func() {
@@ -449,8 +490,8 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		})
 
 		Convey("But the container the job goes on to create is monitored", func() {
-			fake.add("jobs", "jobs_own", 300)
-			So(os.WriteFile(cidPath, []byte("jobs\n"), 0600), ShouldBeNil)
+			fake.add(dockerTestJobsContainerID, "jobs_own", 300)
+			So(os.WriteFile(cidPath, []byte(dockerTestJobsContainerID+"\n"), 0600), ShouldBeNil)
 
 			mem, _ := dm.resolveContainerMem(ctx, dir, 100)
 			So(dm.failures, ShouldEqual, 0)
@@ -462,7 +503,7 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		fake := newFakeInteractor()
 		fake.add("preexisting", "someone_elses", 500)
 
-		dm, err := newDockerMonitor(ctx, "?", fake, dockerTestCallTimeout)
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
 		So(err, ShouldBeNil)
 
 		Convey("The already running one is not monitored", func() {
@@ -472,13 +513,173 @@ func TestDockerMonitorAdoption(t *testing.T) {
 		})
 
 		Convey("The next one to appear is monitored", func() {
-			fake.add("jobs", "jobs_own", 300)
+			fake.add(dockerTestJobsContainerID, "jobs_own", 300)
 
 			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
 			So(dm.failures, ShouldEqual, 0)
 			So(mem, ShouldEqual, 300)
 		})
 	})
+
+	Convey("Given a monitor of the first container to appear, and 2 unlabelled ones appearing", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "was_here_first", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		// a co-tenant's container appears first, then the job's own one, and
+		// nothing about either of them says which is which
+		fake.add("cotenants", "someone_elses_tool", 900)
+		fake.add(dockerTestJobsContainerID, "jobs_own", 300)
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		defer clog.ToDefault()
+
+		Convey("Neither is monitored, so neither one's memory is charged to the job", func() {
+			mem, cpu := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
+			So(mem, ShouldEqual, 100)
+			So(cpu, ShouldEqual, 0)
+
+			Convey("And a kill request kills neither of them", func() {
+				So(dm.killContainer(ctx), ShouldBeNil)
+				So(fake.killedIDs(), ShouldBeEmpty)
+			})
+
+			Convey("And a warning says the job's usage is under-reported", func() {
+				So(buff.String(), ShouldContainSubstring, "lvl=warn")
+				So(buff.String(), ShouldContainSubstring, "more than one container appeared while it ran")
+				So(buff.String(), ShouldContainSubstring, "so its usage will be under-reported")
+				So(buff.String(), ShouldContainSubstring, "no container will be killed with the job")
+
+				// the ids let a user find the containers the warning is about,
+				// so the warning has to actually carry them
+				So(buff.String(), ShouldContainSubstring, "cotenants[someone_elses_tool]")
+				So(buff.String(), ShouldContainSubstring, dockerTestJobsContainerID+"[jobs_own]")
+			})
+		})
+	})
+
+	Convey("Given a monitor of the first container to appear, and a new one labelled as another job's", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "was_here_first", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		fake.addForJob("anothers", "another_jobs_own", dockerTestOtherJobKey, 900)
+		fake.add(dockerTestJobsContainerID, "jobs_own", 300)
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		defer clog.ToDefault()
+
+		Convey("The other job's is ruled out, so the one that could be this job's is monitored", func() {
+			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
+			So(mem, ShouldEqual, 300)
+			So(buff.String(), ShouldBeBlank)
+
+			Convey("And a kill request kills only that container", func() {
+				So(dm.killContainer(ctx), ShouldBeNil)
+				So(fake.killedIDs(), ShouldResemble, []string{dockerTestJobsContainerID})
+			})
+		})
+	})
+
+	Convey("Given a monitor of the first container to appear, and a new one labelled as this job's", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "was_here_first", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		Convey("It is monitored when another new container appeared before it", func() {
+			fake.add("cotenants", "someone_elses_tool", 900)
+			fake.addForJob(dockerTestJobsContainerID, "jobs_own", dockerTestJobKey, 300)
+
+			soOnlyTheJobsContainerIsMonitored(ctx, dm, fake)
+		})
+
+		Convey("It is monitored when another new container appeared after it", func() {
+			fake.addForJob(dockerTestJobsContainerID, "jobs_own", dockerTestJobKey, 300)
+			fake.add("cotenants", "someone_elses_tool", 900)
+
+			soOnlyTheJobsContainerIsMonitored(ctx, dm, fake)
+		})
+	})
+
+	Convey("Given a monitor of the first container to appear, and none appearing", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "was_here_first", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		defer clog.ToDefault()
+
+		Convey("Nothing is monitored, and nothing is said about a container that never came", func() {
+			mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
+			So(mem, ShouldEqual, 100)
+			So(buff.String(), ShouldBeBlank)
+
+			Convey("And a kill request made anyway kills nothing", func() {
+				So(dm.killContainer(ctx), ShouldBeNil)
+				So(fake.killedIDs(), ShouldBeEmpty)
+			})
+		})
+	})
+
+	Convey("Given a monitor that has refused to choose between 2 new containers", t, func() {
+		fake := newFakeInteractor()
+		fake.add("preexisting", "was_here_first", 500)
+
+		dm, err := newDockerMonitor(ctx, "?", dockerTestJobKey, fake, dockerTestCallTimeout)
+		So(err, ShouldBeNil)
+
+		fake.add("cotenants", "someone_elses_tool", 900)
+		fake.add(dockerTestJobsContainerID, "jobs_own", 300)
+
+		buff := clog.ToBufferAtLevel("warn")
+
+		defer clog.ToDefault()
+
+		mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+		So(mem, ShouldEqual, 100)
+
+		Convey("One of them exiting does not make the other one the job's", func() {
+			fake.remove("cotenants")
+
+			mem, _ = dm.resolveContainerMem(ctx, "/tmp", 100)
+			So(dm.failures, ShouldEqual, 0)
+			So(mem, ShouldEqual, 100)
+
+			So(dm.killContainer(ctx), ShouldBeNil)
+			So(fake.killedIDs(), ShouldBeEmpty)
+
+			Convey("And the warning is not repeated on every check", func() {
+				So(strings.Count(buff.String(), "more than one container appeared while it ran"),
+					ShouldEqual, 1)
+			})
+		})
+	})
+}
+
+// soOnlyTheJobsContainerIsMonitored asserts that dm has adopted the container
+// the test gave dockerTestJobsContainerID and 300MB of memory, and that a kill
+// request kills that container alone.
+func soOnlyTheJobsContainerIsMonitored(ctx context.Context, dm *dockerMonitor, fake *fakeInteractor) {
+	mem, _ := dm.resolveContainerMem(ctx, "/tmp", 100)
+	So(dm.failures, ShouldEqual, 0)
+	So(mem, ShouldEqual, 300)
+
+	So(dm.killContainer(ctx), ShouldBeNil)
+	So(fake.killedIDs(), ShouldResemble, []string{dockerTestJobsContainerID})
 }
 
 // failingListDockerSocket serves a fake docker API on a unix socket, returning

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -698,10 +698,13 @@ type Job struct {
 	// would make wr kill it when this job is killed or runs out of resources.
 	//
 	// If the special argument "?" is supplied, monitoring will apply to the
-	// first new docker container that appears after the Cmd starts to run.
-	// NB: if multiple jobs that run docker containers start running at the same
-	// time on the same machine, the reported stats could be wrong for one or
-	// more of those jobs.
+	// only new docker container that appears after the Cmd starts to run. If
+	// more than one appears, which of them is this job's cannot be told, so
+	// none of them is monitored (and a warning is logged saying so) for the
+	// rest of the job's run: a container someone else started must not be
+	// charged to this job, and must not be killed with it. A container wr
+	// itself started for this job is always recognised, however many others
+	// appear.
 	//
 	// Requires that docker is installed on the machine where the job will run
 	// (and that the Cmd uses docker to run a container). NB: does not handle

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -543,8 +543,9 @@ func TestJob(t *testing.T) {
 
 			So(cmd, ShouldStartWith, "cat ")
 
-			dockerPrefix := ` | docker run --rm --name %s -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`
-			dockerSuffix := " -i %s /bin/sh"
+			dockerPrefix := ` | docker run --rm --name %[1]s --label uk.ac.sanger.wr.job-key=%[1]s` +
+				` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`
+			dockerSuffix := " -i %[2]s /bin/sh"
 			So(cmd, ShouldEndWith, fmt.Sprintf(dockerPrefix+dockerSuffix, job.Key(), image))
 			So(job.MonitorDocker, ShouldEqual, job.Key())
 


### PR DESCRIPTION
With `MonitorDocker == "?"`, `findContainerID` adopted the FIRST container that
had appeared since `setupDockerMonitor` remembered the daemon's containers, with
no test of ownership. `GetNewContainers` diffs daemon-wide, so any container
started by anyone on that host during the job's run could be adopted, including
one wr itself started for a different job. The adopted id was then charged to
the job by `resolveContainerMem` and SIGKILLed on every kill path (out of time,
out of memory, out of disk, signalled, killed by the manager). There is no
ancestry to test: a container's processes are children of the docker daemon, not
of the job's command.

## Label the containers wr starts itself

The one place wr starts a container is `container.DockerRunCmd`, reached from
`Job.containerRunCmd` when `Job.WithDocker` is set. Its `name` argument is
already `Job.Key()`. It now also emits
`--label uk.ac.sanger.wr.job-key=<name>`, shell-quoted through
`shellquote.Join` like every other interpolated value in that function.

`container.JobKeyLabel` holds the key. `container.Container` gained `Labels` and
`Label(key) (string, bool)`, so a container carrying no claim can be told from
one carrying another job's claim. `container/docker`'s `Interactor.ContainerList`
carries `Summary.Labels` through.

## Refuse to adopt when the choice is ambiguous

`adoptUnambiguousNewContainer` first rules out any new container labelled for a
*different* job: wr started it for another job, so it demonstrably is not this
one's. Of what remains it adopts a container only if exactly one candidate is
left. On two or more it adopts nothing, so a wrong kill becomes no kill.

The refusal is latched. If a rival exits later and leaves one candidate, that
survivor is no more identifiable than it was, and adopting it would be a coin
flip on a SIGKILL. A later label match can still win, being the one unambiguous
answer.

## When no container appeared

Nothing is adopted, `dm.containerID` stays empty, nothing is charged, nothing is
killed, and nothing is logged. `adoptUnambiguousNewContainer` runs on every poll
of a running job, and "no container yet" is what a job that has not got as far
as starting its container looks like, so a log there would be per-poll noise.

`killContainer` now returns nil without calling docker when `dm.containerID` is
empty. Every call site was enumerated: the only production route to
`Operator.KillContainer` is `dm.killContainer`, whose only production caller is
the `killCmd` closure, which keeps its own non-empty guard. The two are defence
in depth. wr never sent an empty id to docker on any production path, so this
guard fixes no user-visible behaviour; it puts the rule in the function that
owns it.

## Losing monitoring is visible

`adoptUnambiguousNewContainer` logs a `clog.Warn` once per job, latched with the
refusal, naming the candidates it could not choose between, so a user asking
"why is my job's RAM 0" can see what wr saw. The `MonitorDocker` doc comment on
`Job` was corrected too: it promised the "first new docker container that
appears" and warned that concurrent jobs could get each other's stats, which was
this bug written down as a feature.

## Unchanged

`--monitor_docker <name>` and `--monitor_docker <id>` behave exactly as before,
with the same docker call counts as master, measured with a counting interactor:
`?` 1, name 1, cidfile 2. `Job.Key()`'s output is unchanged.

## Tests

5 new scenarios in `TestDockerMonitorAdoption`, 66 assertions, driven by the
`fakeInteractor` that file already had, so no docker and no timing. Each asserts
WHICH container was killed via `fake.killedIDs()`, not merely that a kill
happened. The 4 original scenarios pass unchanged.

`container/docker`'s new `TestDockerContainerLabels` proves the interactor
really carries labels through, using a fake unix-socket daemon.
`container/run_test.go`'s 3 exact-command-string assertions were extended for
the new `--label` arg rather than loosened.

All four halves were mutation-checked separately and are separately
load-bearing; none carries another. Each mutation was `go vet` clean before its
verdict counted and reverted byte-identically afterwards.

## One thing worth knowing

The label *match* is largely dead weight today, and the label *exclusion* is the
part that actually fixes the bug. Because `Job.CmdLine()` overwrites
`MonitorDocker` with the job key, wr never starts a container for a job whose
monitor is `"?"`, so the match can only fire for a container something else
labelled with this job's key. The match is kept because it is
correct-by-construction if that wiring ever changes, and it now costs nothing on
the other paths.

Full write-up in `.docs/bugfixes/260907-4.md`.
