### PR TITLE
Give each job the environment it was promised

### DIFF
--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -1,0 +1,145 @@
+# Bugfixes 2026-09-09
+
+fix-env-propagation
+
+Three defects in how wr propagates an environment into a job, recorded but not
+fixed by `origin/record-env-propagation` (`.docs/bugfixes/260903-7.md`, commit
+`00011cf8`). All three were re-verified against `develop` at `0cc79218` before
+this branch started; the record's line numbers had all moved, so this file names
+functions instead.
+
+Deliberately no `file.go:NNN` references anywhere below: PR #591 shipped with
+stale ones after 3 rebases, and Copilot caught it. Function and identifier names
+stay findable.
+
+- [ ] 1. `envOverride` (`jobqueue/utils.go`) overrides only the FIRST
+  occurrence of a duplicated variable name, because it DELETES the map entry as
+  it uses it:
+
+  ```go
+  if replace, do := override[pair[0]]; do {
+      env[i] = replace
+
+      delete(override, pair[0])
+  }
+  ```
+
+  A second entry with the same name therefore keeps its original value, and no
+  appended copy is added either, because the append loop at the end only walks
+  what is left in the map.
+    - `os.Environ()` normally has no duplicates, but a Job's stored environment
+      is whatever the client sent, compressed at add time, and that CAN have
+      them.
+    - It matters because the overrides on this path are wr's OWN guarantees,
+      not user preferences: `TMPDIR`, `HOME` for `--change_home`, the bsub
+      `PATH` prepend, and `WR_MANAGER_HOST`/`PORT`.
+    - Which value the command then sees is up to the child: libc `getenv`
+      returns the first match, so the override wins; some shells and runtimes
+      rebuild their environment last-wins, so the stale one wins. Either way wr
+      has stopped controlling the answer.
+    - Nothing needs the entry deleted.
+
+- [ ] 2. `cmd/runner.go` accumulates `envOverrides` ACROSS reserve-loop
+  iterations. The slice is declared once, outside the loop, alongside
+  `exePath`, and appended to inside it: for each job the runner reads that job's
+  own `PATH` and, if it does not already contain the runner's exe directory,
+  appends `PATH=<this job's PATH>:<exePath>`. Nothing resets it between jobs.
+    - The victim is not the job that appends. `envOverride` builds its map
+      last-wins, so a job that appends its own `PATH` gets the right one. It is
+      the job that appends NOTHING: one whose `PATH` already contains `exePath`
+      skips the append, and `EnvAddOverride` is then handed the PREVIOUS job's
+      `PATH` line, so the command runs with an unrelated job's `PATH` and can
+      resolve the wrong binaries.
+    - A runner executes many jobs in sequence, so one job with a different
+      `PATH` poisons every later job in that runner that would otherwise have
+      needed no override. The slice also grows one `PATH=` entry per job for
+      the life of the runner.
+    - Fix shape: a per-iteration copy of the base overrides. The base
+      (`WR_MANAGERHOST`, `WR_MANAGERPORT`, `WR_MANAGERCERTDOMAIN`) is genuinely
+      loop-invariant; the `PATH` line is not.
+
+- [x] 3. `containerEnv` (`jobqueue/job.go`) splits `K=V` on ":" and truncates
+  the value. It means to reduce the job's overridden environment to the NAMES
+  of the variables, so `DockerRunCmd` can emit `-e NAME` and let docker copy
+  the value in from the environment. It splits on the wrong character:
+
+  ```go
+  parts := strings.Split(envvar, ":")
+  names[i] = parts[0]
+  ```
+
+    - Entries are `K=V`, so for `PATH=/usr/local/bin:/usr/bin` the "name"
+      becomes `PATH=/usr/local/bin`, and `dockerEnv` emits
+      `-e PATH=/usr/local/bin`. Docker treats `-e K=V` as an ASSIGNMENT, so a
+      `--with_docker` job runs with its `PATH` truncated at the first colon,
+      and likewise for any other colon-bearing value: `LD_LIBRARY_PATH`,
+      `MANPATH`, `PYTHONPATH`.
+    - A value with no colon is passed as a full `K=V` assignment too, which
+      happens to be harmless only by accident.
+    - User experience: a containerised job cannot find binaries that are on its
+      `PATH` outside the container, and the "command not found" says nothing
+      about the environment.
+    - Splitting on "=" and taking `parts[0]` is what the function's own doc
+      comment describes.
+    - Fixed with `name, _, _ := strings.Cut(envvar, "=")`. `strings.SplitN(envvar,
+      "=", 2)` was tried first and `make lint` rejected it: `Magic number: 2, in
+      <argument> detected (mnd)`. `Cut` is the better answer anyway - it is the
+      idiomatic form for "split on the first separator", allocates no slice, and
+      needs no named constant.
+    - An existing test had CODIFIED the bug and had to be corrected, which is
+      the part worth knowing about. `That can include additional mounts and env
+      vars` asserted `-e FOO=bar -e OOF=rab`. Both fixtures are colon-free, so
+      the old `Split(envvar, ":")[0]` returned the whole `K=V` string and the
+      test locked that in. `git log -S` shows the split and the assertion
+      arrived together in `f7995da3` (Nov 2021), and the doc comment written in
+      that SAME commit already said the function returns variable NAMES - so
+      the code contradicted its own doc from day one and the test froze the
+      contradiction. Three later commits reshuffled the assertion without
+      re-examining it. Corrected to `-e FOO -e OOF`; it still asserts the same
+      2 variables, the same arg form, the same position in the full command and
+      the same order-agnostic check, losing only the value text, which was the
+      wrong part.
+    - The correction is a real behaviour change for COLON-FREE values, from an
+      explicit `-e K=V` assignment to `-e K` copy-from-environment, so it was
+      checked empirically rather than argued. The reviewer traced
+      `Client.Execute` -> `prepareCommand`/`buildExecCmd` -> `cmd.Env =
+      job.Env()`, where `Job.Env()` runs the stored env through
+      `applyEnvOverrides` -> `envOverride`, so the shell that runs `docker run`
+      already holds the overridden environment that `-e K` copies from. It then
+      replicated those exact steps in a throwaway test against real docker
+      29.1.3 and `alpine:latest`:
+
+      ```
+      with the fix:      -e PATH -e COLONFREE      IN_PATH=[/opt/wrtest/bin:/opt/go/bin:...:/bin]  IN_COLONFREE=[plainvalue]
+      with it reverted:  -e PATH=/opt/wrtest/bin   IN_PATH=[/opt/wrtest/bin]                       IN_COLONFREE=[plainvalue]
+      ```
+
+      So the colon-free value survives BOTH forms, and only the colon-bearing
+      one was being truncated. No override is dropped. `container/run.go`'s own
+      doc comments already stated this contract; the fix restores documented
+      behaviour rather than inventing it.
+    - Red proved by mutation: reverting to the ":" split turns 2 assertions red,
+      the new one at the `-e PATH=/usr/local/sbin` symptom and the corrected one
+      at `-e FOO=bar -e OOF=rab`.
+    - Edge cases, each run rather than reasoned: `FOO=a=b` -> `FOO`; `FOO=` ->
+      `FOO`; `NOEQUALS` -> the whole string, unchanged from before, and docker
+      silently omits a name it cannot resolve (exit 0, verified); `=value` ->
+      the empty name, which docker rejects with exit 125. No guard added for
+      the last: the old code was equally fatal there, so it is not a
+      regression, and the right home for that check is input validation in
+      `SetEnvOverride`, not here.
+    - Singularity is untouched: `containerRunCmd` returns on the
+      `WithDocker == ""` branch BEFORE reaching `containerEnv`, and a repo-wide
+      grep including tests shows `containerEnv` has exactly one caller.
+      `SingularityRunCmd` takes no env argument at all.
+    - Interaction to keep in mind while doing item 1, found by the reviewer:
+      `-e K` is now sensitive to item 1's bug. If a job's stored env has a
+      duplicated name and an override targets it, `envOverride` replaces only
+      the first and leaves the stale second, and `os/exec` dedups `Cmd.Env`
+      LAST-WINS (verified: `[FOO=new, BAR=x, FOO=stale]` yields `stale`). So
+      docker would copy the stale value, where the old `-e K=V` forced the
+      override's. It needs a duplicated stored env to bite, and item 1 fixes
+      the cause - but item 1 now protects this path too, not just its own.
+    - Pre-existing typo noted, not fixed here: "envionrment" in
+      `containerEnv`'s doc comment. Worth sweeping when that comment is next
+      touched.

--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -12,7 +12,7 @@ Deliberately no `file.go:NNN` references anywhere below: PR #591 shipped with
 stale ones after 3 rebases, and Copilot caught it. Function and identifier names
 stay findable.
 
-- [ ] 1. `envOverride` (`jobqueue/utils.go`) overrides only the FIRST
+- [x] 1. `envOverride` (`jobqueue/utils.go`) overrides only the FIRST
   occurrence of a duplicated variable name, because it DELETES the map entry as
   it uses it:
 
@@ -143,3 +143,85 @@ stay findable.
     - Pre-existing typo noted, not fixed here: "envionrment" in
       `containerEnv`'s doc comment. Worth sweeping when that comment is next
       touched.
+
+## Item 1, as fixed
+
+- Stopping the delete was not enough on its own. The trailing append loop USED
+  the delete as its signal for "this override went unused", so removing it
+  alone would have appended a second copy of every override already applied,
+  turning a stale-value bug into a duplicate-entry bug. That signal is now an
+  explicit `applied map[string]bool`, marked in the replacement loop.
+- The append loop now ranges the caller's `over` slice rather than the map,
+  reading each value back by name. Two gains in one change: `applied` already
+  provides the skip test, so iterating the map bought nothing, and iterating
+  the input makes the appended ORDER deterministic - caller order, where it
+  used to be Go's randomised map order. Marking `applied` as it appends stops a
+  name given twice in `over` being appended twice, while `override[name]`
+  keeps the existing last-wins value.
+- `envName(envvar string) string` extracted using `strings.Cut`, now that name
+  extraction happens 3 times in the function. Verified behaviourally identical
+  to the `strings.Split(envvar, "=")[0]` it replaces across `"" "=" "=v" "A"
+  "A=" "A=1" "A=1=2" "==" "a b=c"` and a NUL-containing name: zero mismatches.
+- Output length is IDENTICAL to the old implementation's, not merely no larger.
+  The reviewer ran both side by side over 13 shapes; every one reported
+  SAME-LEN. The old code appended exactly the names never matched in `orig`
+  (the un-deleted map remainder); the new code appends exactly the names not in
+  `applied`. Same set.
+- Regression test `TestEnvOverrideDuplicates` (`jobqueue/utils_test.go`) drives
+  `Job.Env()`, not `envOverride`. That is the exported call whose result
+  becomes `cmd.Env` in `Client.Execute`, and it is the only seam where the 2
+  halves of the bug meet: a stored environment that came from a client, which
+  CAN hold duplicates unlike `os.Environ()`, and an override applied to it.
+- Red proved 25/25, deterministic in both directions:
+  `Expected ["WR_DUP=fresh" "WR_OTHER=other" "WR_DUP=fresh"]` against
+  `Actual [... "WR_DUP=staler"]`. Post-fix, 25/25 green.
+- CORRECTION to the implementor's own report: it described the SECOND Convey as
+  intermittently red "five passes and one failure in six". The reviewer
+  measured 4 failures in 25, about 16%. The Convey that actually guards the bug
+  is the first, and that one is fully deterministic. Recorded because an
+  intermittent red is only an intermittent guard, and the distinction between
+  the 2 Conveys matters.
+- A line had NO test behind it, found by the reviewer deleting it: the append
+  loop's `applied[name] = true`. The whole gate stayed green without it, yet
+  its absence makes the result GAIN an entry and breaks the length invariant
+  above. Not hypothetical either - `cmd/runner.go` accumulates `envOverrides`
+  across its reserve loop (item 2, still open), so a repeated name in `over`
+  happens in production today. Closed with a third Convey, proved red under
+  that exact mutation:
+  `Actual [... "WR_NEW=two", "WR_NEW=two"]`.
+- The interaction with item 3 was settled against real docker 29.1.3, not
+  argued. A Job whose stored env names `WR_DUP` twice, with an override for it,
+  run through the same wiring `Client.Execute` uses:
+
+  ```
+  with this fix:      job.Env() = [WR_DUP=fresh, WR_OTHER=other, WR_DUP=fresh]   container prints "fresh"
+  utils.go reverted:  job.Env() = [WR_DUP=fresh, WR_OTHER=other, WR_DUP=staler]  container prints "staler"
+  ```
+
+  So item 3's `-e NAME` form really was handing the stale duplicate to the
+  container, and this fixes it. The `os/exec` last-wins dedup was confirmed in
+  the same run by the host's own `printenv`.
+- Aliasing checked, pre-existing and harmless: `env := orig` then `env[i] = ...`
+  mutates the caller's backing array, and the fix now writes to MORE indices
+  than before. Every call site was traced - `applyEnvOverrides`,
+  `EnvAddOverride`, `envWithRunDirs`, `addBsubEnv` - and each passes a slice it
+  already owns.
+- No existing test asserted the old behaviour; the test diff is insertions
+  only.
+- `goconst` rejected the first test draft for 3 occurrences of a literal, the
+  same class of surprise as item 3's `mnd` rejection. Fixed with a
+  function-local `const` block.
+- Tooling problem, pre-existing and NOT caused by this branch, confirmed
+  independently by 2 agents and by running it on `HEAD`'s copy:
+  `cleanorder -min-diff jobqueue/utils_test.go` hoists `const testJobKey`,
+  `const mkHashedDirSweepTries` and 2 interface assertions to the top of the
+  file, stranding `TestCreatedCwdDepthMatchesMkHashedDir`'s doc comment
+  hundreds of lines from its function. Both agents reverted it and hand-placed
+  their additions. `make lint` is `0 issues.` either way, so nothing enforces
+  cleanorder's preference here. Someone should decide whether that file takes
+  the reorder as its own commit or whether cleanorder is simply wrong about
+  test files that document a constant through the test above it.
+- Tidies noted, both out of scope for this item: `Job.containerEnv()` in
+  `jobqueue/job.go` still inlines a 4th copy of the name extraction that
+  `envName` now owns, and `jobqueue/job_test.go`'s either-order hedge for 2 env
+  vars is now dead code, since the append order is deterministic.

--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -529,3 +529,73 @@ stay findable.
       header describes the accumulation in the PAST tense, as the bug this PR
       fixed, which is accurate. A repo-wide grep plus a scan of every comment
       line added by this branch found no other instance in Go code.
+
+- [x] Copilot review of the rebased head `cd99fc4a` (PR #592): `containerEnv`
+  is a FOURTH read path and item 4 missed it.
+    - Item 4 established that validation at the write routes cannot help a job
+      ALREADY STORED with a malformed entry, so the reads must degrade, and it
+      hardened 3 of them: `jobEnvOverrider.overridesFor`, `Job.Getenv` and
+      `prependedPath`. `containerEnv` was not touched, so a legacy job whose
+      stored overrides hold `""` or `=value` still produced
+      `docker run -e ''`, which docker rejects outright.
+    - This is a gap in the reasoning, not only the code: the principle was
+      stated correctly and then applied to 3 of 4 places.
+    - Proved end to end against real docker 29.1.3, through the actual
+      `Job.CmdLine()` output:
+
+      ```
+      pre-fix   ... -e '' -e FOO -e '' -i alpine /bin/sh
+                exit 125: invalid argument "" for "-e, --env" flag
+      post-fix  ... -e FOO -i alpine /bin/sh
+                exit 0: FOO is [bar]
+      ```
+
+    - One detail nearly let the bug survive its own fix: the slice was
+      `make([]string, len(overrideEs))`, so skipping an entry would have left a
+      trailing `""` - the same `-e ''`, at the end instead of the middle. It
+      needed `make([]string, 0, len(...))` with `append`, which is also the
+      shape `prealloc` wants.
+    - Skips SILENTLY, matching all 3 siblings, rather than logging. Item 4
+      recorded that silence as a known gap and named the runner as the single
+      right place to close it for every read at once; a log here alone would be
+      a 4th style, in a pure accessor with no logger, leaving the other 3
+      silent.
+    - One deliberate difference from the siblings, in the TEST rather than the
+      treatment: they skip on "no `=`", this skips on an empty NAME. A bare
+      `NOEQUALS` is a legitimate copy-from-environment argument - `-e NAME` is
+      exactly the form this function exists to emit - and was re-verified at
+      29.1.3 to give exit 0 with the variable unset. Skipping it would be a
+      behaviour change with no bug behind it. `""` and `=value` both yield the
+      empty name and are both covered.
+    - Took 2 tidies the earlier records had nominated: `containerEnv` now uses
+      the `envName` helper item 1 extracted, which item 3's write-up had
+      already flagged as the 4th inlined copy, and the `envionrment` typo in
+      its doc comment is fixed.
+
+- [x] The branch owed a CHANGELOG entry and had written NONE, which the
+  implementor caught rather than the orchestrator: `git log 098b2227..HEAD --
+  CHANGELOG.md` was empty, for 4 user-visible fixes and 1 behaviour change.
+    - Now 1 bullet under `### Changed` and 4 under `### Fixed`, grouped by what
+      a USER would recognise as one thing rather than by item number.
+    - Item 4 is deliberately SPLIT across both sections: the fix half ("you
+      were bitten and now you are not") and the validation half ("your working
+      command line may now error") go to different readers, and putting both in
+      Fixed would hide a breaking change inside a list of repairs.
+    - Items 4-fix and 5 are MERGED, because a user recognises one thing: an env
+      entry that names no variable no longer breaks their job.
+    - Items 1 and 2 are kept apart despite both being "wrong environment",
+      because the triggers differ - item 1 needs a repeated name in your own
+      environment, item 2 needs nothing from you beyond sharing a runner - so
+      someone hitting one would not recognise the other's description.
+    - The behaviour change leads the section, enumerates all 3 now-rejected
+      shapes with a literal example of each, gives the remedy for the likeliest
+      (`--env PATH=$PATH`), names all the affected routes including both REST
+      verbs, and warns explicitly about a script that joins an `--env` list and
+      leaves a trailing comma.
+
+- [x] Tooling hazard found while doing this, worth knowing:
+  `golangci-lint run --fix` silently rewrites a doubled apostrophe `''` inside
+  a Go DOC COMMENT into a typographic close-quote, because gofmt's doc-comment
+  reformatter treats it as a quotation. It then reports `0 issues.` having
+  mangled the text. Anyone writing a shell-quoting example in a Go comment will
+  hit it; reword to avoid `''` rather than keeping the mangled character.

--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -39,7 +39,7 @@ stay findable.
       has stopped controlling the answer.
     - Nothing needs the entry deleted.
 
-- [ ] 2. `cmd/runner.go` accumulates `envOverrides` ACROSS reserve-loop
+- [x] 2. `cmd/runner.go` accumulates `envOverrides` ACROSS reserve-loop
   iterations. The slice is declared once, outside the loop, alongside
   `exePath`, and appended to inside it: for each job the runner reads that job's
   own `PATH` and, if it does not already contain the runner's exe directory,
@@ -225,3 +225,87 @@ stay findable.
   `jobqueue/job.go` still inlines a 4th copy of the name extraction that
   `envName` now owns, and `jobqueue/job_test.go`'s either-order hedge for 2 env
   vars is now dead code, since the append order is deterministic.
+
+## Item 2, as fixed
+
+- `cmd/runner.go` gained `jobEnvOverrider{base, exePath}` with one method,
+  `overridesFor(env) []string`, owning exactly the 2 things previously declared
+  outside the reserve loop. The PATH-scanning loop and its append moved into the
+  method verbatim. Each call returns `slices.Clone(j.base)` plus that job's own
+  `PATH` line, so nothing survives into the next job.
+- Why a struct and not a plain function, which is the interesting design point:
+  a pure `jobEnvOverrides(base, exePath, env)` CANNOT go red for this bug.
+  Extracting one silently fixes it, because the accumulation lives in the
+  caller's `envOverrides = append(...)`, and that line sits in a cobra `Run`
+  closure needing a live manager, scheduler and `jq.Execute` to reach. The
+  state that persists across jobs has to be inside the seam for a test to prove
+  it gone. The reviewer checked this reasoning and agreed, while noting the
+  implementor's "could NOT go red" was too absolute: a pure function CAN be
+  red-tested for "the base you hand me is not mutated", which is a different
+  half of the property.
+- Behaviour preservation verified line by line by the reviewer: the guard
+  `len(overrider.base) > 0` is equivalent to the old `len(envOverrides) > 0`
+  (`base` is non-empty iff `rserver != ""`, and the old in-loop append was
+  itself gated by that same condition so could never be what first made the
+  slice non-empty); both release paths, both `warn` texts and both exit reasons
+  are byte-identical; `job.Env()` and `job.EnvAddOverride` happen at the same
+  points.
+- Red proved, and reproduced independently by the reviewer: 3 of 5 Conveys go
+  red under the accumulating mutation.
+
+  ```
+  Line  99  Expected "/opt/wrtest/bin:/jobtwo/bin"   Actual "/jobone/bin:/usr/bin:/opt/wrtest/bin"
+  Line 112  Actual [...base..., "PATH=/jobone/bin:/usr/bin:/opt/wrtest/bin"]
+  Line 120  Actual [...base..., "PATH=...", "PATH=...", "PATH=..."]
+  ```
+
+  Line 99 is the poisoning, line 112 is the no-PATH victim, line 120 is the
+  growth: 3 jobs, 3 entries.
+- The growth is fully fixed, not just the wrong value. `overrider.base` is only
+  appended to during setup; after 3 jobs a 4th still gets exactly the 3 base
+  entries.
+- A test gap the reviewer PROVED and we closed: the test was blind to the
+  `slices.Clone`. Replacing it with `overrides := j.base` left the whole `cmd`
+  package green. The mechanical reason is capacity, and it is worth knowing:
+
+  ```
+  production-shaped base len/cap: 3 4   (var base; 3 appends onto nil -> cap 1,2,4)
+  test-literal base len/cap:      3 3   ([]string{a,b,c})
+  ```
+
+  In production `cap > len`, so a no-clone `append` writes into the shared
+  backing array and 2 successive results alias. The test's composite literal
+  had `cap == len`, so every append reallocated and the aliasing could not
+  occur AT ALL. Doubly blind, since `EnvAddOverride` also compresses each
+  result before the next call.
+- Closed by building the fixture the way the runner builds it - appending to
+  the field one at a time - and asserting one job's overrides still hold their
+  own values after a later job's call. Exactly one leaf goes red under
+  `overrides := j.base`, with
+  `Expected "PATH=/jobone/bin:..." Actual "PATH=/jobthree/bin:..."`, and the
+  other 5 stay green, which is itself the proof that they were blind.
+- A linter rule would have re-created the blindness, which is worth recording:
+  `prealloc` rejects `var base []string` followed by appends, suggesting
+  `make([]string, 0, 3)` - and that gives `cap == len`, the very shape that
+  hides the bug. Sidestepped by appending to the struct field instead, which
+  `prealloc` does not inspect and which matches production more closely anyway.
+- Tidies taken: the assertion on the private `overrider.base` field was dropped
+  as implementation-detail coupling, with no coverage lost because the
+  following behavioural assertion fails just the same on a grown base; and the
+  poisoned-run Convey was renamed to say that it depends on an earlier job.
+- The `break` in the PATH search is right and item 1 is what makes it right. It
+  takes the first `PATH` entry, matching libc `getenv`; with a duplicated
+  `PATH`, item 1 now replaces every copy with the same value, so the
+  first-match read and `os/exec`'s last-wins dedup agree. They could disagree
+  before item 1.
+- Item 2 removes the production source of repeated names in `over` that item
+  1's write-up cited when justifying `applied[name] = true`. That guard is
+  still correct and still needed, since a user can repeat a name through
+  `wr mod --env`, and item 1's third Convey still covers it - it simply no
+  longer has this caller behind it.
+- Pre-existing quirks found and deliberately left, neither a regression:
+  `strings.Contains(pair[1], exePath)` is a substring test rather than a
+  path-element one, so `PATH=/opt/wrtest/binx` counts as already containing
+  `/opt/wrtest/bin`; and with `PATH=A` (already containing exePath) followed by
+  `PATH=B` (not), the `break` skips the append and exec's last-wins gives `B`
+  without exePath.

--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -481,3 +481,51 @@ stay findable.
 - Also left, non-blocking: nothing is logged when a read skips a malformed
   stored entry, so a legacy job degrades silently. A `warn` in the runner would
   close the last "no diagnostic" case this item complained about.
+
+- [x] Copilot review of PR #592, both findings valid and both taken.
+    - `envOverride`'s doc said it "returns the new slice", hiding that it
+      assigns `env := orig` and mutates the caller's backing array in place -
+      and this branch's fix makes it write to MORE indices than before. The
+      implementor verified the behaviour rather than describing it from the
+      code, running the real function over 5 shapes:
+      * every replaced index is written through to `orig`, at EVERY duplicate
+        index now;
+      * when `cap(orig) > len(orig)` the append writes into `orig`'s own array
+        past its length, overwriting what another slice over that array sees;
+      * when the append must grow, the result is a fresh array and `orig` keeps
+        the replacements but not the appends - so whether a caller sees
+        appended entries is CAPACITY-dependent, and not something to rely on
+        either way;
+      * two results derived from the same over-capacity `orig` alias each
+        other, which is precisely the class of bug item 2's `slices.Clone`
+        guards against in `cmd/runner.go`.
+      The doc now says a caller holding `orig` can assume its length is
+      unchanged and nothing else.
+    - A test comment documented behaviour THIS PR removed, which is the sharper
+      finding: `TestEnvOverrideDuplicates`'s third Convey justified itself by
+      citing `cmd/runner.go` accumulating overrides across the reserve loop -
+      and item 2, 2 commits later on this same branch, deleted exactly that.
+      Stale on arrival.
+    - The correct remaining rationale was established, not invented, and the
+      duplicate case is NOT dead: `wr mod --env "A=1,A=2"` is accepted. Item
+      4's `compressUserEnv` rejects 3 shapes - empty, no "=", no name before
+      the "=" - and says nothing about a name repeating, and all 4 write routes
+      funnel through it. Proved by driving the exact call `cmd/mod.go` makes:
+      `SetEnvOverride("A=1,A=2")` returns nil and the stored override decodes
+      to `[A=1 A=2]`. Both of `envOverride`'s arguments can carry duplicates -
+      `over` via `applyEnvOverrides`, and `orig` via `EnvAddOverride`, which
+      the runner calls on every job it reserves.
+    - CORRECTION to this item's own opening claim, and it is worth having
+      exactly right: it said "`os.Environ()` NORMALLY has no duplicates". It
+      can never have them. Go's `syscall.copyenv` blanks every duplicate key -
+      the source comment is literally `// Clear duplicate keys.` - so it is a
+      language-level guarantee, not a convention. Confirmed by `syscall.Exec`ing
+      a binary with an `envp` containing the same key twice: the child's
+      `os.Environ()` reported only the first. So the justification for item 1
+      rests entirely on environments that came from a CLIENT, never on the
+      ambient one, and `wr add`'s own `addEnvVars` returns `os.Environ()` and
+      so contributes no duplicate either.
+    - Checked and NOT stale, having been suspected: `cmd/runner_env_test.go`'s
+      header describes the accumulation in the PAST tense, as the bug this PR
+      fixed, which is accurate. A repo-wide grep plus a scan of every comment
+      line added by this branch found no other instance in Go code.

--- a/.docs/bugfixes/260909-fix-env-propagation.md
+++ b/.docs/bugfixes/260909-fix-env-propagation.md
@@ -309,3 +309,175 @@ stay findable.
   `/opt/wrtest/bin`; and with `PATH=A` (already containing exePath) followed by
   `PATH=B` (not), the `break` skips the append and exec's last-wins gives `B`
   without exePath.
+
+- [x] 4. NOT in the original record, found while fixing item 2 and escalated by
+  its reviewer: **a one-typo command line crash-loops a scheduler group.** An
+  environment entry that is a bare NAME with no "=" makes the runner panic.
+    - `strings.Split("PATH", "=")` has length 1, and both
+      `jobEnvOverrider.overridesFor` (`cmd/runner.go`), `Job.Getenv`
+      (`jobqueue/job.go`) and `prependedPath` (`jobqueue/client.go`, on the
+      bsub path) index `pair[1]`. CORRECTION: this item named only the first 2
+      when filed; the 3rd was found by the implementor and confirmed by the
+      reviewer, and fixing only the named 2 would have left the bsub path
+      crash-looping:
+
+      ```
+      panic: runtime error: index out of range [1] with length 1
+        cmd.(*jobEnvOverrider).overridesFor(...) cmd/runner.go
+      ```
+
+    - PRE-EXISTING, not introduced by item 2's extraction. Proved by running
+      HEAD's own loop body, copied out of `git show HEAD:cmd/runner.go`, over
+      the identical env: same panic, same line, same input.
+    - Reachable from ordinary user input by 4 unvalidated routes, not the 1
+      first reported (this item said 3 when filed; the implementor found a
+      4th). Both `compressEnv(strings.Split(...))` sites take the value
+      verbatim:
+      * `wr add --env PATH` -> `JobDefaults.Env` ->
+        `jobqueue/serverREST.go`'s `compressEnv(strings.Split(jd.Env, ","))`.
+        This is the likeliest trigger and the one the implementor missed: the
+        flag help says "comma-separated list of key=value environment
+        variables", so a user writing `--env PATH` to mean "pass PATH through"
+        poisons the job at ADD time.
+      * `wr mod --env PATH` -> `JobModifier.SetEnvOverride` ->
+        `compressEnv(strings.Split(newVal, ","))`.
+      * `wr add` with a JSON line `{"cmd":..., "env":["PATH"]}`, and REST
+        `POST /rest/v1/jobs` with the same body -> `JobViaJSON.resolveEnvOverride`.
+        This is a SEPARATE route from `JobDefaults.Env` above, and is the 4th.
+      * REST `PATCH /rest/v1/jobs/<ids>` with `env: ["PATH"]` ->
+        `JobModifier.setEnvOverrideValues`. CORRECTION: this item said `PUT`
+        when filed; `restJobs` dispatches PATCH to `restJobsModifyResponse`
+        and rejects PUT as unsupported.
+    - `Job.Env()` -> `applyEnvOverrides` -> `envOverride` then faithfully
+      substitutes the bare `PATH` for the job's real `PATH=...` entry, or
+      appends it if absent, and the runner walks into `pair[1]`.
+    - Blast radius, which is why this is worth doing now. There is no
+      `recover()` anywhere in `cmd`. The runner dies with exit 2. The deferred
+      `jq.Disconnect()` closes the socket, so the reserved job is never
+      touched, times out on `ServerTimings.ItemTTR` and returns to the queue as
+      lost with `numrun` still 0 - so the manager spawns another runner, which
+      reserves the same poisoned job and dies the same way. Each dying runner
+      also takes down every other job it would have gone on to execute in its
+      sequence.
+    - Validation at entry is necessary but NOT sufficient, and this is the part
+      that decides the shape of the fix: it does nothing for a job ALREADY
+      STORED with a bare entry. Those exist in any database where someone has
+      already typed it, and they would keep crash-looping after an upgrade. So
+      both halves are needed:
+      * reject an env element with no "=" at every write route, with an error
+        that names the offending element and says what the format is; and
+      * make the 3 `pair[1]` reads non-panicking, so a stored bad entry
+        degrades instead of killing the runner.
+    - The second half is NOT the symptom-suppression `implementation-principles`
+      warns against, precisely because the first half is also being done. A
+      guard alone would leave the malformed entry in place, leave the user with
+      a silently broken `PATH` and no diagnostic, and leave `Job.Getenv`
+      panicking. A read accessor that panics on stored data is its own defect.
+
+## Item 4, as fixed
+
+- Half A: one new `compressUserEnv` in `jobqueue/utils.go`, beside `envName`
+  and `envOverride` which already own what an environment entry looks like. It
+  validates then delegates to `compressEnv`. `SetEnvOverride` was reduced to
+  call `setEnvOverrideValues`, which was its duplicate, so 4 routes are 3 call
+  sites of 1 implementation. Each route was proved individually load-bearing:
+  reverting any one of them to plain `compressEnv` reddens only that route.
+- The check is deliberately NOT inside `compressEnv`, and this is the crux of
+  the design. `Job.EnvAddOverride` re-compresses an environment ALREADY STORED
+  on a job, and the runner calls it on every job it reserves. Validating there
+  would make a legacy bad job fail `EnvAddOverride`, whose handler is
+  `jq.Release(job, nil, "failed to add env var overrides")` then `break` - so
+  the job returns to the queue and the runner exits, and the manager starts
+  another. That converts half B's degradation into a GRACEFUL crash-loop: the
+  same bug in a nicer coat.
+- The reviewer proved that rather than accepting it, by moving the check into
+  `compressEnv` and driving a legacy job through: `EnvAddOverride` returned
+  `environment variable is not in key=value format: "PATH"`, where the shipped
+  design returns nil.
+- It also proved the loop is genuinely INFINITE, which this item asserted
+  without proof. `Client.Release` passes `attempted=false`, and the server's
+  `releaseSpendsARetry` is `rep.attempted || !job.StartTime.IsZero()`. A job
+  released before execution has a zero `StartTime`, so no retry is spent,
+  `UntilBuried` never reaches 0, and the job is never buried. `Client.Release`'s
+  own doc says as much.
+- End-to-end proof on 2 real managers. Pre-fix build, job added with
+  `--env PATH`:
+
+  ```
+  lvl=eror msg="runCmd wait" cmd="... wr_head runner -s '1024:60:1:0:456997...'" err="exit status 2"
+  lvl=eror msg="runCmd wait" cmd="... wr_head runner -s '200:30:1:0:456997...'"  err="exit status 2"
+  poisoned : complete=0 running=1 ... buried=0
+  ```
+
+  Two runner deaths 2 minutes apart, job stuck running, never buried. Fixed
+  build, same job: `complete=1`, exit code 0, the bare entry STILL stored, and
+  the shell supplying its own default PATH.
+- Half B: 3 reads, not the 2 this item named. `prependedPath`
+  (`jobqueue/client.go`, reached from `Client.Execute` -> `addBsubEnv`) has the
+  same `pair[1]`, so a `--bsub` job crash-looped identically and fixing only
+  the named 2 would have left it alive. All 3 now use `strings.Cut` and skip an
+  entry with no "=", matching what `getenv(3)` does with one.
+- Degradations chosen: `overridesFor` skips it and keeps looking, so such a job
+  behaves exactly like a job with no PATH - it does NOT synthesise
+  `PATH=<exeDir>`, which would leave the command with a one-directory PATH,
+  worse than the shell's fallback. It is also strictly better than before on
+  `["PATH", "PATH=/real"]`, where the old code panicked on the first entry and
+  the new one walks past it to the real one. `Getenv` returns blank, its
+  existing answer for an absent variable. `prependedPath` falls through to its
+  no-PATH branch.
+- A SECOND pre-existing bug the same `Cut` fixes: `Split(...)[1]` truncated any
+  value containing a further "=". CORRECTION to how this was first described -
+  it was called a live bug on the grounds that `Getenv`'s only production
+  caller reads JSON (`WR_BSUB_CONFIG`). The reviewer marshalled the actual
+  struct: for a plain bsub job it is 1081 bytes containing NO "=" at all,
+  because every `[]byte` field is nil and the string fields are empty. It bites
+  only when a field carries one - `Requirements.Other["cloud_script"]` holding
+  something like `export FOO=bar` is the realistic case, and then the JSON
+  truncates mid-value, `json.Unmarshal` fails, `mountCouldFail` stays false,
+  and a bsub child job is buried on a mount failure it should have tolerated.
+  Reachable, not routine.
+- Empty elements are rejected too, so `wr add --env "A=1,"` now errors. That is
+  not merely tidiness: an empty element reaches `containerEnv` as the empty
+  name and `dockerEnv` emits `-e ''`, which docker 29.1.3 rejects with
+  `invalid argument "" for "-e, --env" flag`, exit 125. The old behaviour
+  silently stored a value that made any `--with_docker` job fail to start.
+  `--env "A=1,2"` likewise now errors rather than storing a bare "2".
+- `=value` is rejected as well, on the reviewer's recommendation and verified
+  rather than taken: docker gives the same exit 125 for it, and on the
+  non-container path `os/exec` passes it to a child that has no name to look it
+  up by, so it defines nothing either way. Item 3's own record above had
+  already nominated this exact home for the check.
+- 3 sentinels, not 1, because each input has a different remedy and a message
+  carrying a remedy must not be reused for an input that remedy does not fit:
+
+  ```
+  "PATH"   -> "PATH": environment variable is not in key=value format; to pass a variable through, write NAME=$NAME
+  ""       -> environment variable is empty; check for a stray or doubled comma
+  "=value" -> "=value": environment variable has no name before the =
+  ```
+
+  The hint names the generic `NAME=$NAME` rather than interpolating the
+  element, since the element is arbitrary user text and "write foo bar=$foo
+  bar" would be nonsense; the element is already quoted at the front of the
+  same line.
+- Well-formed values are untouched, asserted across all 4 routes: `A=1`,
+  `PATH=/usr/bin`, a value containing "=" (`WR_ENV_EQUALS=a=b`), a value
+  containing ":" (`WR_ENV_COLON=/usr/bin:/bin`) and a legitimately empty value
+  (`D=`).
+- Gap named rather than papered over: all 4 checks are client-side, and the
+  server stores whatever compressed `EnvOverride` bytes a client sends, so an
+  OLDER wr client against an upgraded manager can still poison a job. Half B is
+  what covers that. Validating server-side would mean decompressing every job's
+  override on add.
+- Not done, raised as its own item rather than folded in: `--env` is now the
+  only comma-separated `wr add` flag that hard-errors on a trailing comma.
+  `--limit_grps "a,"`, `--modules "x,"` and `--queues_avoid "z,"` all accept
+  one silently (`cmd/add.go` does a bare `strings.Split` with no element
+  validation). The asymmetry tracks blast radius rather than taste - an empty
+  env entry crash-looped a scheduler group, an empty limit group appears to be
+  inert - and removing it either way is a user-visible change to 3 unrelated
+  flags. Anyone taking it should first measure what an empty limit group and an
+  empty module name actually DO, since the right answer may differ per flag.
+- Also left, non-blocking: nothing is logged when a read skips a malformed
+  stored entry, so a legacy job degrades silently. A `warn` in the runner would
+  close the last "no diagnostic" case this item complained about.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ project adheres to [Semantic Versioning](http://semver.org/).
   anything it creates in your working directory to be owned by that user.
 
 ### Changed
+- `--env` now refuses an element that defines no variable, naming the offending
+  element and saying what to write instead, where before it stored one that no
+  command could read. This covers `wr add --env`, `wr mod --env`, the `env`
+  array of a JSON job, and the same field in a REST `POST /rest/v1/jobs` or
+  `PATCH /rest/v1/jobs/<ids>`. Three things that used to be accepted are now
+  errors: a bare name such as `--env PATH`, which you might write hoping to
+  pass your own value through (write `--env PATH=$PATH` for that); an element
+  with no name before its `=`, such as `--env =value`; and an empty element, so
+  `--env "A=1,"` and `--env "A=1,,B=2"` now fail on the trailing or doubled
+  comma, and `--env "A=1,2"` fails on the bare `2`. Check any script that
+  builds an `--env` list by joining, because a trailing comma there used to be
+  accepted silently. Commands already in the queue with such an entry are not
+  rejected retrospectively; wr now skips the entry when it runs them, as
+  described below.
 - Commands you run with `--with_docker` now run as you instead of as the user
   the image specifies, which is normally root. Files they create in your working
   directory are therefore yours, so you can delete them and so can wr's own
@@ -33,6 +47,33 @@ project adheres to [Semantic Versioning](http://semver.org/).
   the mounts they were added with.
 
 ### Fixed
+- One mistyped `--env` element could stop every command in a scheduler group.
+  An entry with no `=`, such as a bare `PATH`, crashed the runner as it
+  prepared the command. The command went back to the queue without using up a
+  retry, so it was never buried, and the manager kept starting runners that
+  died on it the same way, each of them also taking down the other commands it
+  would have gone on to run. An entry with no name before its `=` broke a
+  `--with_docker` command differently but as completely: docker was asked to
+  set a variable with no name, and refused to start the container at all. wr
+  now skips such an entry when it runs a command, so commands added before this
+  release run rather than failing, and `--env` refuses to store a new one.
+- A command could run with a different command's `PATH`. A runner runs many
+  commands in turn, and one that needed no `PATH` adjustment of its own,
+  because its `PATH` already included the directory wr's executable is in, was
+  handed the `PATH` of the previous command that runner ran, and so could
+  resolve binaries it never asked for. One command with an unusual `PATH`
+  affected every later command in that runner.
+- A `--with_docker` command ran with its `PATH` cut off at the first colon, so
+  it could not find binaries that were on its `PATH` outside the container, and
+  reported only that the command was not found. Any other overridden value
+  containing a colon, such as `LD_LIBRARY_PATH`, `MANPATH` or `PYTHONPATH`, was
+  truncated the same way. Overridden variables now reach the container whole.
+- When a command's environment named the same variable twice, the settings wr
+  makes for you could fail to take effect: `TMPDIR`, the `HOME` that
+  `--change_home` sets, the host and port a command uses to talk back to the
+  manager, and the `PATH` that `--bsub` prepends to. Only the first copy was
+  replaced, so which value the command saw came down to how the program it ran
+  reads its environment. Every copy is now replaced.
 - With `--with_docker`, a `--container_mounts` mount with more than one colon,
   such as `/data/opt:/opt:ro`, silently mounted your local path at that same
   path inside the container, dropping both the in-container path and the option

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -34,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -183,19 +184,16 @@ complete.`,
 
 		// in case any job we execute has a Cmd that calls `wr add`, we will
 		// override their environment to make that call work
-		var (
-			envOverrides []string
-			exePath      string
-		)
+		overrider := &jobEnvOverrider{}
 
 		if rserver != "" {
 			hostPort := strings.Split(rserver, ":")
 			if len(hostPort) == hostPortParts {
-				envOverrides = append(envOverrides, "WR_MANAGERHOST="+hostPort[0])
-				envOverrides = append(envOverrides, "WR_MANAGERPORT="+hostPort[1])
+				overrider.base = append(overrider.base, "WR_MANAGERHOST="+hostPort[0])
+				overrider.base = append(overrider.base, "WR_MANAGERPORT="+hostPort[1])
 			}
 
-			envOverrides = append(envOverrides, "WR_MANAGERCERTDOMAIN="+rdomain)
+			overrider.base = append(overrider.base, "WR_MANAGERCERTDOMAIN="+rdomain)
 
 			// later we will add our own wr exe to the path if not there
 			exe, err := osext.Executable()
@@ -203,7 +201,7 @@ complete.`,
 				die("%s", err)
 			}
 
-			exePath = filepath.Dir(exe)
+			overrider.exePath = filepath.Dir(exe)
 		}
 
 		// we'll stop the below loop before using up too much time
@@ -266,8 +264,7 @@ complete.`,
 			}
 
 			// actually run the cmd
-			if len(envOverrides) > 0 {
-				// add exePath to this job's PATH
+			if len(overrider.base) > 0 {
 				env, erre := job.Env()
 				if erre != nil {
 					err = jq.Release(job, nil, "failed to read job's Env")
@@ -280,18 +277,7 @@ complete.`,
 					break
 				}
 
-				for _, envvar := range env {
-					pair := strings.Split(envvar, "=")
-					if pair[0] == "PATH" {
-						if !strings.Contains(pair[1], exePath) {
-							envOverrides = append(envOverrides, envvar+":"+exePath)
-						}
-
-						break
-					}
-				}
-
-				err = job.EnvAddOverride(envOverrides)
+				err = job.EnvAddOverride(overrider.overridesFor(env))
 				if err != nil {
 					err = jq.Release(job, nil, "failed to add env var overrides")
 					if err != nil {
@@ -392,4 +378,37 @@ func init() {
 		"domain the manager's cert is valid for")
 	runnerCmd.Flags().BoolVar(&logToSyslog, "syslog", false, "enable logging to syslog")
 	runnerCmd.Flags().StringVar(&logToDir, "logdir", "", "enable logging to files within the given dir")
+}
+
+// jobEnvOverrider builds the environment overrides a runner applies to each job
+// it runs: the manager's connection details, which are the same for every job,
+// plus the runner's own exe directory appended to the job's PATH when the job's
+// PATH lacks it, so that a Cmd calling `wr add` finds the wr exe.
+type jobEnvOverrider struct {
+	base    []string
+	exePath string
+}
+
+// overridesFor returns the overrides to apply to a job whose environment is
+// env.
+//
+// The PATH entry belongs to this job alone, so base is cloned rather than
+// appended to: a runner runs many jobs in sequence, and a job whose PATH already
+// has the exe directory adds nothing, which would otherwise leave it running
+// with an earlier job's PATH.
+func (j *jobEnvOverrider) overridesFor(env []string) []string {
+	overrides := slices.Clone(j.base)
+
+	for _, envvar := range env {
+		pair := strings.Split(envvar, "=")
+		if pair[0] == "PATH" {
+			if !strings.Contains(pair[1], j.exePath) {
+				overrides = append(overrides, envvar+":"+j.exePath)
+			}
+
+			break
+		}
+	}
+
+	return overrides
 }

--- a/cmd/runner.go
+++ b/cmd/runner.go
@@ -396,18 +396,25 @@ type jobEnvOverrider struct {
 // appended to: a runner runs many jobs in sequence, and a job whose PATH already
 // has the exe directory adds nothing, which would otherwise leave it running
 // with an earlier job's PATH.
+//
+// An entry with no "=" in it defines nothing, as far as the C library's getenv()
+// is concerned, so it is skipped rather than read for a value it does not have.
+// A job stored with a bare "PATH" therefore runs with the base overrides alone,
+// where reading it used to panic and kill the runner.
 func (j *jobEnvOverrider) overridesFor(env []string) []string {
 	overrides := slices.Clone(j.base)
 
 	for _, envvar := range env {
-		pair := strings.Split(envvar, "=")
-		if pair[0] == "PATH" {
-			if !strings.Contains(pair[1], j.exePath) {
-				overrides = append(overrides, envvar+":"+j.exePath)
-			}
-
-			break
+		name, path, ok := strings.Cut(envvar, "=")
+		if !ok || name != "PATH" {
+			continue
 		}
+
+		if !strings.Contains(path, j.exePath) {
+			overrides = append(overrides, envvar+":"+j.exePath)
+		}
+
+		break
 	}
 
 	return overrides

--- a/cmd/runner_env_test.go
+++ b/cmd/runner_env_test.go
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+// This file tests item 2 of .docs/bugfixes/260909-fix-env-propagation.md: a
+// runner accumulated its environment overrides across the jobs it ran, so a job
+// that needed no PATH override of its own was handed the PREVIOUS job's PATH and
+// could resolve the wrong binaries.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/jobqueue"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// runnerEnvExeDir stands in for the directory holding the runner's own wr
+	// exe, which the runner wants on every job's PATH.
+	runnerEnvExeDir = "/opt/wrtest/bin"
+
+	// runnerEnvPathWithout is a job PATH that lacks runnerEnvExeDir, so the
+	// runner must append it.
+	runnerEnvPathWithout = "/jobone/bin:/usr/bin"
+
+	// runnerEnvPathWith is a job PATH that already has runnerEnvExeDir, so the
+	// runner must leave it exactly as it is.
+	runnerEnvPathWith = "/opt/wrtest/bin:/jobtwo/bin"
+
+	// runnerEnvPathLater is a later job's PATH that also lacks runnerEnvExeDir,
+	// so the runner appends the exe dir to this one as well.
+	runnerEnvPathLater = "/jobthree/bin:/usr/bin"
+
+	runnerEnvPathName    = "PATH"
+	runnerEnvHostName    = "WR_MANAGERHOST"
+	runnerEnvHost        = "localhost"
+	runnerEnvTestRepGrp  = "runner-env-test"
+	runnerEnvTestCmd     = "true"
+	runnerEnvSequenceLen = 3
+)
+
+func TestRunnerJobEnvOverrides(t *testing.T) {
+	Convey("Given a runner's job environment overrider", t, func() {
+		overrider := &jobEnvOverrider{exePath: runnerEnvExeDir}
+
+		// the base overrides are appended one at a time, as the runner appends
+		// them, which leaves the slice with spare capacity; a composite literal
+		// would not, and that spare capacity is what would let one job's
+		// overrides overwrite another's.
+		overrider.base = append(overrider.base, runnerEnvHostName+"="+runnerEnvHost)
+		overrider.base = append(overrider.base, "WR_MANAGERPORT=1234")
+		overrider.base = append(overrider.base, "WR_MANAGERCERTDOMAIN=wr.example.com")
+
+		baseOnly := slices.Clone(overrider.base)
+
+		Convey("A job whose PATH lacks the exe dir runs with the exe dir appended", func() {
+			job := runnerEnvTestJob(runnerEnvPathWithout)
+
+			runnerEnvTestRun(overrider, job)
+
+			So(job.Getenv(runnerEnvPathName), ShouldEqual, runnerEnvPathWithout+":"+runnerEnvExeDir)
+			So(job.Getenv(runnerEnvHostName), ShouldEqual, runnerEnvHost)
+		})
+
+		Convey("A job whose PATH already has the exe dir runs with its own PATH", func() {
+			job := runnerEnvTestJob(runnerEnvPathWith)
+
+			runnerEnvTestRun(overrider, job)
+
+			So(job.Getenv(runnerEnvPathName), ShouldEqual, runnerEnvPathWith)
+			So(job.Getenv(runnerEnvHostName), ShouldEqual, runnerEnvHost)
+		})
+
+		Convey("It still does when an earlier job in the same runner needed the exe dir appended", func() {
+			first := runnerEnvTestJob(runnerEnvPathWithout)
+			runnerEnvTestRun(overrider, first)
+
+			second := runnerEnvTestJob(runnerEnvPathWith)
+			runnerEnvTestRun(overrider, second)
+
+			So(second.Getenv(runnerEnvPathName), ShouldEqual, runnerEnvPathWith)
+			So(second.Getenv(runnerEnvHostName), ShouldEqual, runnerEnvHost)
+			So(first.Getenv(runnerEnvPathName), ShouldEqual, runnerEnvPathWithout+":"+runnerEnvExeDir)
+		})
+
+		Convey("A job's overrides keep its own PATH once a later job's are built", func() {
+			first := overrider.overridesFor([]string{runnerEnvPathName + "=" + runnerEnvPathWithout})
+
+			overrider.overridesFor([]string{runnerEnvPathName + "=" + runnerEnvPathLater})
+
+			So(first, ShouldResemble, append(slices.Clone(baseOnly),
+				runnerEnvPathName+"="+runnerEnvPathWithout+":"+runnerEnvExeDir))
+		})
+
+		Convey("A job with no environment of its own gets only the base overrides, "+
+			"even after an earlier job needed a PATH override", func() {
+			runnerEnvTestRun(overrider, runnerEnvTestJob(runnerEnvPathWithout))
+
+			noEnv := &jobqueue.Job{Cmd: runnerEnvTestCmd, Cwd: statusTestCwd, RepGroup: runnerEnvTestRepGrp}
+			env, err := noEnv.Env()
+			So(err, ShouldBeNil)
+			So(env, ShouldBeEmpty)
+
+			So(overrider.overridesFor(env), ShouldResemble, baseOnly)
+		})
+
+		Convey("The overrides do not grow as the runner works through jobs", func() {
+			for range runnerEnvSequenceLen {
+				runnerEnvTestRun(overrider, runnerEnvTestJob(runnerEnvPathWithout))
+			}
+
+			last := runnerEnvTestJob(runnerEnvPathWith)
+			env, err := last.Env()
+			So(err, ShouldBeNil)
+			So(overrider.overridesFor(env), ShouldResemble, baseOnly)
+		})
+	})
+}
+
+// runnerEnvTestJob returns a job that stands in for one the runner reserved,
+// with the given PATH in the environment its Cmd would run under.
+//
+// A reserved job carries the environment its client stored, which Env() applies
+// the job's own overrides to; an empty EnvC with EnvCRetrieved set means the
+// current environment, so an override is how a test gives the job a PATH of its
+// own.
+func runnerEnvTestJob(path string) *jobqueue.Job {
+	job := &jobqueue.Job{
+		Cmd:           runnerEnvTestCmd,
+		Cwd:           statusTestCwd,
+		RepGroup:      runnerEnvTestRepGrp,
+		EnvCRetrieved: true,
+	}
+
+	So(job.EnvAddOverride([]string{runnerEnvPathName + "=" + path}), ShouldBeNil)
+
+	return job
+}
+
+// runnerEnvTestRun does to job what the runner's reserve loop does before
+// executing it: read the environment the job would run under, then add the
+// overrides that environment calls for.
+func runnerEnvTestRun(overrider *jobEnvOverrider, job *jobqueue.Job) {
+	env, err := job.Env()
+	So(err, ShouldBeNil)
+
+	So(job.EnvAddOverride(overrider.overridesFor(env)), ShouldBeNil)
+}

--- a/cmd/runner_env_test.go
+++ b/cmd/runner_env_test.go
@@ -25,10 +25,12 @@
 
 package cmd
 
-// This file tests item 2 of .docs/bugfixes/260909-fix-env-propagation.md: a
-// runner accumulated its environment overrides across the jobs it ran, so a job
-// that needed no PATH override of its own was handed the PREVIOUS job's PATH and
-// could resolve the wrong binaries.
+// This file tests items 2 and 4 of
+// .docs/bugfixes/260909-fix-env-propagation.md. Item 2: a runner accumulated
+// its environment overrides across the jobs it ran, so a job that needed no
+// PATH override of its own was handed the PREVIOUS job's PATH and could resolve
+// the wrong binaries. Item 4: a job whose stored environment held a bare name
+// with no "=" made the runner panic as it read the value after the "=".
 
 import (
 	"slices"
@@ -137,6 +139,56 @@ func TestRunnerJobEnvOverrides(t *testing.T) {
 			env, err := last.Env()
 			So(err, ShouldBeNil)
 			So(overrider.overridesFor(env), ShouldResemble, baseOnly)
+		})
+	})
+}
+
+// TestRunnerStoredBareEnvName covers a job that was stored with an environment
+// entry that has no "=" in it. Rejecting such an entry at the routes that write
+// it does nothing for the jobs already in a database, and one of those used to
+// panic the runner that reserved it: the runner died, the job was never touched
+// so it returned to the queue as lost with numrun 0, and the manager started
+// another runner to die on it in turn.
+func TestRunnerStoredBareEnvName(t *testing.T) {
+	Convey("Given a runner's overrider and a job stored with a bare environment name", t, func() {
+		overrider := &jobEnvOverrider{exePath: runnerEnvExeDir}
+		overrider.base = append(overrider.base, runnerEnvHostName+"="+runnerEnvHost)
+
+		baseOnly := slices.Clone(overrider.base)
+
+		job := &jobqueue.Job{
+			Cmd:           runnerEnvTestCmd,
+			Cwd:           statusTestCwd,
+			RepGroup:      runnerEnvTestRepGrp,
+			EnvCRetrieved: true,
+		}
+		So(job.EnvAddOverride([]string{runnerEnvPathName}), ShouldBeNil)
+
+		env, err := job.Env()
+		So(err, ShouldBeNil)
+		So(env, ShouldContain, runnerEnvPathName)
+
+		Convey("Preparing that job to run leaves the runner alive", func() {
+			So(func() { runnerEnvTestRun(overrider, job) }, ShouldNotPanic)
+		})
+
+		Convey("The job runs with the base overrides and no PATH the runner made up", func() {
+			So(overrider.overridesFor(env), ShouldResemble, baseOnly)
+
+			runnerEnvTestRun(overrider, job)
+
+			So(job.Getenv(runnerEnvHostName), ShouldEqual, runnerEnvHost)
+			So(job.Getenv(runnerEnvPathName), ShouldBeBlank)
+		})
+
+		Convey("A later job with a usable PATH still gets the exe dir appended", func() {
+			runnerEnvTestRun(overrider, job)
+
+			later := runnerEnvTestJob(runnerEnvPathWithout)
+			runnerEnvTestRun(overrider, later)
+
+			So(later.Getenv(runnerEnvPathName), ShouldEqual, runnerEnvPathWithout+":"+runnerEnvExeDir)
+			So(later.Getenv(runnerEnvHostName), ShouldEqual, runnerEnvHost)
 		})
 	})
 }

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -1772,11 +1772,16 @@ func (c *Client) addBsubEnv(env []string, job *Job, prependPath, host, shell str
 
 // prependedPath returns a "PATH=" override that puts prependPath before the
 // existing PATH value found in env (if any).
+//
+// An entry with no "=" in it defines nothing, as far as the C library's getenv()
+// is concerned, so it is skipped: a job stored with a bare "PATH" gets
+// prependPath alone, the same as one with no PATH at all, where reading it used
+// to panic and kill the runner.
 func prependedPath(env []string, prependPath string) string {
 	for _, envvar := range env {
-		pair := strings.Split(envvar, "=")
-		if pair[0] == "PATH" {
-			return "PATH=" + prependPath + ":" + pair[1]
+		name, path, ok := strings.Cut(envvar, "=")
+		if ok && name == "PATH" {
+			return "PATH=" + prependPath + ":" + path
 		}
 	}
 

--- a/jobqueue/env_validation_test.go
+++ b/jobqueue/env_validation_test.go
@@ -1,0 +1,269 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+// This file tests item 4 of .docs/bugfixes/260909-fix-env-propagation.md: an
+// environment entry that is a bare NAME with no "=" was accepted by every route
+// that stores an environment on a job, and then made the runner panic when it
+// read the value after the "=". The entries that define no variable for other
+// reasons - an empty one, and one with no name before the "=" - are refused by
+// the same routes.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// envValidationBare is the entry a user produces by typing `--env PATH`
+	// when they mean "pass my PATH through".
+	envValidationBare = "PATH"
+
+	envValidationGood    = "PATH=/usr/bin"
+	envValidationOther   = "WR_ENV_TEST=1"
+	envValidationTestCmd = "echo env validation"
+
+	// the other entries that define no variable: the empty one a trailing or
+	// doubled comma leaves behind, and one with nothing before the "=".
+	envValidationEmpty  = ""
+	envValidationNoName = "=value"
+
+	// envValidationColon is a well formed entry whose value holds a ":", which
+	// must go on being accepted; envValidationEqualsName below covers a value
+	// holding a further "=".
+	envValidationColon = "WR_ENV_COLON=/usr/bin:/bin"
+
+	// the parts of a refusal that make it actionable: what wr wanted instead,
+	// how to write the pass-through the bare name was meant to be, and the
+	// words that name the other two mistakes and their likely cause.
+	envValidationFormat      = "key=value"
+	envValidationPassThrough = "NAME=$NAME"
+	envValidationEmptyWord   = "empty"
+	envValidationComma       = "comma"
+	envValidationNameless    = "no name"
+
+	// the variables of a job that was stored before the write routes started
+	// refusing a bare name: one bare, one ordinary, and one whose value
+	// contains a further "=".
+	envValidationStoredBare = "WR_ENV_BARE"
+	envValidationStoredName = "WR_ENV_OK"
+	envValidationStoredVal  = "value"
+	envValidationEqualsName = "WR_ENV_EQUALS"
+	envValidationEqualsVal  = "a=b"
+
+	// envValidationPrepend stands in for the directory holding wr's bsub
+	// symlinks, which a bsub-mode job wants at the front of its PATH.
+	envValidationPrepend = "/wr/bsub"
+	envValidationPathVar = "PATH"
+)
+
+// TestGetenvSurvivesStoredBareName covers a job that was stored with a bare
+// environment name before the write routes started refusing them: validation
+// does nothing for those, and they would go on crash-looping their scheduler
+// group after an upgrade.
+func TestGetenvSurvivesStoredBareName(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a job stored with an environment entry that has no =", t, func() {
+		envc, err := compressEnv([]string{
+			envValidationStoredBare,
+			envValidationStoredName + "=" + envValidationStoredVal,
+			envValidationEqualsName + "=" + envValidationEqualsVal,
+		})
+		So(err, ShouldBeNil)
+
+		job := &Job{EnvC: envc, EnvCRetrieved: true}
+
+		Convey("Getenv of that name answers blank instead of panicking", func() {
+			So(func() { job.Getenv(envValidationStoredBare) }, ShouldNotPanic)
+			So(job.Getenv(envValidationStoredBare), ShouldBeBlank)
+		})
+
+		Convey("Getenv of the job's other variables still answers their whole value", func() {
+			So(job.Getenv(envValidationStoredName), ShouldEqual, envValidationStoredVal)
+			So(job.Getenv(envValidationEqualsName), ShouldEqual, envValidationEqualsVal)
+		})
+	})
+}
+
+// TestBsubEnvSurvivesStoredBareName covers the same stored bare name reaching
+// the bsub emulation environment, which reads the value after the "=" of the
+// job's PATH so it can put wr's bsub symlink directory in front of it. This read
+// is inside Client.Execute, in the runner, so it crash-looped a scheduler group
+// the same way the runner's own read did.
+func TestBsubEnvSurvivesStoredBareName(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("Given a bsub-mode job whose stored environment holds a bare PATH", t, func() {
+		client := &Client{}
+		job := &Job{Cmd: envValidationTestCmd, Requirements: &scheduler.Requirements{}}
+
+		bareEnv := func() []string { return []string{envValidationBare, envValidationOther} }
+
+		Convey("Building its bsub environment leaves the runner alive, "+
+			"with a PATH of the bsub directory alone", func() {
+			var (
+				env []string
+				err error
+			)
+
+			So(func() {
+				env, err = client.addBsubEnv(bareEnv(), job, envValidationPrepend, "localhost", "/bin/sh")
+			}, ShouldNotPanic)
+
+			So(err, ShouldBeNil)
+			So(env, ShouldContain, envValidationPathVar+"="+envValidationPrepend)
+			So(env, ShouldNotContain, envValidationBare)
+		})
+
+		Convey("A usable PATH still gets the bsub directory put in front of it", func() {
+			env, err := client.addBsubEnv([]string{envValidationGood}, job,
+				envValidationPrepend, "localhost", "/bin/sh")
+
+			So(err, ShouldBeNil)
+			So(env, ShouldContain, envValidationPathVar+"="+envValidationPrepend+":/usr/bin")
+		})
+	})
+}
+
+// TestEnvWriteRoutesRejectMalformedEntries checks that no route that stores an
+// environment on a job accepts an entry that defines no variable, and that each
+// refusal says enough for the user to fix what they typed.
+func TestEnvWriteRoutesRejectMalformedEntries(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	for _, route := range envValidationRoutes() {
+		Convey("Given the "+route.name+" way of setting a job's environment", t, func() {
+			for _, bad := range envValidationBadEntries() {
+				Convey(bad.desc, func() {
+					err := route.set([]string{envValidationOther, bad.entry})
+
+					So(err, ShouldNotBeNil)
+
+					for _, says := range bad.says {
+						So(err.Error(), ShouldContainSubstring, says)
+					}
+				})
+			}
+
+			Convey("Entries that are all key=value are accepted, including values "+
+				"that themselves hold a = or a :", func() {
+				So(route.set([]string{
+					envValidationOther,
+					envValidationGood,
+					envValidationEqualsName + "=" + envValidationEqualsVal,
+					envValidationColon,
+				}), ShouldBeNil)
+			})
+		})
+	}
+}
+
+// envValidationRoutes returns every route by which a user's environment reaches
+// a Job's stored EnvOverride, each expressed as a call taking the environment
+// the user supplied.
+func envValidationRoutes() []struct {
+	name string
+	set  func(envars []string) error
+} {
+	return []struct {
+		name string
+		set  func(envars []string) error
+	}{
+		{
+			name: "wr mod --env",
+			set: func(envars []string) error {
+				return NewJobModifer().SetEnvOverride(strings.Join(envars, ","))
+			},
+		},
+		{
+			name: "REST PATCH /jobs with an env array",
+			set: func(envars []string) error {
+				_, err := (&JobModifyViaJSON{Env: &envars}).Convert()
+
+				return err
+			},
+		},
+		{
+			name: "wr add --env, and REST POST /jobs with an env default",
+			set: func(envars []string) error {
+				_, err := (&JobViaJSON{Cmd: envValidationTestCmd}).
+					Convert(&JobDefaults{Env: strings.Join(envars, ",")})
+
+				return err
+			},
+		},
+		{
+			name: "wr add with a JSON env, and REST POST /jobs with a job env array",
+			set: func(envars []string) error {
+				_, err := (&JobViaJSON{Cmd: envValidationTestCmd, Env: envars}).Convert(&JobDefaults{})
+
+				return err
+			},
+		},
+	}
+}
+
+// envValidationBadEntries returns every entry that defines no variable, with
+// what the refusal of each should tell the user.
+func envValidationBadEntries() []struct {
+	desc  string
+	entry string
+	says  []string
+} {
+	return []struct {
+		desc  string
+		entry string
+		says  []string
+	}{
+		{
+			desc: "An entry with no = is refused, naming it, the format wanted, " +
+				"and how to pass a variable through",
+			entry: envValidationBare,
+			says:  []string{envValidationBare, envValidationFormat, envValidationPassThrough},
+		},
+		{
+			desc: "An empty entry, as a trailing or doubled comma leaves behind, " +
+				"is refused with the comma pointed at",
+			entry: envValidationEmpty,
+			says:  []string{envValidationEmptyWord, envValidationComma},
+		},
+		{
+			desc:  "An entry with no name before the = is refused, naming it",
+			entry: envValidationNoName,
+			says:  []string{envValidationNoName, envValidationNameless},
+		},
+	}
+}

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -980,19 +980,26 @@ func (j *Job) containerMounts() []string {
 	return strings.Split(j.ContainerMounts, ",")
 }
 
-// containerEnv converts EnvOverride to a slice of the envionrment variable
+// containerEnv converts EnvOverride to a slice of the environment variable
 // names that were set.
+//
+// A stored entry that is empty, or that has no name before its "=", names no
+// variable, so it is left out: it would reach docker as an empty -e argument,
+// which docker refuses to start the container at all for. Jobs stored before
+// the write routes started refusing such an entry still hold them, and one made
+// every containerised job of theirs fail to start.
 func (j *Job) containerEnv() ([]string, error) {
 	overrideEs, err := j.envCurrentOverrides()
 	if err != nil {
 		return nil, err
 	}
 
-	names := make([]string, len(overrideEs))
+	names := make([]string, 0, len(overrideEs))
 
-	for i, envvar := range overrideEs {
-		name, _, _ := strings.Cut(envvar, "=")
-		names[i] = name
+	for _, envvar := range overrideEs {
+		if name := envName(envvar); name != "" {
+			names = append(names, name)
+		}
 	}
 
 	return names, nil

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -991,8 +991,8 @@ func (j *Job) containerEnv() ([]string, error) {
 	names := make([]string, len(overrideEs))
 
 	for i, envvar := range overrideEs {
-		parts := strings.Split(envvar, ":")
-		names[i] = parts[0]
+		name, _, _ := strings.Cut(envvar, "=")
+		names[i] = name
 	}
 
 	return names, nil

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -1168,6 +1168,12 @@ func (j *Job) EnvAddOverride(env []string) error {
 // Getenv is like os.Getenv(), but for the environment variables stored in the
 // job, including any overrides. Returns blank if Env() would have returned
 // an error.
+//
+// Like the C library's getenv(), a stored entry with no "=" in it defines
+// nothing, so it is skipped: asking for its name gets you blank, the same
+// answer as for a variable the job does not have. Jobs stored before the write
+// routes started refusing such an entry still hold them, and reading one used
+// to panic.
 func (j *Job) Getenv(key string) string {
 	env, err := j.Env()
 	if err != nil {
@@ -1175,9 +1181,9 @@ func (j *Job) Getenv(key string) string {
 	}
 
 	for _, envvar := range env {
-		pair := strings.Split(envvar, "=")
-		if pair[0] == key {
-			return pair[1]
+		name, value, ok := strings.Cut(envvar, "=")
+		if ok && name == key {
+			return value
 		}
 	}
 
@@ -2294,24 +2300,16 @@ func (j *JobModifier) SetNoRetriesOverWalltime(newVal time.Duration) {
 }
 
 // SetEnvOverride notes that you want to modify the EnvOverride of Jobs. The
-// supplied string should be a comma separated list of key=value pairs. This can
-// generate an error if compression of the data fails.
+// supplied string should be a comma separated list of key=value pairs. This
+// generates an error if an element is not a key=value pair, or if compression
+// of the data fails.
 func (j *JobModifier) SetEnvOverride(newVal string) error {
-	var compressedEnv []byte
-
+	var envars []string
 	if newVal != "" {
-		var err error
-
-		compressedEnv, err = compressEnv(strings.Split(newVal, ","))
-		if err != nil {
-			return err
-		}
+		envars = strings.Split(newVal, ",")
 	}
 
-	j.EnvOverride = compressedEnv
-	j.EnvOverrideSet = true
-
-	return nil
+	return j.setEnvOverrideValues(envars)
 }
 
 func (j *JobModifier) setEnvOverrideValues(newVal []string) error {
@@ -2320,7 +2318,7 @@ func (j *JobModifier) setEnvOverrideValues(newVal []string) error {
 	if len(newVal) > 0 {
 		var err error
 
-		compressedEnv, err = compressEnv(newVal)
+		compressedEnv, err = compressUserEnv(newVal)
 		if err != nil {
 			return err
 		}

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -624,8 +624,8 @@ func TestJob(t *testing.T) {
 
 				dockerExtra := " --mount type=bind,source=/foo/bar,target=/bar" +
 					" --mount type=bind,source=/foo/baz,target=/baz"
-				dockerEnv1 := " -e FOO=bar -e OOF=rab"
-				dockerEnv2 := " -e OOF=rab -e FOO=bar"
+				dockerEnv1 := " -e FOO -e OOF"
+				dockerEnv2 := " -e OOF -e FOO"
 
 				exp1 := fmt.Sprintf(dockerPrefix+dockerExtra+dockerEnv1+dockerSuffix, job.Key(), image)
 				exp2 := fmt.Sprintf(dockerPrefix+dockerExtra+dockerEnv2+dockerSuffix, job.Key(), image)
@@ -635,6 +635,18 @@ func TestJob(t *testing.T) {
 				} else {
 					So(cmd, ShouldEndWith, exp2)
 				}
+			})
+
+			Convey("That names an env var whose value contains a colon, not a truncation of it", func() {
+				So(job.EnvAddOverride([]string{"PATH=/usr/local/sbin:/opt/wrtest/bin"}), ShouldBeNil)
+
+				cmd, cleanup, err = job.CmdLine(ctx)
+				So(err, ShouldBeNil)
+				So(cleanup, ShouldNotBeNil)
+
+				defer cleanup()
+
+				So(cmd, ShouldEndWith, fmt.Sprintf(dockerPrefix+" -e PATH"+dockerSuffix, job.Key(), image))
 			})
 		})
 

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -648,6 +648,21 @@ func TestJob(t *testing.T) {
 
 				So(cmd, ShouldEndWith, fmt.Sprintf(dockerPrefix+" -e PATH"+dockerSuffix, job.Key(), image))
 			})
+
+			Convey("That leaves out a stored env entry naming nothing, which docker refuses to start with", func() {
+				stored, errc := compressEnv([]string{"", "FOO=bar", "=orphan", "EQ=a=b"})
+				So(errc, ShouldBeNil)
+
+				job.EnvOverride = stored
+
+				cmd, cleanup, err = job.CmdLine(ctx)
+				So(err, ShouldBeNil)
+				So(cleanup, ShouldNotBeNil)
+
+				defer cleanup()
+
+				So(cmd, ShouldEndWith, fmt.Sprintf(dockerPrefix+" -e FOO -e EQ"+dockerSuffix, job.Key(), image))
+			})
 		})
 
 		Convey("Though with WithSingularity it returns a singularity shell command", func() {

--- a/jobqueue/serverREST.go
+++ b/jobqueue/serverREST.go
@@ -441,11 +441,12 @@ func (jd *JobDefaults) DefaultTime() time.Duration {
 	return jd.Time
 }
 
-// DefaultEnv returns an encoded compressed version of the Env value.
+// DefaultEnv returns an encoded compressed version of the Env value, erroring
+// if one of its comma separated elements is not a key=value pair.
 func (jd *JobDefaults) DefaultEnv() ([]byte, error) {
 	var err error
 	if len(jd.compressedEnv) == 0 {
-		jd.compressedEnv, err = compressEnv(strings.Split(jd.Env, ","))
+		jd.compressedEnv, err = compressUserEnv(strings.Split(jd.Env, ","))
 	}
 
 	return jd.compressedEnv, err
@@ -722,7 +723,7 @@ func (jvj *JobViaJSON) resolveDependencies(jd *JobDefaults) Dependencies {
 // resolveEnvOverride resolves the compressed environment variable override.
 func (jvj *JobViaJSON) resolveEnvOverride(jd *JobDefaults) ([]byte, error) {
 	if len(jvj.Env) > 0 {
-		return compressEnv(jvj.Env)
+		return compressUserEnv(jvj.Env)
 	}
 
 	if len(jd.Env) > 0 {

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -652,29 +652,53 @@ func writeStd(out io.Writer, b []byte, merr **multierror.Error) {
 
 // envOverride deals with values you get from os.Environ, overriding one set
 // with values from another. Returns the new slice of environment variables.
+//
+// A name that appears more than once in orig is overridden at every occurrence,
+// since a stored environment (unlike os.Environ) can hold duplicates, and which
+// copy the command then sees is up to the child: libc getenv() answers with the
+// first, while os/exec's Cmd.Env dedup answers with the last.
 func envOverride(orig []string, over []string) []string {
-	override := make(map[string]string)
+	override := make(map[string]string, len(over))
 
 	for _, envvar := range over {
-		pair := strings.Split(envvar, "=")
-		override[pair[0]] = envvar
+		override[envName(envvar)] = envvar
 	}
+
+	applied := make(map[string]bool, len(override))
 
 	env := orig
 	for i, envvar := range env {
-		pair := strings.Split(envvar, "=")
-		if replace, do := override[pair[0]]; do {
+		name := envName(envvar)
+		if replace, do := override[name]; do {
 			env[i] = replace
 
-			delete(override, pair[0])
+			applied[name] = true
 		}
 	}
 
-	for _, envvar := range override {
-		env = append(env, envvar)
+	// over, not override, so that what gets appended comes out in the order it
+	// was supplied rather than a map's random one; applied then also stops a
+	// name supplied twice being appended twice.
+	for _, envvar := range over {
+		name := envName(envvar)
+		if applied[name] {
+			continue
+		}
+
+		applied[name] = true
+
+		env = append(env, override[name])
 	}
 
 	return env
+}
+
+// envName returns the variable name of a "NAME=value" environment variable,
+// which is the whole string if it has no "=" in it.
+func envName(envvar string) string {
+	name, _, _ := strings.Cut(envvar, "=")
+
+	return name
 }
 
 func compressedLiveTailSuffix(tail []byte) []byte {

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -701,6 +701,53 @@ func envName(envvar string) string {
 	return name
 }
 
+// The ways a user's environment variable can fail to define anything, each
+// saying what the user most likely meant to type.
+var (
+	// errEnvNotKeyValue is for a bare name like the "PATH" someone types hoping
+	// to pass their current PATH through, which is why it says how to.
+	errEnvNotKeyValue = errors.New("environment variable is not in key=value format; " +
+		"to pass a variable through, write NAME=$NAME")
+
+	// errEnvEmpty is for an element with nothing in it at all, which in a comma
+	// separated list means the user typed one comma too many.
+	errEnvEmpty = errors.New("environment variable is empty; " +
+		"check for a stray or doubled comma")
+
+	// errEnvNoName is for an element like "=value". Nothing can read it: docker
+	// refuses to start the container at all, and a command run directly just
+	// gets an entry with no name to look it up by.
+	errEnvNoName = errors.New("environment variable has no name before the =")
+)
+
+// compressUserEnv is compressEnv for an environment a user supplied, refusing
+// any element that defines no variable: one that is empty, one with no "=", and
+// one with no name before its "=". The middle kind also used to make the runner
+// that read the value after the "=" panic.
+//
+// The check belongs to this wrapper rather than to compressEnv itself because
+// compressEnv is also how an environment already stored on a job is written
+// back (Job.EnvAddOverride). Refusing it there would take a job stored with a
+// malformed entry - which validation cannot help, since it is already in the
+// database - and turn it from one a runner can now get past into one that
+// releases the job and exits every time.
+func compressUserEnv(envars []string) ([]byte, error) {
+	for _, envvar := range envars {
+		name, _, hasValue := strings.Cut(envvar, "=")
+
+		switch {
+		case envvar == "":
+			return nil, errEnvEmpty
+		case !hasValue:
+			return nil, fmt.Errorf("%q: %w", envvar, errEnvNotKeyValue)
+		case name == "":
+			return nil, fmt.Errorf("%q: %w", envvar, errEnvNoName)
+		}
+	}
+
+	return compressEnv(envars)
+}
+
 func compressedLiveTailSuffix(tail []byte) []byte {
 	low := 1
 	high := len(tail)

--- a/jobqueue/utils.go
+++ b/jobqueue/utils.go
@@ -651,7 +651,14 @@ func writeStd(out io.Writer, b []byte, merr **multierror.Error) {
 }
 
 // envOverride deals with values you get from os.Environ, overriding one set
-// with values from another. Returns the new slice of environment variables.
+// with values from another. Returns the resulting slice of environment
+// variables.
+//
+// The result is not a copy: every override is written into orig in place, and
+// an append may take orig's spare capacity. A caller still holding orig can
+// therefore only assume its length is unchanged, not its contents nor what any
+// longer slice over the same array sees, so it should read the return value
+// instead. Every call site passes a slice it owns.
 //
 // A name that appears more than once in orig is overridden at every occurrence,
 // since a stored environment (unlike os.Environ) can hold duplicates, and which

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -141,9 +141,10 @@ func TestEnvOverrideDuplicates(t *testing.T) {
 			So(env, ShouldResemble, []string{first, other, second, "WR_NEW=new", "WR_ALSO=also"})
 		})
 
-		// cmd/runner.go accumulates its envOverrides across reserve-loop
-		// iterations, so a repeated name in the overrides is what actually
-		// reaches this path.
+		// a repeated name in the overrides comes from the user: what is refused
+		// is an element that defines no variable, not one whose name repeats,
+		// so `wr add --env "A=1,A=2"` and `wr mod --env "A=1,A=2"` both store
+		// both elements and hand them to this path.
 		Convey("An override given twice for a variable it lacks is appended once, with the last value", func() {
 			So(job.EnvAddOverride([]string{newOne, newTwo}), ShouldBeNil)
 

--- a/jobqueue/utils_test.go
+++ b/jobqueue/utils_test.go
@@ -94,6 +94,66 @@ func TestMemoryHoldingChild(t *testing.T) {
 	runtime.KeepAlive(held)
 }
 
+// TestEnvOverrideDuplicates goes through Job.Env() rather than calling
+// envOverride directly, because that is the slice that becomes the command's
+// Cmd.Env: it is where a user suffers the symptom, and it is the only place
+// that shows the stored environment and the overrides meeting.
+//
+// os.Environ() holds no duplicates, but a Job's stored environment is whatever
+// the client sent, and that can. The overrides applied to it are wr's own
+// guarantees - TMPDIR, HOME for --change_home, the bsub PATH prepend,
+// WR_MANAGER_HOST/PORT - so a surviving stale copy takes wr's control of them
+// away: libc getenv() answers with the first match, while os/exec's Cmd.Env
+// dedup and some shells answer with the last.
+func TestEnvOverrideDuplicates(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	const (
+		first  = "WR_DUP=stale"
+		second = "WR_DUP=staler"
+		other  = "WR_OTHER=other"
+		fresh  = "WR_DUP=fresh"
+		newOne = "WR_NEW=one"
+		newTwo = "WR_NEW=two"
+	)
+
+	Convey("Given a stored environment that names the same variable twice", t, func() {
+		envc, err := compressEnv([]string{first, other, second})
+		So(err, ShouldBeNil)
+
+		job := &Job{EnvC: envc, EnvCRetrieved: true}
+
+		Convey("An override for that variable replaces every occurrence of it", func() {
+			So(job.EnvAddOverride([]string{fresh}), ShouldBeNil)
+
+			env, err := job.Env()
+			So(err, ShouldBeNil)
+			So(env, ShouldResemble, []string{fresh, other, fresh})
+		})
+
+		Convey("Overrides for variables it lacks are appended once each, in the order given", func() {
+			So(job.EnvAddOverride([]string{"WR_NEW=new", "WR_ALSO=also"}), ShouldBeNil)
+
+			env, err := job.Env()
+			So(err, ShouldBeNil)
+			So(env, ShouldResemble, []string{first, other, second, "WR_NEW=new", "WR_ALSO=also"})
+		})
+
+		// cmd/runner.go accumulates its envOverrides across reserve-loop
+		// iterations, so a repeated name in the overrides is what actually
+		// reaches this path.
+		Convey("An override given twice for a variable it lacks is appended once, with the last value", func() {
+			So(job.EnvAddOverride([]string{newOne, newTwo}), ShouldBeNil)
+
+			env, err := job.Env()
+			So(err, ShouldBeNil)
+			So(env, ShouldResemble, []string{first, other, second, newTwo})
+		})
+	})
+}
+
 // TestOwnMemoryMB checks that ownMemoryMB reports this process's own Pss and,
 // unlike currentMemory, excludes child processes.
 //


### PR DESCRIPTION
Fixes the three environment-propagation defects recorded but not fixed by
`origin/record-env-propagation` (`.docs/bugfixes/260903-7.md`), plus a fourth —
a crash — found while fixing the second.

All three recorded defects were re-verified against `develop` before work
started; every line number in the record had moved, so the new write-up names
functions instead.

## 1. `envOverride` overrode only the first copy of a repeated name

It deleted each map entry as it used it, so a second entry with the same name
kept its original value and no appended copy was added either. That matters
because the overrides on this path are wr's own guarantees — `TMPDIR`, `HOME`
for `--change_home`, the bsub `PATH` prepend, `WR_MANAGER_HOST`/`PORT` — and
which value the command then saw depended on the child: libc `getenv` returns
the first match, some runtimes rebuild last-wins.

Stopping the delete was not enough: the trailing append loop *used* the delete
as its signal for "this override went unused", so removing it alone would have
appended a second copy of every override already applied. That signal is now an
explicit `applied` set. The append loop also now walks the caller's slice rather
than the map, which makes appended order deterministic instead of random.

Output length is identical to before, verified by running both implementations
side by side over 13 input shapes.

## 2. The runner handed one job's `PATH` to the next

`envOverrides` was declared outside the reserve loop and appended to inside it.
The victim was not the job that appended — it was the job that appended
*nothing*: one whose `PATH` already contained the runner's exe directory skipped
the append and was handed the **previous** job's `PATH` line, so it ran with an
unrelated job's `PATH` and could resolve the wrong binaries. One job with an
unusual `PATH` poisoned every later job in that runner. The slice also grew one
entry per job.

Now a `jobEnvOverrider` owns the base overrides and returns `slices.Clone(base)`
plus that job's own line.

A plain extracted function could not have been red-tested for this: extracting
one silently fixes the bug, because the accumulation lives in the caller's
reassignment. The state had to stay inside the seam.

## 3. `containerEnv` truncated a containerised job's `PATH`

It split `K=V` on `":"` instead of `"="`, so `PATH=/usr/local/bin:/usr/bin`
became the "name" `PATH=/usr/local/bin` and docker got that as an assignment. A
`--with_docker` job ran with its `PATH` truncated at the first colon, and the
"command not found" said nothing about the environment. Same for
`LD_LIBRARY_PATH`, `MANPATH`, `PYTHONPATH`.

An existing test had **codified the bug**, asserting `-e FOO=bar`. `git log -S`
shows the wrong split and that assertion arrived in the same 2021 commit — whose
doc comment already said the function returns variable *names*. The code
contradicted its own documentation from day one and the test froze it.

Correcting it changes colon-free values from `-e K=V` to `-e K`, so that was
checked against real docker rather than argued: `Client.Execute` sets
`cmd.Env = job.Env()` with overrides already applied, so `-e K` copies the right
value. Verified both ways with docker 29.1.3.

## 4. A one-typo command line crash-looped a scheduler group

Not in the record. An environment entry that is a bare name with no `=` panicked
the runner: `strings.Split("PATH","=")` has length 1 and three places indexed
`pair[1]`.

Reachable from `wr add --env PATH`, `wr mod --env PATH`, a JSON `env` element,
and REST — the `--env` help says "comma-separated list of key=value", so writing
`--env PATH` to mean "pass PATH through" poisons the job at add time.

There is no `recover()` in `cmd`. The runner died with exit 2, the reserved job
was never touched, timed out and returned to the queue — and because
`Client.Release` passes `attempted=false` and the server only spends a retry
when `attempted || !StartTime.IsZero()`, a job released before it started never
burns a retry and is **never buried**. So the manager spawned another runner,
which died the same way. Each dying runner also took down every other job it
would have gone on to run. Reproduced: two runner deaths two minutes apart, job
stuck `running`, never buried.

The fix has two halves, and needs both. Validation alone does nothing for a job
*already stored* with a bare entry, and those would keep crash-looping after an
upgrade:

- **Reject at every write route.** One `compressUserEnv`, three call sites, four
  routes. Deliberately *not* inside `compressEnv`: `Job.EnvAddOverride`
  re-compresses an already-stored environment on every job the runner reserves,
  so validating there would make a legacy job fail, and the handler is `Release`
  then `break` — turning the crash-loop into a *graceful* crash-loop. Proved by
  building that alternative and watching it happen.
- **Make the reads survive stored bad data.** Three of them, including
  `prependedPath` on the bsub path, which the item never named. All three now
  use `strings.Cut` and skip an entry with no `=`, as `getenv(3)` does.

Three sentinels, because each input has a different remedy:

```
"PATH"   -> "PATH": environment variable is not in key=value format; to pass a variable through, write NAME=$NAME
""       -> environment variable is empty; check for a stray or doubled comma
"=value" -> "=value": environment variable has no name before the =
```

The empty and no-name cases are rejected because docker fails them with exit
125 — the old behaviour silently stored a value that made any `--with_docker`
job refuse to start.

The same `strings.Cut` fixes a second pre-existing bug: `Split(...)[1]`
truncated any value containing a further `=`. It bites when a `cloud_script`
holds something like `export FOO=bar`, which truncates the bsub config JSON,
fails to unmarshal, and buries a child job on a mount failure it should have
tolerated.

## Known gaps, recorded rather than hidden

- The four checks are client-side; the server stores whatever compressed bytes a
  client sends, so an older client against an upgraded manager can still poison
  a job. Half B covers that.
- Nothing is logged when a read skips a malformed stored entry, so a legacy job
  degrades silently.
- `--env` is now the only comma-separated `wr add` flag that hard-errors on a
  trailing comma; `--limit_grps`, `--modules` and `--queues_avoid` accept one
  silently. Raised as its own item rather than folded in.

Full write-up, including the mutation evidence for every fix, in
`.docs/bugfixes/260909-fix-env-propagation.md`.
