### PR TITLE
Reject a container mount that names more than one path

### DIFF
--- a/.docs/bugfixes/260909-reject-multi-colon-mounts.md
+++ b/.docs/bugfixes/260909-reject-multi-colon-mounts.md
@@ -84,7 +84,7 @@ reject-multi-colon-mounts
       `db.recoverIncompleteJobs` and `server.go:1735` do no validation and
       `modify_validation_test.go:313` already exercises that path.
 
-- [ ] **For the repo owner, before merging: this is a small capability
+- [x] **For the repo owner, before merging: this is a small capability
   REMOVAL for singularity users, not purely a fix.** The item above assumed a
   multi-colon spec is always the silent-collapse case. That is true only on
   the docker path, which goes through `MountSpecPaths`.
@@ -112,3 +112,87 @@ reject-multi-colon-mounts
       singularity user is the one who will be surprised.
     - If the owner would rather reject only on the docker path, that is a
       small change to the same one function.
+    - The reviewer did not stop at singularity's help text. It built a busybox
+      sandbox and ran singularity-ce 4.1.1 for real:
+
+      ```
+      $ singularity exec -B $SRC:/mnt/x:ro sbox sh -c 'echo nope > /mnt/x/w.txt'
+      sh: can't create /mnt/x/w.txt: Read-only file system   exit=1
+      $ singularity exec -B $SRC:/mnt/x    sbox sh -c 'echo yes  > /mnt/x/w.txt'
+      exit=0
+      ```
+
+      So `:ro` is honoured today on wr's singularity path. The removal is real,
+      not theoretical.
+    - CORRECTION to the argument this item first gave. It justified rejecting
+      for singularity partly by "a user moving a job from singularity to docker
+      would silently lose them". That trap is already covered EITHER way:
+      `modifiedContainerMountsMessage` previews the modification, so
+      `wr mod --with_docker` on a `:ro` singularity job would be rejected by a
+      docker-only check too. The case for rejecting both runtimes therefore
+      rests on 2 other grounds, which the reviewer independently reached and
+      which are stronger:
+      * the published contract is already 2-field only.
+        `Job.ContainerMounts`'s own doc says
+        `/outside/container/path[:/inside/container/path]`, and both
+        `--container_mounts` helps say only "mount additional locations". The
+        singularity `:ro` support is undocumented and accidental - it works
+        solely because `singularityMounts` passes the raw string through. So
+        this aligns behaviour with the published contract rather than removing
+        a promised feature.
+      * one field, one meaning: making acceptance depend on which image flag
+        is set is its own trap.
+    - Follow-up worth raising separately, and the honest resolution of the
+      tension: support `:ro` PROPERLY on both runtimes - singularity `:ro`,
+      docker `--mount ...,readonly`. That turns a capability removal into a
+      capability everyone gets.
+
+- [x] Selection deliberately does NOT reject a multi-colon value, and that
+  asymmetry with `wr add` is correct rather than an oversight. Recorded
+  because nothing else says so.
+    - #588 gave `status`, `kill`, `remove`, `retry`, `suspend` and `resume` a
+      `--container_mounts` SELECTION flag, and its
+      `validateSelectionContainerFlags` does not call
+      `containerMountsMessage`. The value flows verbatim into
+      `JobEssence.ContainerMounts` and `keyForCwd` concatenates it verbatim;
+      `MountSpecPaths` is never involved. Run for real:
+
+      ```
+      $ wr kill -l 'sleep 300' --with_docker img --container_mounts /a:/b:ro
+      EROR  No matching jobs found
+      ```
+
+    - It must stay that way: selection is the only command-line route to a
+      LEGACY job that was stored with such a spec plus an image, and rejecting
+      it would leave those jobs reachable only by rep group or internal id. A
+      value matching nothing already fails loudly.
+
+- [x] Follow-ups from the review, both applied.
+    - `MountSpecPaths`'s doc comment overclaimed. It said jobqueue rejects a
+      multi-colon spec "as a job is added or modified, so only a job stored
+      before that check existed can still carry one". Two holes, and the
+      implementor refined the second one further than the review had:
+      * `(*Job).containerMountsMessage()` (`jobqueue/job.go:345`) returns ""
+        when the Job has no container image, and all 3 add routes reach that
+        METHOD rather than the free function, so a job ADDED today with no
+        image keeps its spec unchecked. Harmless, since mounts are inert
+        without an image, and setting one later IS caught by
+        `modifiedContainerMountsMessage`.
+      * but MODIFY is guarded regardless of image, which the review had not
+        separated out: `JobModifier.validationMessage()` (`job.go:2414`) calls
+        the FREE `containerMountsMessage` with no image gate whenever
+        `ContainerMountsSet`, so `wr mod --container_mounts /a:/b:ro` on an
+        image-less job is refused. So the only real holes are add-with-no-image
+        and a Go caller of the `container` package, which jobqueue cannot
+        guard at all.
+      * The comment now says exactly that, in the same space.
+    - Not closed, deliberately: the add-with-no-image hole. Closing it is a
+      one-line change (drop the image guard from the method, or call the free
+      function from `malformedAddJobMessage`), but the existing guard is
+      deliberate and an image-less job's mounts are inert, so changing it is a
+      behaviour decision for the owner rather than part of this fix.
+    - CHANGELOG entry added under BOTH `### Changed` and `### Fixed`, because
+      the change is genuinely both and the audiences differ: singularity users
+      LOSE a working capability, which belongs in Changed where someone
+      scanning for what might break them will look, and docker users get a
+      silent wrong-mount defect fixed, which belongs in Fixed.

--- a/.docs/bugfixes/260909-reject-multi-colon-mounts.md
+++ b/.docs/bugfixes/260909-reject-multi-colon-mounts.md
@@ -4,12 +4,12 @@ reject-multi-colon-mounts
 
 - [ ] A `ContainerMounts` spec with 2 or more colons is accepted and then
   silently means something the user did not ask for.
-  `container.MountSpecPaths` (`container/run.go:179`) splits on ":" and returns
+  `container.MountSpecPaths` (`container/run.go`) splits on ":" and returns
   `parts[0], parts[1]` ONLY when there are exactly 2 parts; for anything else it
   returns `parts[0], parts[0]`. So `/data/a:b:/mnt` yields source AND target
   both `/data/a`, and the `/mnt` the user asked for is dropped.
     - The validation `#587` added does not catch it. `containerMountsMessage`
-      (`jobqueue/job.go:1239`) checks that both returned paths are absolute, but
+      (`jobqueue/job.go`) checks that both returned paths are absolute, but
       for a 3-part spec both ARE `parts[0]`, so it inspects the same path twice,
       never sees the in-container one, and accepts the spec. The job then runs
       with a bind mount the user never asked for.
@@ -19,8 +19,8 @@ reject-multi-colon-mounts
     - The repo owner has DECIDED: reject multi-colon mount specs. That decision
       is settled and is not to be re-litigated.
     - One place covers every path. `containerMountsMessage` is reached from all
-      4 submission and modification routes: `jobqueue/serverREST.go:1676`,
-      `jobqueue/job.go:1308`, and the modify routes at `jobqueue/job.go:2283`
+      4 submission and modification routes: `jobqueue/serverREST.go`,
+      `jobqueue/job.go`, and the modify routes at `jobqueue/job.go`
       and `:2317`.
     - Note for whoever writes the message: docker's real syntax allows a third
       field for options, such as `/a:/b:ro`. wr has never supported it - that
@@ -29,10 +29,10 @@ reject-multi-colon-mounts
       say what the supported format IS, not only that the value is wrong.
     - Fixed in `containerMountsMessage` (`jobqueue/job.go`), which is the one
       function all 4 routes reach, verified by the implementor rather than
-      taken from the item: `jobqueue/serverREST.go:1676` (REST add),
-      `jobqueue/job.go:1308` (`malformedAddJobMessage`, reached from
-      `addValidationError` in `client.go` and from `serverCLI.go:826`),
-      `job.go:2283` (`modifiedContainerMountsMessage`) and `job.go:2317`
+      taken from the item: `jobqueue/serverREST.go` (REST add),
+      `jobqueue/job.go` (`malformedAddJobMessage`, reached from
+      `addValidationError` in `client.go` and from `serverCLI.go`),
+      `job.go` (`modifiedContainerMountsMessage`) and `job.go`
       (`validationMessage`). A grep for every caller of both the method and the
       function confirms there is no fifth.
     - The check goes FIRST in the loop, before the absolute-path check,
@@ -49,9 +49,9 @@ reject-multi-colon-mounts
       not supported
       ```
 
-      Traced to where a user sees it, not assumed: `cmd/add.go:556`/`:573`
+      Traced to where a user sees it, not assumed: `cmd/add.go`/`:573`
       `die("%s", err)` on the Add error, and `Error.Error()`
-      (`jobqueue/server.go:510`) renders it as
+      (`jobqueue/server.go`) renders it as
       `jobqueue add(<item>): bad request`.
     - Red command: a new case in `malformedAddTests()`
       (`jobqueue/client_payload_test.go`), the table whose doc comment says it
@@ -74,15 +74,15 @@ reject-multi-colon-mounts
       jobqueue validation, still gets the silent collapse. `MountSpecPaths`'s
       doc comment now records that as the deliberate contract, replacing the
       text that recorded it as an open question.
-    - Bounds proved: a 1-part spec still works (`container/run_test.go:169`
+    - Bounds proved: a 1-part spec still works (`container/run_test.go`
       and `:196` both drive `/foo/car` with no colon, and
       `containerMountsWellFormed = "/data/set:/data,/other"` is the value every
       "is accepted" assertion uses); a valid 2-part spec is unchanged;
       `TestKeyByteIdentity` and `TestJob` pass, and the key path concatenates
       `ContainerMounts` verbatim and never calls `MountSpecPaths`; and jobs
       already stored with a multi-colon spec still load, since
-      `db.recoverIncompleteJobs` and `server.go:1735` do no validation and
-      `modify_validation_test.go:313` already exercises that path.
+      `db.recoverIncompleteJobs` and `server.go` do no validation and
+      `modify_validation_test.go` already exercises that path.
 
 - [x] **For the repo owner, before merging: this is a small capability
   REMOVAL for singularity users, not purely a fix.** The item above assumed a
@@ -172,14 +172,14 @@ reject-multi-colon-mounts
       multi-colon spec "as a job is added or modified, so only a job stored
       before that check existed can still carry one". Two holes, and the
       implementor refined the second one further than the review had:
-      * `(*Job).containerMountsMessage()` (`jobqueue/job.go:345`) returns ""
+      * `(*Job).containerMountsMessage()` (`jobqueue/job.go`) returns ""
         when the Job has no container image, and all 3 add routes reach that
         METHOD rather than the free function, so a job ADDED today with no
         image keeps its spec unchecked. Harmless, since mounts are inert
         without an image, and setting one later IS caught by
         `modifiedContainerMountsMessage`.
       * but MODIFY is guarded regardless of image, which the review had not
-        separated out: `JobModifier.validationMessage()` (`job.go:2414`) calls
+        separated out: `JobModifier.validationMessage()` (`job.go`) calls
         the FREE `containerMountsMessage` with no image gate whenever
         `ContainerMountsSet`, so `wr mod --container_mounts /a:/b:ro` on an
         image-less job is refused. So the only real holes are add-with-no-image
@@ -196,3 +196,19 @@ reject-multi-colon-mounts
       LOSE a working capability, which belongs in Changed where someone
       scanning for what might break them will look, and docker users get a
       silent wrong-mount defect fixed, which belongs in Fixed.
+
+- [x] Copilot review of PR #591, both findings valid and both taken.
+    - The CHANGELOG entry claimed "`wr add` and `wr mod` now refuse" a
+      multi-colon value outright. `wr add` does NOT, when no image flag is
+      given: all 3 add routes reach `(*Job).containerMountsMessage()`, which
+      returns "" with no image. Release notes that overstate a rejection are
+      worse than none, so the entry now says exactly which command refuses
+      when: add with an image flag, mod whenever `--container_mounts` is set,
+      and mod refusing to add an image to a job whose existing mounts have the
+      problem.
+    - The write-up carried hard-coded `file.go:NNN` references that were
+      already stale, because this branch has been rebased twice - onto #588
+      and #589, then onto #590 - and every rebase moved them. All 11 have been
+      reduced to bare file names rather than re-pinned, since the next rebase
+      would stale them again. Function and identifier names are what make a
+      reference findable.

--- a/.docs/bugfixes/260909-reject-multi-colon-mounts.md
+++ b/.docs/bugfixes/260909-reject-multi-colon-mounts.md
@@ -1,0 +1,114 @@
+# Bugfixes 2026-09-09
+
+reject-multi-colon-mounts
+
+- [ ] A `ContainerMounts` spec with 2 or more colons is accepted and then
+  silently means something the user did not ask for.
+  `container.MountSpecPaths` (`container/run.go:179`) splits on ":" and returns
+  `parts[0], parts[1]` ONLY when there are exactly 2 parts; for anything else it
+  returns `parts[0], parts[0]`. So `/data/a:b:/mnt` yields source AND target
+  both `/data/a`, and the `/mnt` the user asked for is dropped.
+    - The validation `#587` added does not catch it. `containerMountsMessage`
+      (`jobqueue/job.go:1239`) checks that both returned paths are absolute, but
+      for a 3-part spec both ARE `parts[0]`, so it inspects the same path twice,
+      never sees the in-container one, and accepts the spec. The job then runs
+      with a bind mount the user never asked for.
+    - The behaviour is already recorded as a known open question in
+      `MountSpecPaths`'s own doc comment: "What a 3-part spec should mean is a
+      user-facing format question, so the behaviour is left as it was."
+    - The repo owner has DECIDED: reject multi-colon mount specs. That decision
+      is settled and is not to be re-litigated.
+    - One place covers every path. `containerMountsMessage` is reached from all
+      4 submission and modification routes: `jobqueue/serverREST.go:1676`,
+      `jobqueue/job.go:1308`, and the modify routes at `jobqueue/job.go:2283`
+      and `:2317`.
+    - Note for whoever writes the message: docker's real syntax allows a third
+      field for options, such as `/a:/b:ro`. wr has never supported it - that
+      spec is exactly the case that silently collapses to `("/a", "/a")` today -
+      so rejecting it is not a removal of a working feature. The message should
+      say what the supported format IS, not only that the value is wrong.
+    - Fixed in `containerMountsMessage` (`jobqueue/job.go`), which is the one
+      function all 4 routes reach, verified by the implementor rather than
+      taken from the item: `jobqueue/serverREST.go:1676` (REST add),
+      `jobqueue/job.go:1308` (`malformedAddJobMessage`, reached from
+      `addValidationError` in `client.go` and from `serverCLI.go:826`),
+      `job.go:2283` (`modifiedContainerMountsMessage`) and `job.go:2317`
+      (`validationMessage`). A grep for every caller of both the method and the
+      function confirms there is no fifth.
+    - The check goes FIRST in the loop, before the absolute-path check,
+      because `MountSpecPaths` answers a multi-colon spec with its local path
+      twice, which would otherwise look like a pair of perfectly absolute
+      paths.
+    - Message, and it names the offending mount separately from the whole
+      value, which matters when commas made the value multi-mount:
+
+      ```
+      ContainerMounts "/data/opt:/opt:ro" is invalid: mount "/data/opt:/opt:ro"
+      has more than one colon; each mount must be /outside/container or
+      /outside/container:/inside/container, and mount options such as ":ro" are
+      not supported
+      ```
+
+      Traced to where a user sees it, not assumed: `cmd/add.go:556`/`:573`
+      `die("%s", err)` on the Add error, and `Error.Error()`
+      (`jobqueue/server.go:510`) renders it as
+      `jobqueue add(<item>): bad request`.
+    - Red command: a new case in `malformedAddTests()`
+      (`jobqueue/client_payload_test.go`), the table whose doc comment says it
+      holds one case per check `malformedAddJobMessage` makes.
+      `TestClientAddErrorNamesTheProblem` runs every case through all 4 public
+      Add entry points. Red before the fix at `Line 987`,
+      `So(errors.As(err, &jqErr), ShouldBeTrue)` `Expected: true Actual: false`
+      x4 - once per Add variant, because `err` was nil and the spec was
+      accepted.
+    - `MountSpecPaths` itself is UNCHANGED, deliberately, with 3 reasons:
+      hardening it would centralise nothing, since `singularityMounts` never
+      calls it and shell-quotes the raw spec straight into `-B`; rejection
+      cannot be expressed in a 2-string return without breaking an exported
+      signature that `dockerMounts` and `DockerRunCmd` depend on; and changing
+      the >2-part return to `parts[0], parts[1]` would silently RELOCATE the
+      bind mount of a job already stored with such a spec, which still loads
+      and runs, while still dropping the option they asked for.
+    - The residual gap is named rather than papered over: a Go API caller who
+      builds a `Job` and calls `container.DockerRunCmd` directly, bypassing
+      jobqueue validation, still gets the silent collapse. `MountSpecPaths`'s
+      doc comment now records that as the deliberate contract, replacing the
+      text that recorded it as an open question.
+    - Bounds proved: a 1-part spec still works (`container/run_test.go:169`
+      and `:196` both drive `/foo/car` with no colon, and
+      `containerMountsWellFormed = "/data/set:/data,/other"` is the value every
+      "is accepted" assertion uses); a valid 2-part spec is unchanged;
+      `TestKeyByteIdentity` and `TestJob` pass, and the key path concatenates
+      `ContainerMounts` verbatim and never calls `MountSpecPaths`; and jobs
+      already stored with a multi-colon spec still load, since
+      `db.recoverIncompleteJobs` and `server.go:1735` do no validation and
+      `modify_validation_test.go:313` already exercises that path.
+
+- [ ] **For the repo owner, before merging: this is a small capability
+  REMOVAL for singularity users, not purely a fix.** The item above assumed a
+  multi-colon spec is always the silent-collapse case. That is true only on
+  the docker path, which goes through `MountSpecPaths`.
+  `singularityMounts` (`container/run.go`) never calls it - it shell-quotes
+  the whole spec and emits `-B '/a:/b:ro'`.
+    - Checked against the real tool on this box rather than by reading code.
+      `singularity exec --help`, singularity-ce 4.1.1:
+
+      ```
+      -B, --bind strings   a user-bind path specification. spec
+                           has the format src[:dest[:opts]],
+                           where src and dest are outside and
+                           inside paths.
+      ```
+
+      So `/a:/b:ro` is a valid, WORKING singularity bind spec today, and this
+      change rejects it at submission. Already-queued jobs keep running;
+      only new submissions are refused.
+    - Implemented as decided rather than narrowed to docker, because
+      `ContainerMounts` is one field and its meaning should not depend on
+      which image field is set: supporting options only for singularity is its
+      own trap, and a user moving a job from singularity to docker would
+      silently lose them. It is also why the message says "mount options such
+      as \":ro\" are not supported" rather than only "invalid" - the
+      singularity user is the one who will be surprised.
+    - If the owner would rather reject only on the docker path, that is a
+      small change to the same one function.

--- a/.docs/bugfixes/260909-reject-multi-colon-mounts.md
+++ b/.docs/bugfixes/260909-reject-multi-colon-mounts.md
@@ -212,3 +212,39 @@ reject-multi-colon-mounts
       reduced to bare file names rather than re-pinned, since the next rebase
       would stale them again. Function and identifier names are what make a
       reference findable.
+
+- [x] Sighting only, provably NOT caused by this branch:
+  `TestReliable4RacBoundedBySchedulable`
+  (`jobqueue/reliable4_rac_bound_test.go`, the
+  `So(scanWork, ShouldEqual, limit)` at the "only the schedulable (limit) jobs
+  incur the expensive prepareReadyJob work" Convey) failed on CI for
+  `ec0966ca`: `Expected: 5 Actual: 19`. CI run 34342089929.
+    - Decisively not this commit's: `git diff --name-only 5fc08d00 ec0966ca`
+      is 2 `.md` files and nothing else, so the compiled code is BYTE-IDENTICAL
+      to `5fc08d00`, on which the same CI `test` job had already passed. A
+      commit that changes no code cannot change a test result.
+    - Not reproducible on this box: 20/20 green plain, and 12/12 green under 6
+      spinning CPU hogs. `make test` had also passed twice on this exact code
+      locally, at `640 passed · 13 skipped`.
+    - What the assertion means: the test pins that the scheduler does the
+      expensive `prepareReadyJob` work for EXACTLY the number of schedulable
+      jobs, which is the bound `.docs/bugfixes/260725-2.md` introduced the test
+      to protect. CI measured 19 against a limit of 5, so more of the backlog
+      was scanned than the bound allows.
+    - So it is either a genuine bound violation that only a slower, contended
+      machine exposes, or an assertion that is too tight to hold under
+      scheduling jitter. Worth the repo owner deciding which, because the 2
+      answers are very different: the first is a real performance regression
+      hiding in a flake, the second is a test to loosen. `ShouldEqual` on a
+      work COUNT is the kind of assertion that is exact by design here - the
+      whole point of `260725-2` was that the count used to be the whole
+      backlog - so it should not simply be relaxed without establishing which
+      it is.
+    - Remedy applied here: re-ran the CI job on the unchanged commit, as the
+      repo does for its other load-sensitive tests. It PASSED, which confirms
+      the failure is intermittent on CI rather than deterministic - but note
+      that this does not distinguish the 2 explanations above, since a real
+      bound violation exposed only under contention would also pass on a
+      quieter runner. This is a NEW name for
+      that family; it is not on the known list and no prior bugfix doc records
+      it as flaky, only as a test that was added and passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,17 @@ project adheres to [Semantic Versioning](http://semver.org/).
   `cleanup` behaviours; previously a root-owned file or directory left your
   working directory littered and the command's workspace undeletable. Only
   docker is affected: singularity already ran your commands as you.
-- `wr add` and `wr mod` now refuse a `--container_mounts` value in which any
-  single mount has more than one colon, naming the offending mount and the
-  supported format: `/outside/container`, or
-  `/outside/container:/inside/container`. If you use `--with_singularity`, a
-  mount option such as the `:ro` in `/data/opt:/opt:ro` did reach
-  `singularity -B` and really did make the mount read-only; it is no longer
-  accepted, so drop it from new submissions and modifications. Commands already
-  in the queue keep running with the mounts they were added with.
+- wr now refuses a `--container_mounts` value in which any single mount has more
+  than one colon, naming the offending mount and the supported format:
+  `/outside/container`, or `/outside/container:/inside/container`. `wr add`
+  refuses it when you also give `--with_docker` or `--with_singularity`, since
+  without an image the mounts are unused; `wr mod` refuses it whenever you set
+  `--container_mounts`, and also refuses to add an image to a job whose existing
+  mounts have this problem. If you use `--with_singularity`, a mount option such
+  as the `:ro` in `/data/opt:/opt:ro` did reach `singularity -B` and really did
+  make the mount read-only; it is no longer accepted, so drop it from new
+  submissions and modifications. Commands already in the queue keep running with
+  the mounts they were added with.
 
 ### Fixed
 - With `--with_docker`, a `--container_mounts` mount with more than one colon,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,21 @@ project adheres to [Semantic Versioning](http://semver.org/).
   `cleanup` behaviours; previously a root-owned file or directory left your
   working directory littered and the command's workspace undeletable. Only
   docker is affected: singularity already ran your commands as you.
+- `wr add` and `wr mod` now refuse a `--container_mounts` value in which any
+  single mount has more than one colon, naming the offending mount and the
+  supported format: `/outside/container`, or
+  `/outside/container:/inside/container`. If you use `--with_singularity`, a
+  mount option such as the `:ro` in `/data/opt:/opt:ro` did reach
+  `singularity -B` and really did make the mount read-only; it is no longer
+  accepted, so drop it from new submissions and modifications. Commands already
+  in the queue keep running with the mounts they were added with.
 
 ### Fixed
+- With `--with_docker`, a `--container_mounts` mount with more than one colon,
+  such as `/data/opt:/opt:ro`, silently mounted your local path at that same
+  path inside the container, dropping both the in-container path and the option
+  you asked for. Such a value is now rejected instead of quietly meaning
+  something else.
 - With `--monitor_docker '?'`, wr could charge another container's RAM to your
   job as its peak, and SIGKILL a container it never started, whenever more than
   one container appeared while the job ran; on a shared machine that other

--- a/container/run.go
+++ b/container/run.go
@@ -174,12 +174,13 @@ func dockerMounts(mounts []string) string {
 // "/local/path[:/inside/container/path]" in to its local path and its path
 // inside the container. The 2 are the same when the spec has no colon.
 //
-// A spec with 2 or more colons has no meaning in this format, and jobqueue
-// rejects one as a job is added or modified, so only a job stored before that
-// check existed can still carry one. For those, this gives the local path twice,
-// as the code this was extracted from did: "/a:/b:ro" gives ("/a", "/a"). Making
-// it ("/a", "/b") here would silently move an already-stored job's mount, and
-// would still drop the "ro" the user asked for.
+// A spec with 2 or more colons has no meaning in this format. jobqueue rejects
+// one as a job with a container image is added, and as any job's mounts or image
+// are modified, but a job added with no image keeps its spec unchecked, and a Go
+// caller of this package is not guarded at all. Such a spec gives the local path
+// twice, as the code this was extracted from did: "/a:/b:ro" gives ("/a", "/a").
+// Making it ("/a", "/b") here would silently move an already-stored job's mount,
+// and would still drop the "ro" the user asked for.
 func MountSpecPaths(spec string) (local, inContainer string) {
 	parts := strings.Split(spec, ":")
 

--- a/container/run.go
+++ b/container/run.go
@@ -172,14 +172,14 @@ func dockerMounts(mounts []string) string {
 
 // MountSpecPaths splits a mount specification in the form
 // "/local/path[:/inside/container/path]" in to its local path and its path
-// inside the container.
+// inside the container. The 2 are the same when the spec has no colon.
 //
-// The 2 are the same when the spec has no colon, and - preserving the behaviour
-// of the code this was extracted from - also when it has 2 or more, so "/a:/b:ro"
-// gives ("/a", "/a") rather than ("/a", "/b"). One consequence is that
-// jobqueue's containerMountsMessage then checks the local path twice and never
-// inspects the in-container one. What a 3-part spec should mean is a user-facing
-// format question, so the behaviour is left as it was.
+// A spec with 2 or more colons has no meaning in this format, and jobqueue
+// rejects one as a job is added or modified, so only a job stored before that
+// check existed can still carry one. For those, this gives the local path twice,
+// as the code this was extracted from did: "/a:/b:ro" gives ("/a", "/a"). Making
+// it ("/a", "/b") here would silently move an already-stored job's mount, and
+// would still drop the "ro" the user asked for.
 func MountSpecPaths(spec string) (local, inContainer string) {
 	parts := strings.Split(spec, ":")
 

--- a/jobqueue/client_payload_test.go
+++ b/jobqueue/client_payload_test.go
@@ -75,6 +75,11 @@ const (
 	// the comma advice would be irrelevant to it.
 	containerMountsRelative = "data:/data"
 
+	// containerMountsWithOptions asks for a docker mount option, which wr has
+	// never supported, and which has 2 colons and so no in-container path wr
+	// can work out.
+	containerMountsWithOptions = "/data/opt:/opt:ro"
+
 	// nilBehaviourItem is the item a malformed add names when the second
 	// behaviour of the second job is nil.
 	nilBehaviourItem = "jobs[1].Behaviours[1] is nil"
@@ -1024,6 +1029,16 @@ func malformedAddTests() []struct {
 				containerMountsWithComma, "1"),
 			jobs: func(valid *Job) []*Job {
 				return []*Job{valid, containerMountsJob(containerMountsWithComma, containerMountsTestImage, "")}
+			},
+		},
+		{
+			name: "a mount option after a second colon",
+			item: fmt.Sprintf("jobs[1].ContainerMounts %q is invalid: mount %q has more than one colon; "+
+				"each mount must be /outside/container or /outside/container:/inside/container, "+
+				"and mount options such as \":ro\" are not supported",
+				containerMountsWithOptions, containerMountsWithOptions),
+			jobs: func(valid *Job) []*Job {
+				return []*Job{valid, containerMountsJob(containerMountsWithOptions, containerMountsTestImage, "")}
 			},
 		},
 		{

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1423,12 +1423,21 @@ func (ms *mountState) buildRemoteConfigs(mc MountConfig, defaultCacheBase string
 // malformed mounts before the container runtime ever sees it. Quoting can't fix
 // that, but the detectable symptom is a resulting path that isn't absolute,
 // which a bind mount path has to be anyway.
+//
+// A colon separates the 2 paths of a mount, so a second colon leaves a field wr
+// has no meaning for. That is checked first, because container.MountSpecPaths
+// answers such a spec with its local path twice, which would otherwise look like
+// a pair of perfectly absolute paths.
 func containerMountsMessage(containerMounts string) string {
 	if containerMounts == "" {
 		return ""
 	}
 
 	for _, spec := range strings.Split(containerMounts, ",") {
+		if strings.Count(spec, ":") > 1 {
+			return containerMountsMultiColonMessage(containerMounts, spec)
+		}
+
 		local, inContainer := container.MountSpecPaths(spec)
 
 		for _, path := range []string{local, inContainer} {
@@ -1439,6 +1448,20 @@ func containerMountsMessage(containerMounts string) string {
 	}
 
 	return ""
+}
+
+// containerMountsMultiColonMessage describes a ContainerMounts value rejected
+// because spec has more than one colon.
+//
+// Docker's own --mount syntax gives a third field to mount options, but wr has
+// never passed one on: such a spec used to be read as its local path twice, so
+// the container got a mount the user never asked for. The message therefore
+// names the whole supported format, since a user who wrote ":ro" needs to know
+// wr has no way to express it rather than just that their value was refused.
+func containerMountsMultiColonMessage(containerMounts, spec string) string {
+	return fmt.Sprintf("ContainerMounts %q is invalid: mount %q has more than one colon; "+
+		"each mount must be /outside/container or /outside/container:/inside/container, "+
+		"and mount options such as %q are not supported", containerMounts, spec, ":ro")
 }
 
 // containerMountsInvalidMessage describes a ContainerMounts value rejected


### PR DESCRIPTION
`container.MountSpecPaths` splits a mount spec on `:` and returns
`parts[0], parts[1]` only when there are exactly two parts. For anything else it
returns `parts[0], parts[0]`. So `/data/a:b:/mnt` yielded source **and** target
both `/data/a`, silently dropping the `/mnt` the user asked for.

The validation added by #587 did not catch it. `containerMountsMessage` checked
that both returned paths were absolute, but for a three-part spec both **are**
`parts[0]`, so it inspected the same path twice, never saw the in-container one,
and accepted the value.

The behaviour was already recorded as a known open question in
`MountSpecPaths`'s own doc comment: *"What a 3-part spec should mean is a
user-facing format question, so the behaviour is left as it was."*

## The fix

Reject in `containerMountsMessage`, which is the one function all four
submission and modification routes reach: `serverREST.go` (REST add),
`malformedAddJobMessage` (client and CLI add), `modifiedContainerMountsMessage`
and `JobModifier.validationMessage`. The check goes first in the loop, before
the absolute-path check, because `MountSpecPaths` answers a multi-colon spec
with its local path twice, which would otherwise look like a pair of perfectly
absolute paths.

The message names the offending mount separately from the whole value, which
matters when commas made the value multi-mount, and states the supported format
rather than only that the value is wrong:

```
jobqueue add(jobs[0].ContainerMounts "/data/opt:/opt:ro" is invalid: mount
"/data/opt:/opt:ro" has more than one colon; each mount must be
/outside/container or /outside/container:/inside/container, and mount options
such as ":ro" are not supported): bad request
```

That was read off a real terminal against a real manager, not inferred.

## This removes something that worked, for singularity users

`singularityMounts` never calls `MountSpecPaths` — it shell-quotes the spec
straight into `singularity -B`, whose documented format is `src[:dest[:opts]]`.
So `/a:/b:ro` gave a genuine read-only bind mount. Proved against
singularity-ce 4.1.1 with a real sandbox:

```
singularity exec -B $SRC:/mnt/x:ro sbox sh -c 'echo nope > /mnt/x/w.txt'
  sh: can't create /mnt/x/w.txt: Read-only file system   exit=1
singularity exec -B $SRC:/mnt/x    sbox sh -c 'echo yes  > /mnt/x/w.txt'
  exit=0
```

It is rejected for both runtimes rather than docker only, on two grounds. The
published contract is already two-field: `Job.ContainerMounts`'s own doc says
`/outside/container/path[:/inside/container/path]`, and both `--container_mounts`
helps say only "mount additional locations", so the singularity support is
undocumented and accidental. And `ContainerMounts` is one field whose meaning
should not depend on which image flag is set.

Already-queued jobs keep running; only new submissions and modifications are
refused. The CHANGELOG says so under **Changed**, not buried under Fixed, so a
singularity user scanning for what might break them will see it.

A follow-up worth having, not done here: support `:ro` properly on both
runtimes — singularity `:ro`, docker `--mount ...,readonly` — which would turn a
removal into a capability everyone gets.

## What is deliberately not rejected

**Selection.** `wr kill -l "cmd" --with_docker img --container_mounts /a:/b:ro`
is not refused; it simply matches nothing. That asymmetry with `add` is correct:
selection is the only command-line route to a legacy job stored with such a
spec, and rejecting it would leave those jobs reachable only by rep group or
internal id.

**A job added with no container image.** `(*Job).containerMountsMessage()`
returns `""` when no image is set, so such a job keeps its spec unchecked. Its
mounts are inert, and setting an image later *is* validated. Closing that is a
one-line behaviour decision, left to the repo owner.

**`MountSpecPaths` itself.** Unchanged, for three reasons: hardening it would
centralise nothing, since `singularityMounts` never calls it; rejection cannot
be expressed in a two-string return without breaking an exported signature; and
changing the `>2`-part return to `parts[0], parts[1]` would silently relocate
the bind mount of a job already stored with such a spec, while still dropping
the option. Its doc comment now records what actually guards it — including that
a Go caller of the `container` package is not guarded at all — instead of
recording the behaviour as an open question.

## Tests

A new case in `malformedAddTests()`, the table whose doc comment says it holds
one case per check `malformedAddJobMessage` makes.
`TestClientAddErrorNamesTheProblem` runs every case through all four public Add
entry points against a real client and server, asserting the exact error the
caller gets and that the batch was neither sent nor queued.

Proved load-bearing: with the guard removed it fails four times, once per Add
variant, at `errors.As(err, &jqErr)` returning false because the spec was
accepted.

Bounds checked rather than assumed: a one-part spec (`/data`) and a valid
two-part spec are unaffected; `/a:` and `:/b` still fail on the pre-existing
absolute-path branch; `Job.Key()` is untouched and `TestKeyByteIdentity` and
`TestJob` pass; and a job already stored with a multi-colon spec still loads,
verified by adding one, restarting a real manager and seeing it recovered.

Full write-up in `.docs/bugfixes/260909-reject-multi-colon-mounts.md`.
