### PR TITLE
Finish the container monitoring and run-command gaps

### DIFF
--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -506,3 +506,39 @@ rebases and Copilot caught it; this file names functions instead.
       defensible hardening, but it is not a fix for anything wr did, and doing
       it in reaction to a transient upstream hiccup would have been treating
       the symptom of somebody else's mirror.
+
+- [x] Copilot review of PR #593, 2 findings, both taken.
+    - `container/docker/docker_test.go` copied `docker pull` progress to
+      `os.Stdout`, spamming CI logs. It could NOT simply be dropped:
+      `ImagePull` does not complete until its body is consumed, verified
+      rather than assumed - a throwaway that closed the body without reading
+      it left the image absent from the daemon 9 seconds later, while the
+      draining version had it present immediately.
+    - Drained with a `json.Decoder` over moby's own `jsonstream.Message`
+      rather than `io.Discard`, which is MORE than the finding asked for, so
+      the trade-off is recorded. What plain discard loses: a pull that dies
+      part way through, AFTER the reference resolves, is reported by docker
+      only as an `errorDetail` inside the stream, and `io.Copy(io.Discard,
+      rc)` returns nil for it - the test would then fail later at
+      `ContainerCreate` with a bare "No such image", naming the image but not
+      the cause. Every failure BEFORE resolution is already returned by
+      `ImagePull` itself, checked on this daemon for both a bad digest and an
+      unknown repository, so the stream added nothing for those.
+    - Accepted over the 1-line version because it uses moby's own message type
+      rather than sniffing another tool's output format, and
+      `github.com/moby/moby/api` is already a direct dependency, so it costs
+      no `go.mod` change. The 1-line `io.Discard` alternative remains
+      available if the extra 15 lines in a test helper are judged not worth a
+      rare failure mode.
+    - Proved quiet AND working from a cold image: with alpine removed from the
+      daemon, `go test -v ./container/docker/` printed not one line of pull
+      progress and still passed in 1.5s, with the image present afterwards.
+      Honest caveat recorded by the implementor: containerd still held the
+      layer blobs, so it was a cold pull of the IMAGE rather than a cold
+      download of its layers - which does not weaken the drain finding, since
+      the no-drain run had the same warm blobs and still produced no image.
+    - Grammar in `fs/file/file.go` comments: "records an path read error" ->
+      "a path", the one Copilot named, plus "an error related to path could
+      not be read" -> "related to a path that could not be read", which is
+      ungrammatical rather than merely stylistic, and 2 of "read in to memory"
+      -> "read into memory". Comments only, no reword for style.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -420,3 +420,49 @@ rebases and Copilot caught it; this file names functions instead.
   `createContainers` error into "skipping docker tests", so a real regression
   in container creation reads as "no docker". Unique names shrink that surface
   but do not close it.
+
+- [x] Copilot review of PR #593, 3 findings, all valid, all taken.
+    - `PathReadError` could carry a NIL `Err`: `&PathReadError{"", nil}` at 2
+      sites, so an empty filename rendered
+      `path [] could not be read: %!s(<nil>)` in a log, and `Unwrap()` returned
+      nil, defeating the `errors.Is` matching item 6 had just added. Both nil
+      sites predate this branch; the `Unwrap` it added is what makes the second
+      half bite.
+    - Fixed with a package-level `ErrEmptyPath` sentinel wrapped by both sites,
+      beside `ErrLineTooLong` in the same file, so it is the file's existing
+      pattern rather than a new one. The 2 alternatives were rejected for
+      leaving the nil in place: a nil guard in `Error()` would make the
+      rendering tolerable while `Unwrap()` still returned nil, which is the
+      guard-around-a-should-never-be-nil that implementation-principles warns
+      about; and refusing to construct the struct without an error would mean
+      unexporting the `Err` field.
+    - Behaviour change, so red first, and each half proved separately because
+      GoConvey's `FailureHalts` hides the second assertion of a pair:
+      `errors.Is(err, ErrEmptyPath)` false, and the rendering
+      `Expected "path [] could not be read: path is empty"` against
+      `Actual "path [] could not be read: %!s(<nil>)"`. No CHANGELOG entry: the
+      only non-test caller is `cidPathToContainer`, whose path always comes
+      from an existing file or a glob match, so the branch is unreachable from
+      a user's job.
+    - "tilda" corrected to "tilde" in the 2 comments in `fs/file/file.go`.
+      Deliberately left, and listed rather than silently skipped: the exported
+      `TildaToHome` in `fs/filepath` and `internal`, its 10 call sites,
+      comments in `jobqueue/mount.go` and `internal/utils.go`, a test name in
+      `jobqueue/mount_test.go`, and 2 historical `.docs` records. Renaming an
+      exported identifier is not a comment fix.
+    - A FIFTH instance of the safety overstatement, in
+      `jobqueue/job_test.go`. That claim had already been corrected in 4 places
+      on this branch - `removeStaleContainerCmd`'s comment, `WithDocker`'s
+      field doc, `CmdLine`'s bullet and `cmd/add.go`'s help - and 4 separate
+      sweeps still missed this one. Worth recording as a lesson: finding the
+      same wrong claim 5 times by accident is not a search.
+    - So the 5th fix came with a deliberate repo-wide sweep across all text
+      files on 10 phrasings, with everything found reported whether changed or
+      not. Result: the 4 already-corrected sites, this 5th, and 2 that read as
+      the property but are NOT it - `CmdLine`'s bullet states the 2 filters and
+      defers to `WithDocker`, and the CHANGELOG states the literal consequence
+      of the filters. Also examined and correctly left:
+      `container/run_test.go`'s "never removes a container of that name that is
+      not this job's", whose body uses an UNLABELLED container, which genuinely
+      never is removed - the two-manager container carries this job's own key,
+      so it is not a counterexample to what that test asserts.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -50,7 +50,7 @@ rebases and Copilot caught it; this file names functions instead.
     - `DockerRunCmd` already does the equivalent: `-w "$PWD"` plus
       `--mount type=bind,source="$PWD",target="$PWD"`.
 
-- [ ] 6. A cid-file glob can read a large data file once a second, and inflate
+- [x] 6. A cid-file glob can read a large data file once a second, and inflate
   the job's recorded PeakRAM.
     - `GetContainerByPath` falls back to `cidPathGlobToContainer` when the
       configured path is not an existing file, and each glob match goes through
@@ -274,3 +274,81 @@ rebases and Copilot caught it; this file names functions instead.
   `FailReasonExit`, "command exited non-zero", though the command never ran.
   Special-casing 125 would misclassify a real job that legitimately exits 125,
   and telling the 2 apart needs the stderr sniffing that was avoided.
+
+## Item 6, as fixed
+
+- A FUNCTIONAL BUG the record did not spot, and the more user-visible half:
+  `GetFirstLine` never returned a first line. For any multi-line file it
+  returned everything with ONE trailing newline trimmed, so
+  `"id1\nsome other output\n"` came back as `"id1\nsome other output"` and
+  never matched a container id. A cidfile with any trailing content therefore
+  left the job unmonitored, silently.
+- Its consequence, confirmed at the monitor level by the reviewer: a cidfile
+  containing `jobs\ntrailing junk\n` now yields `containerID="jobs"` and that
+  container's memory is charged to the job - AND the container is SIGKILLed
+  with the job, inside `killCmd`. So the fix widens what wr kills, which is why
+  it earned its own CHANGELOG entry rather than being folded into the memory
+  one.
+- The widening is bounded, checked rather than assumed: only a container that
+  appeared AFTER `newDockerMonitor` remembered the baseline can be adopted, so
+  #589's guard is untouched; the first line must equal a container id exactly,
+  so a longer line can never match; and `GetContainerByPath`'s documented
+  contract already said "if the first line contains the ID of a container".
+- All 3 links of the memory chain verified. The harm was MEASURED: a 500 MB
+  file read once a second took `ownMemoryMB()` from 2 MB to 957 MB, and the
+  fixed version stays at 2. The reviewer independently confirmed the mechanism
+  at 32 MB, 67 MB allocated for a 4-byte answer - about 2x the file, because
+  `os.ReadFile` grows its buffer and `string()` copies it.
+- CORRECTION to the record's implication that the inflation is permanent: Go's
+  scavenger reclaims it after roughly 2 to 5 minutes. It does not matter,
+  because `ownMemoryMB()` is called once after `cmd.Wait()`, within a second of
+  the last 1-second tick, deep inside the inflated window.
+- `GetFirstLine` itself was changed rather than only its caller, because no
+  caller wants the old behaviour: it has exactly ONE non-test caller,
+  `cidPathToContainer`. `ToString` is byte-identical and has NO non-test
+  callers at all.
+- Bound is a named `maxFirstLineBytes = 4096`, 64x the 64 hex characters a cid
+  actually is, so no real cidfile can trip it. Past the bound it returns
+  `ErrLineTooLong` rather than a truncated prefix, because a 4096-byte prefix
+  is not the first line and a caller cannot tell it from one. Zero `//nolint`
+  in the diff - `mnd` was satisfied by naming the constants, not silenced.
+- A deliberate behaviour change, flagged by its author and kept: on the
+  EXACT-PATH route a too-long first line is now counted as a failure, and after
+  3 ticks wr warns and stops monitoring, where before it re-read for ever in
+  silence. The job is unaffected - `resolveContainerMem` returns no error by
+  design, so no `on_failure` behaviour fires, and `killCmd` is gated on a
+  non-empty container id so nothing is killed.
+- The asymmetry with the GLOB route, which skips a bad match silently, is
+  correct rather than an oversight: a glob is EXPECTED to match non-cidfiles,
+  while an exact path names one file the user asserted is a cidfile. 3 ticks is
+  right because the condition is not transient - the same file gives the same
+  answer every tick - and the latch is what stops one warning per second.
+- Tests measure ALLOCATION, which is the harm itself rather than a proxy for
+  it, via `TotalAlloc` deltas after a `runtime.GC()`. Deliberately not wall
+  clock. Proved deterministic: 25 in-process runs plus 20 separate processes,
+  zero failures, with a 60-200x margin below budget and a 3,300x gap from the
+  broken value. Files are made 32 MB instantly with a sparse `Truncate`, so the
+  tests cost nothing.
+- 4 mutations, each red for its own reason: the old `GetFirstLine` body; the
+  length guard removed; the length check reordered before the newline search
+  (which pins the exact boundary, a 4096-byte line returned and 4097 rejected);
+  and `cidPathToContainer` swallowing the error.
+- 2 GoConvey traps hit and worth passing on: the default `FailureHalts` meant
+  an allocation assertion silently never ran until it was moved first, so the
+  first "red" proved only the wrong half; and asserting equality on a 32 MB
+  string dumped 128 MB into the failure output, fixed with a `shorten()`
+  helper.
+- `PathReadError` gained an `Unwrap` so `errors.Is` works on it. Its sibling
+  `OperatorError` already had one, so this is consistency rather than a new
+  pattern, and no existing caller does `errors.Is`/`errors.As` on it.
+- CHANGELOG failed review twice over and now says the truth: the old entry
+  claimed wr "ignores" a too-long match, which is true only of the glob loop,
+  and was framed as "a path WITH A GLOB IN IT", which excluded the exact-path
+  route entirely. It is now 2 entries - the memory one covering both routes and
+  saying the job itself is unaffected, and a separate one for the recognition
+  fix that ends on the kill, which is the sentence a user needs.
+- Caveat, contrived and non-blocking: `--monitor_docker mycontainer` resolves
+  to `<cmdDir>/mycontainer`, so if the job's own working directory happens to
+  hold a large file of that name with no newline in its first 4096 bytes, the
+  latch now disables the BY-NAME lookup too. That setup was already inflating
+  PeakRAM every second before this change.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -12,7 +12,7 @@ was re-verified against `develop` at `0cc79218` before this branch started.
 No `file.go:NNN` references below. PR #591 shipped with stale ones after three
 rebases and Copilot caught it; this file names functions instead.
 
-- [ ] 4. A container that outlives its `docker run` keeps the job key as its
+- [x] 4. A container that outlives its `docker run` keeps the job key as its
   name, and then every retry of that job fails immediately.
     - `containerRunCmd` (`jobqueue/job.go`) passes `j.Key()` as `--name`.
       `--rm` covers the normal case, but a container that outlives its client
@@ -167,3 +167,110 @@ rebases and Copilot caught it; this file names functions instead.
   `--mount type=bind,source="$PWD"` (`invalid field 'me' must be a key=value
   pair`). `Job.containerMounts()` already splits `ContainerMounts` on comma, so
   the assumption is baked in upstream.
+
+## Item 4, as fixed
+
+- `DockerRunCmd`'s line is now prefixed by `removeStaleContainerCmd(name)`,
+  which removes a container matching BOTH filters, `AND`ed by docker:
+  `name=^<name>$` says it is in our way, and
+  `label=uk.ac.sanger.wr.job-key=<name>` says it is ours.
+  `regexp.QuoteMeta` on the name, because docker's `name` filter is a regex.
+- Name and label are UNCHANGED, both still `j.Key()`, so #589's correlation is
+  untouched. The reviewer proved that independently by driving the real
+  `Operator` over the real docker `Interactor` in `setupDockerMonitor`'s order:
+  after the stale container is removed, both `GetNewContainerByName` and
+  `adoptLabelledNewContainer`'s label loop resolve to the same new container.
+- Design, with the rejected options recorded because they look attractive:
+  * a UNIQUE NAME per attempt fixes the retry without any destructive call,
+    but leaves the orphan alive FOREVER - wr's only removal path is
+    `KillContainer` from a live runner that has already identified the
+    container, and there is no reaper - so orphans accumulate on worker nodes.
+    It also races the retry, since `mkHashedDir` is deterministic on the key
+    and both land in the same `$PWD`. And it moves the monitor surface,
+    because `containerRunCmd` sets `MonitorDocker = j.Key()` and
+    `findContainerID` takes the by-name path for `--with_docker` jobs.
+  * DETECTING docker's error and renaming it never makes the job runnable, and
+    means string-matching another tool's prose.
+  * DOING IT IN GO is blocked: `Interactor.ContainerList` passes `All: false`,
+    so an EXITED leftover is invisible to the Go client, and widening that
+    listing is exactly what the monitor's new-container diff is built on.
+- CORRECTION to that last point as first reported: "the Go client cannot see
+  the leftover at all" is true only for an exited one. A RUNNING leftover IS in
+  the baseline the monitor remembers - benign, and in fact helpful, since being
+  remembered it can never be adopted.
+- Safety, verified by the reviewer against real docker 29.1.3 across 8 cases,
+  with an unrelated bystander present throughout. It could not be made to
+  remove anything it should not:
+
+  ```
+  running leftover, our label                 -> removed
+  exited leftover, our label                  -> removed
+  our name, ANOTHER job's label               -> survives, run fails as before
+  our name, no label at all                   -> survives, run fails as before
+  our label, different name                   -> survives
+  name wrrevF, container wrrevFextra          -> survives (the ^...$ anchors)
+  job wrrev.G, container wrrevXG              -> survives (regexp.QuoteMeta)
+  job wrrev.G, container really named wrrev.G -> removed
+  ```
+
+- Shell safety: 8 hostile names driven through the real line under `/bin/sh`
+  (`evil; touch`, `evil$(touch)`, backticks, embedded newline, `evil*`, quote
+  breakouts) created ZERO files. The failure in each case is docker's own
+  "Invalid container name". This does not rely on `j.Key()` being hex.
+  `260907-1.md`'s trap is avoided because the `$` here is MEANT to be literal,
+  unlike `$PWD`.
+- Failure modes of the prefix are all clean no-ops with the exit status still
+  `docker run`'s, checked against the bare line: filter matches nothing (bash
+  and dash), docker absent from PATH, daemon down, `docker ps` failing,
+  `docker ps` printing a non-id. It introduces no `|`, so
+  `buildExecCmd`'s `set -o pipefail` trigger is unchanged.
+- The still-running case is deliberate, and the justification was verified
+  against code rather than accepted: `wr retry` only touches buried jobs;
+  `jobConfirmedDead` re-runs only when the command pid and the runner pid are
+  both confirmed dead, and the command pid IS the shell running `docker run`;
+  `backstopKillWedgedRunner` kills the runner and command but NOT the
+  container, which is what manufactures the leftover; and
+  `killLostJobAndTriggerBehaviours` latches, so one manager never has 2 live
+  runners for a key.
+- The LIMIT of that, now stated in the code rather than asserted away:
+  `Job.Key()` is derived from Cwd, Cmd, mounts and image and names no manager,
+  so 2 managers on one docker host running the identical command in the
+  identical Cwd share a key, and either could remove a container the other has
+  running. Before this change the second merely failed loudly. Mitigating: that
+  pair already shares the same deterministic `mkHashedDir` working directory
+  and is already corrupting each other. A second additive label carrying a
+  manager id would close it without disturbing #589, and is NOT done here.
+- That overstatement had reached 4 places. All 4 corrected:
+  `removeStaleContainerCmd`'s comment, `WithDocker`'s field doc, `CmdLine`'s
+  doc bullet, and `cmd/add.go`'s terminal help - the last being the only copy a
+  wr USER sees, so it keeps the caveat in the user's own vocabulary, with no
+  mention of the label or the key. The CHANGELOG's trailing "cannot prove is
+  its own" became the literal consequence of the 2 filters.
+- Blocking test defect found by the reviewer and fixed, and it would have
+  broken CI rather than this box: `startTestContainer` read the container id
+  from `CombinedOutput()`, but `docker run --detach` writes the id to STDOUT
+  and any image pull to STDERR, so on a machine without `alpine:latest` cached
+  the "id" is the pull progress and the assertion compares against
+  `"Unable to fi"`. `realTestSetup` never pre-pulls, so that is a fresh
+  runner's normal state. Proved by `docker save`, `docker rmi`, run, then
+  `docker load` - and the fix proved the same way, with the image id and repo
+  digest verified byte-identical afterwards.
+- `regexp.QuoteMeta` had NO test: removing it left `./container/...` and
+  `TestJob` green, on the most destructive change here. Closed with an exact
+  string case for a name containing a metacharacter, which also pins the
+  asymmetry that makes the 2 filters do different jobs - the name filter
+  escapes, the label filter carries the name raw.
+- The co-tenant Convey, honestly flagged by its author as green before and
+  after, IS load-bearing: it goes red under the mutation that drops the label
+  filter, which is precisely the mutation that would make the change
+  destructive.
+- Legibility: the item claimed the failure "names an opaque key rather than the
+  job". Only docker's half does - wr's `loggableCmd()` already puts the user's
+  own command line in front of it, and `wr status` prints `StdErr:` alongside
+  the `Cmd`. So no error sniffing was added. When wr does destroy something it
+  says so on the job's own stderr:
+  `wr: removing container 08a4951e32a5, left behind by a lost run of this same command`.
+- Left alone deliberately, and worth its own item: exit 125 is classified
+  `FailReasonExit`, "command exited non-zero", though the command never ran.
+  Special-casing 125 would misclassify a real job that legitimately exits 125,
+  and telling the 2 apart needs the stderr sniffing that was avoided.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -466,3 +466,43 @@ rebases and Copilot caught it; this file names functions instead.
       not this job's", whose body uses an UNLABELLED container, which genuinely
       never is removed - the two-manager container carries this job's own key,
       so it is not a counterexample to what that test asserts.
+
+- [x] Sighting only, and NOT a test failure at all: CI `test` for `73c5db7`
+  failed in the "Install container runtimes" step, before any test ran.
+    - `sudo apt-get update` failed on the GitHub runner's PREINSTALLED Google
+      Chrome repository, which served an index whose hashes did not match its
+      Release file:
+
+      ```
+      Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
+        Hash Sum mismatch
+        Last modification reported: Wed, 09 Sep 2026 09:41:12 +0000
+        Release file created at:    Wed, 09 Sep 2026 17:16:59 +0000
+      E: Some index files failed to download.
+      ##[error]Process completed with exit code 100
+      ```
+
+      An 8-hour gap between the Release file and the Packages file it points
+      at: a stale mirror, momentarily inconsistent.
+    - Nothing to do with wr, and nothing to do with this branch: the branch
+      changes no `.github/` file and no `Makefile`, and the failing step is
+      `apt-get update` fetching a repository the runner image ships and wr does
+      not ask for. `make lint` passed on the same commit, and `make test` and
+      `make race` both passed locally at `645 passed · 13 skipped`.
+    - Recorded rather than waved through, and worth knowing for next time: a
+      red CI `test` on this repo is not necessarily a test. Read which STEP
+      failed before reading the assertions.
+    - Remedy: re-ran the job. It took THREE attempts, not one - the first
+      re-run failed identically, which briefly looked like a persistent broken
+      mirror rather than a transient one. It was transient: PR #592's CI passed
+      minutes after that second failure, on the same runner image, so the
+      mirror had already recovered. 2 consecutive failures of ONE pull request
+      is not evidence of a systemic problem, and reading it that way nearly
+      cost a needless change to `.github/workflows/tests.yml`.
+    - What would have been wrong about that change, recorded so nobody makes
+      it later on this evidence: the workflow's bare `sudo apt-get update`
+      refreshes every repository the runner image ships, including a Google
+      Chrome one wr never asks for. Dropping that repo before updating is a
+      defensible hardening, but it is not a fix for anything wr did, and doing
+      it in reaction to a transient upstream hiccup would have been treating
+      the symptom of somebody else's mirror.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -1,0 +1,169 @@
+# Bugfixes 2026-09-09
+
+fix-container-monitor-gaps
+
+The remaining items from `origin/record-container-monitor-gaps`
+(`.docs/bugfixes/260903-8.md`, commit `bdd17d4`). Items 1, 2 and 3 of that
+record are already fixed and merged, as #589, #587 and #590 respectively.
+
+FOUR items remain, not the two that were expected: 6 and 7 were open too. Each
+was re-verified against `develop` at `0cc79218` before this branch started.
+
+No `file.go:NNN` references below. PR #591 shipped with stale ones after three
+rebases and Copilot caught it; this file names functions instead.
+
+- [ ] 4. A container that outlives its `docker run` keeps the job key as its
+  name, and then every retry of that job fails immediately.
+    - `containerRunCmd` (`jobqueue/job.go`) passes `j.Key()` as `--name`.
+      `--rm` covers the normal case, but a container that outlives its client
+      keeps the name: the runner SIGKILLed, the host lost, the daemon restarted
+      mid-run.
+    - wr only removes a container via `KillContainer` from `killCmd`, which
+      needs a live runner that has already identified it. Verified still true:
+      a repo-wide grep for `ContainerRemove` / `RemoveContainer` outside tests
+      finds nothing.
+    - So after a lost run, every retry dies at `docker run` with "The container
+      name ... is already in use", and the message names an opaque
+      32-character key rather than the job. The job is effectively unrunnable
+      until someone removes the container by hand.
+    - Two halves to weigh: making the retry work, and making the failure
+      legible if it still happens.
+    - Constraint: #589 gave the container a
+      `--label uk.ac.sanger.wr.job-key=<key>` and its monitor matches on that
+      label, so whatever is done to the NAME must keep that correlation
+      working.
+
+- [x] 5. `SingularityRunCmd` contradicts its own doc comment.
+    - The comment promises "The CWD is always mounted at / in container". The
+      implementation emits only `cat %s | singularity shell%s %s`, with `-B`
+      for each explicitly configured mount and nothing else: no bind for the
+      working directory, and no `--pwd`. Verified unchanged on `develop`.
+    - So the command runs wherever singularity puts it, with whatever the
+      site's `singularity.conf` binds. Typical site defaults bind the user's
+      real `$HOME` read-write and NOT wr's working directory - the opposite of
+      what a wr job wants. The job writes to its home instead of its workspace,
+      and `--change_home` has no effect inside the container.
+    - The record is careful about what it can prove, and so should the fix be:
+      the singularity-default half is a claim about site configuration, not
+      about this repo. The missing bind and the missing `--pwd` are in the
+      code, and those are what this item owns.
+    - `DockerRunCmd` already does the equivalent: `-w "$PWD"` plus
+      `--mount type=bind,source="$PWD",target="$PWD"`.
+
+- [ ] 6. A cid-file glob can read a large data file once a second, and inflate
+  the job's recorded PeakRAM.
+    - `GetContainerByPath` falls back to `cidPathGlobToContainer` when the
+      configured path is not an existing file, and each glob match goes through
+      `cidPathToContainer` -> `file.GetFirstLine` -> `file.ToString` ->
+      `os.ReadFile`. Verified: `GetFirstLine` reads the WHOLE file into memory
+      and then trims one trailing newline.
+    - `findContainerID` runs on the 1-second resource ticker for as long as no
+      container has been identified, so a `--monitor_docker` glob matching a
+      large output file - `*.txt`, `out*` - re-reads that file every second for
+      the life of the job.
+    - The record corrects its own first telling of where the cost lands, and
+      the correction matters: `currentMemory(job.Pid)` measures the job's own
+      process tree, not the runner, so the read does not land there. It lands
+      through the runner's own footprint, which wr deliberately adds to the
+      job's peak (`ourmem, _ := ownMemoryMB()` then `peakmem += ourmem`). So a
+      big glob match inflates the job's recorded PeakRAM, and with it the RAM
+      wr reserves for its next run.
+
+- [ ] 7. `container/docker/docker_test.go` uses the developer's real docker.
+    - `pullUbuntuImage` calls `cli.ImagePull(ctx, "ubuntu", ...)` against
+      `client.FromEnv`, and the tests start containers named `container_1` and
+      `container_2` in that same daemon. Verified all three still present.
+    - Running the package's tests therefore pulls
+      `docker.io/library/ubuntu:latest` into the developer's real docker,
+      re-pointing the `ubuntu:latest` tag if they had built their own, and
+      takes names that may collide with theirs.
+    - A test that needs a real daemon should at least use a digest-pinned image
+      and unique names.
+
+## Item 5, as fixed
+
+- The code was made to match the promise, not the other way round, and the case
+  is stronger than this item put it: there were TWO pre-existing promises, both
+  verified by the reviewer and both predating the branch.
+  * `cmd/add.go`'s `with_singularity` help: "The container is created with cwd
+    mounted and set to current directory inside the container", dating to
+    `f7995da` (Nov 2021), the commit that added container support.
+  * `jobqueue/job.go`'s `WithSingularity` field doc: "Cwd will be mounted
+    inside the container and will be the working directory in the container."
+  A repo-wide grep finds exactly 4 such statements - 2 docker, already true,
+  and these 2. So every user-facing and API-facing thing wr said already
+  described the fixed behaviour, and fixing only the doc comment would have
+  left the text users actually read still lying.
+- New `singularityWorkDirArgs` mirrors `workDirMountArgs`, emitting
+  `-B "$PWD" --pwd "$PWD"` before the explicit `-B` mounts. `$PWD` stays a
+  double-quoted shell expansion for the reason `260907-1.md` established:
+  `shellquote.Join` would emit `'$PWD'` and kill the expansion.
+- CORRECTION to the mechanism the implementor gave, which the reviewer
+  disproved empirically. It argued "mounted at `/`" cannot be literal because
+  binding CWD over `/` would shadow the image root and leave no `/bin/sh`. Not
+  so - singularity-ce 4.1.1 accepts the bind and makes it a SILENT NO-OP,
+  mounting the source and then layering the rootfs over it:
+
+  ```
+  $ echo 'pwd; ls /' | singularity shell -B "$PWD/bindroot:/" docker://alpine
+  bin dev environment etc home lib ... usr var
+  EXIT=0
+  ```
+
+  The image root survives and `/bin/sh` runs. The conclusion is unchanged and
+  actually stronger: the comment's literal reading is not implementable at all,
+  so it can only ever have been the symptom written down as the mechanism -
+  when a site binds nothing, singularity simply STARTS the process at `/`.
+- `--pwd` rather than `--cwd`, deliberately. 4.1.1's help presents `--cwd` as
+  the flag and `--pwd` as its synonym, so the naive choice is `--cwd` - but
+  `--cwd` is the NEWER name (SingularityCE 3.11 / Apptainer 1.1) while `--pwd`
+  goes back to Singularity 2.x and works on every release. A
+  `with_singularity` job runs against whatever singularity is on the worker
+  nodes.
+- The existing real tests were STRUCTURALLY BLIND to this, which is why it
+  survived: they build their working directory under `/tmp`, which singularity
+  binds by default, so the job landed in the right place by accident. Proved by
+  the reviewer running the unfixed line both ways:
+
+  ```
+  no fix, no NO_MOUNT  -> /tmp/.../home + home.file   exit 0   (the old tests' world)
+  no fix, NO_MOUNT set -> /  + ls: *.file not found   exit 1   (a hostile site)
+  ```
+
+- The new `TestRunRealSingularityWorkDir` therefore sets
+  `SINGULARITY_NO_MOUNT=cwd,home,tmp`, which is singularity's own `--no-mount`
+  and so genuinely stands in for a site whose `singularity.conf` binds none of
+  them. That `t.Setenv` is itself load-bearing: with the fix reverted AND the
+  setenv removed, the test passes.
+- Verified against real singularity, not asserted: with the fix the container
+  prints its wr working directory and lists the file placed there; without it,
+  `/` and `ls: *.file: No such file or directory`. Also driven with a working
+  directory containing a space, and one containing `;rm -rf x&*'q'` - the path
+  is printed verbatim, nothing executed, nothing removed.
+- Known and accepted: the real test CANNOT discriminate `--pwd`. Under
+  `SINGULARITY_NO_MOUNT`, `-B "$PWD"` alone already lands in the working
+  directory, because singularity defaults its cwd to the host cwd once that
+  path exists in the container; only the string assertions cover `--pwd`. It is
+  kept because it states the contract explicitly, mirrors docker's `-w`, and
+  does not depend on a default that varies by version and with `--contain`.
+- Two failure modes checked for regression risk, both benign: `--pwd` at a path
+  that does not exist in the container (a site with `user bind control = no`,
+  where `-B` is ignored) does not hard-fail, singularity falls back to `$HOME`;
+  and a duplicate bind, where the user's own `container_mounts` also names the
+  cwd, warns and proceeds.
+- `jobqueue/job_test.go` asserts the same command string in 3 more places,
+  which this item did not name. Updated, and every changed assertion got
+  LONGER: `ShouldEqual` stayed `ShouldEqual`, `ShouldEndWith` stayed
+  `ShouldEndWith` with a longer suffix, and no `ShouldContainSubstring` was
+  introduced anywhere.
+- CHANGELOG entry added under `### Fixed`, not `### Changed`: no documented
+  contract moved, the code caught up with one that had been wrong since 2021.
+- The test's red output now names the directory the container actually started
+  in, so a future regression reads `output: "/\n"` rather than only
+  `exit status 1`.
+- Residual limitation, confirmed present in DOCKER too and therefore left for
+  consistency: a working directory containing a comma breaks `-B "$PWD"`
+  (`unable to add ... to mount list`), exactly as it breaks
+  `--mount type=bind,source="$PWD"` (`invalid field 'me' must be a key=value
+  pair`). `Job.containerMounts()` already splits `ContainerMounts` on comma, so
+  the assumption is baked in upstream.

--- a/.docs/bugfixes/260909-fix-container-monitor-gaps.md
+++ b/.docs/bugfixes/260909-fix-container-monitor-gaps.md
@@ -69,7 +69,7 @@ rebases and Copilot caught it; this file names functions instead.
       big glob match inflates the job's recorded PeakRAM, and with it the RAM
       wr reserves for its next run.
 
-- [ ] 7. `container/docker/docker_test.go` uses the developer's real docker.
+- [x] 7. `container/docker/docker_test.go` uses the developer's real docker.
     - `pullUbuntuImage` calls `cli.ImagePull(ctx, "ubuntu", ...)` against
       `client.FromEnv`, and the tests start containers named `container_1` and
       `container_2` in that same daemon. Verified all three still present.
@@ -352,3 +352,71 @@ rebases and Copilot caught it; this file names functions instead.
   hold a large file of that name with no newline in its first 4096 bytes, the
   latch now disables the BY-NAME lookup too. That setup was already inflating
   PeakRAM every second before this change.
+
+## Item 7, as fixed
+
+- All 3 problems were proved real rather than argued, and the first is the
+  worst because it is silent:
+  * a COLLIDING NAME does not fail the test, it SKIPS it -
+    `skipping docker tests: ... Conflict. The container name "/container_1" is
+    already in use` then `--- SKIP: TestDocker`. A developer with their own
+    `container_1` had these tests quietly not running.
+  * the TAG really is re-pointed: pointing `ubuntu:latest` at another image and
+    running the unmodified test replaced it with the registry's, while the pull
+    stream said `Status: Image is up to date`.
+  * a FAILURE leaks: one forced assertion left 2 containers behind.
+- Now `alpine@sha256:28bd5fe8...`, 13 MB rather than ubuntu's 160 MB. Nothing
+  depended on it being ubuntu: every assertion in the file is `err == nil`,
+  `stats != nil`, `len(list) >= 2` or an error case. Nothing execs, reads a
+  shell path, or reads a stats VALUE. The only implicit requirement is that the
+  container stays RUNNING, because `ContainerList` passes `All: false`, and
+  alpine's `/bin/sh` with `Tty: true` does that as well as ubuntu's
+  `/bin/bash`.
+- The digest is the multi-platform OCI INDEX, verified against the registry by
+  both agents: `content-type: application/vnd.oci.image.index.v1+json`, 8
+  architectures. A per-arch manifest digest would have quietly broken the suite
+  on arm64.
+- Names are `filepath.Base(filepath.Dir(t.TempDir())) + "_1"/"_2"`, reusing
+  item 4's scheme rather than inventing a second. Proved under concurrency: 3
+  simultaneous test binaries produced 6 distinct names, all green.
+- Cleanup moved to `t.Cleanup`, registered BEFORE the start attempt, because a
+  container that fails to start still exists and still holds its name. Verified
+  on all 3 paths - pass, forced failure, and forced start failure - each
+  leaving `docker ps -a` identical to baseline. The old code leaked on the
+  failure path, demonstrated against `git show HEAD`'s version.
+- The cold-pull claim was checked the hard way: the reviewer removed the real
+  alpine, planted a FAKE `alpine:latest` standing in for a developer's own
+  build, and ran the tests. The developer's image survived untouched and the
+  pull landed as a separate digest-only row with no tag. With no alpine at all,
+  no `alpine:latest` was created either.
+- Honest footnote the implementor missed and the reviewer added: the digest
+  pull DOES persist `alpine@sha256:...` in the reference store, so on a machine
+  that does not already hold that content, `./container/...` leaves a 13 MB
+  `alpine <none>` row behind. Benign and unavoidable for a suite needing a real
+  daemon - but it means "daemon identical before and after" was true on this
+  box only because it already had that exact digest.
+- `Platform: {Architecture: "amd64"}` removed from `createContainer`, with the
+  now-unused `linuxOS` const and `specs` import. It contradicted the new
+  comment 3 functions above, and on an arm64 host it made the whole
+  real-daemon test SKIP - simulated by flipping the literal to `arm64` on this
+  amd64 box. With it gone the daemon resolves the multi-arch index to its own
+  platform, which is what the comment promises. `TestDocker` runs rather than
+  skipping.
+- Judged out of scope, with the reasoning recorded because the 2 look alike:
+  `container/run_test.go` still passes an unpinned `alpine` in 5 places, but
+  that is MATERIALLY WEAKER - `docker run` pulls only when the image is
+  ABSENT, so it can never re-point an existing tag, proved by resolving
+  `docker create alpine` against a fake local tag with no registry contact.
+  Item 7's defect was `cli.ImagePull`, which pulls UNCONDITIONALLY and
+  therefore always re-points. Worth its own item, since 3 of those 5 sites are
+  new on this branch.
+- Follow-up for the repo owner, NOT done here because it is outside a test-only
+  item: `github.com/opencontainers/image-spec v1.1.1` is in go.mod's DIRECT
+  require block and this was its last direct import in the repo. A `go mod
+  tidy` will move it to indirect. `make lint` is `0 issues.` as it stands, so
+  nothing fails on it today.
+- No CHANGELOG entry: test-only, no user-visible behaviour.
+- Pre-existing and unchanged, worth knowing: `TestDocker` turns EVERY
+  `createContainers` error into "skipping docker tests", so a real regression
+  in container creation reads as "no docker". Unique names shrink that surface
+  but do not close it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
   under-reported and that no container will be killed with it. A container wr
   started for the job itself (`--with_docker`) is still recognised whatever
   else appears alongside it.
+- `--with_singularity` now really does what it has always said it does: your
+  working directory is mounted at the same path inside the container, and is
+  the working directory your command runs in there. Previously wr asked
+  singularity for neither, so your command ran wherever your site's
+  `singularity.conf` put it, commonly `/` or your real home directory, with the
+  command's own working directory not visible inside the container at all and
+  `--change_home` having no effect there. If your site's `singularity.conf`
+  already bound your working directory, nothing changes.
 
 
 ## [0.37.2] - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,16 @@ project adheres to [Semantic Versioning](http://semver.org/).
   command's own working directory not visible inside the container at all and
   `--change_home` having no effect there. If your site's `singularity.conf`
   already bound your working directory, nothing changes.
+- A `--with_docker` command whose container outlived the run that started it -
+  the runner SIGKILLed, its host lost, or the docker daemon restarted mid-run -
+  could not be retried. Every attempt failed immediately with docker's "The
+  container name ... is already in use", naming only wr's own 32-character key
+  for the command, and the command stayed unrunnable until someone removed that
+  container by hand. wr now removes the leftover container itself before
+  starting the new one, and reports on the command's STDERR which container it
+  removed. It only ever removes a container that both holds the name it needs
+  and carries wr's own label naming that same command, so any other container of
+  that name is left alone and docker's conflict is reported as before.
 
 
 ## [0.37.2] - 2026-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,29 @@ project adheres to [Semantic Versioning](http://semver.org/).
   removed. It only ever removes a container that both holds the name it needs
   and carries wr's own label naming that same command, so any other container of
   that name is left alone and docker's conflict is reported as before.
+- A `--monitor_docker` cidfile path, with or without a glob in it (`*.cid`,
+  `out*`, or a plain path to a single file), no longer inflates the peak RAM wr
+  records for your command. Until wr found the container, it re-read the whole
+  of every file the path matched, once a second for the life of the command; if
+  the path also matched one of your command's large output files, the memory
+  that took was added to the command's peak, and so to the RAM wr reserved for
+  it next time. wr now reads no more than the first 4096 bytes of a match: far
+  more than a container id needs, and little enough that a large file the path
+  matched by accident is never read in. A match whose first line is longer than
+  that is skipped if the path had a glob in it, the remaining matches still
+  being checked; if the path named that one file, wr instead warns that it could
+  not read it, and after three such checks stops monitoring for the rest of the
+  command, so no container's RAM and CPU are added to what wr reports for it and
+  no container is killed if you kill the job. Either way your command itself is
+  unaffected: it runs on as normal, and none of its `on_failure` behaviours
+  fire.
+- A `--monitor_docker` cidfile with anything after the container id in it, such
+  as your command's own output appended to the same file, is now recognised. wr
+  took the id to be the whole file bar one trailing newline, so such a file
+  never matched a container and the command ran unmonitored without wr saying
+  so. wr now reads just the first line, so the container's peak RAM and total
+  CPU are added to the usage wr reports for the command - and, as for any
+  monitored container, wr kills that container too when you kill the job.
 
 
 ## [0.37.2] - 2026-09-01

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -442,11 +442,16 @@ automatically pulled if it is missing. The container is created with cwd mounted
 and set to the workdir. Any mounts specified by "container_mounts" will also be
 mounted inside the container. Any environment variables you explicitly override
 with "env" will be set inside the container, but not other environment variables
-you have set at the time you add the command. Finally, "monitor_docker" will be
-overridden and set to monitor the container wr creates. If you would need to run
-your docker container with additional options or in a different way, don't use
-"with_docker", and instead have command be your own 'docker run [...]' command,
-and set "monitor_docker" as appropriate.
+you have set at the time you add the command. If a previous run of this same
+command left its container behind, wr removes that container first, so that the
+command can be retried. A container of that name that wr did not create for this
+same command is left alone, and still fails the run. Two wr managers on one
+docker host running this command in the same directory are indistinguishable
+here, so either can remove a container the other is running. Finally,
+"monitor_docker" will be overridden and set to monitor the container wr creates.
+If you would need to run your docker container with additional options or in a
+different way, don't use "with_docker", and instead have command be your own
+'docker run [...]' command, and set "monitor_docker" as appropriate.
 
 "with_singularity" takes an image name/location and is a convenience feature
 that will run your command by piping it into 'singularity shell [image]'.

--- a/container/docker/docker_test.go
+++ b/container/docker/docker_test.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -42,11 +43,21 @@ import (
 	cn "github.com/moby/moby/api/types/container"
 	nw "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const linuxOS = "linux"
+// testImage is the image the tests that need a real docker daemon run. It is
+// alpine, not ubuntu, because all they need is a container that stays up, and
+// alpine is a 13MB pull rather than a 160MB one; it is also what
+// container/run_test.go's real tests use, so a developer running ./container/...
+// needs one image and not two.
+//
+// It is pinned by digest so that pulling it cannot re-point a developer's own
+// alpine:latest: docker only writes a tag when it pulls one, and this asks for
+// a digest. The digest is that of the multi-platform index alpine:latest
+// pointed at on 2026-09-09 (alpine 3.24.1), so it resolves on any architecture
+// the daemon runs.
+const testImage = "alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
 
 // testAPIVersion is the docker API version our fake daemon serves; the moby
 // client asks for a pinned version directly instead of negotiating one.
@@ -217,6 +228,22 @@ func listingDockerSocket(t *testing.T, containers []cn.Summary) string {
 	return "unix://" + sock
 }
 
+func pullTestImage(ctx context.Context, cli *client.Client) error {
+	rc, err := cli.ImagePull(ctx, testImage, client.ImagePullOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, copyErr := io.Copy(os.Stdout, rc)
+	closeErr := rc.Close()
+
+	if copyErr != nil {
+		return copyErr
+	}
+
+	return closeErr
+}
+
 func TestDockerContainerLabels(t *testing.T) {
 	ctx := context.Background()
 
@@ -255,45 +282,40 @@ func TestDockerContainerLabels(t *testing.T) {
 }
 
 // createContainers creates and starts the test containers, given a list of
-// container names.
-func createContainers(ctx context.Context, cli *client.Client, containerNames []string) ([]string, error) {
-	if err := pullUbuntuImage(ctx, cli); err != nil {
+// container names, and arranges for each one it creates to be removed when the
+// test ends.
+func createContainers(ctx context.Context, t *testing.T, cli *client.Client,
+	containerNames []string) ([]string, error) {
+	t.Helper()
+
+	if err := pullTestImage(ctx, cli); err != nil {
 		return nil, err
 	}
 
-	return createAndStartNamedContainers(ctx, cli, containerNames)
+	return createAndStartNamedContainers(ctx, t, cli, containerNames)
 }
 
-func pullUbuntuImage(ctx context.Context, cli *client.Client) error {
-	rc, err := cli.ImagePull(ctx, "ubuntu", client.ImagePullOptions{})
-	if err != nil {
-		return err
-	}
+func createAndStartNamedContainers(ctx context.Context, t *testing.T, cli *client.Client,
+	containerNames []string) ([]string, error) {
+	t.Helper()
 
-	_, copyErr := io.Copy(os.Stdout, rc)
-	closeErr := rc.Close()
+	cntrIDs := make([]string, 0, len(containerNames))
 
-	if copyErr != nil {
-		return copyErr
-	}
-
-	return closeErr
-}
-
-func createAndStartNamedContainers(ctx context.Context, cli *client.Client, containerNames []string) ([]string, error) {
-	cntrIDs := make([]string, len(containerNames))
-
-	for idx, cname := range containerNames {
+	for _, cname := range containerNames {
 		containerID, err := createContainer(ctx, cli, cname)
 		if err != nil {
-			return nil, err
+			return cntrIDs, err
 		}
+
+		// registered before the start, because a container that fails to start
+		// still exists and still holds its name.
+		removeContainerAtEnd(t, cli, containerID)
 
 		if err = startContainer(ctx, cli, containerID); err != nil {
-			return nil, err
+			return cntrIDs, err
 		}
 
-		cntrIDs[idx] = containerID
+		cntrIDs = append(cntrIDs, containerID)
 	}
 
 	return cntrIDs, nil
@@ -301,33 +323,34 @@ func createAndStartNamedContainers(ctx context.Context, cli *client.Client, cont
 
 func createContainer(ctx context.Context, cli *client.Client, cname string) (string, error) {
 	cbody, err := cli.ContainerCreate(ctx, client.ContainerCreateOptions{
-		Config:           &cn.Config{Image: "ubuntu", Tty: true},
+		Config:           &cn.Config{Image: testImage, Tty: true},
 		HostConfig:       &cn.HostConfig{},
 		NetworkingConfig: &nw.NetworkingConfig{},
-		Platform:         &specs.Platform{Architecture: "amd64", OS: linuxOS},
 		Name:             cname,
 	})
 
 	return cbody.ID, err
 }
 
+// removeContainerAtEnd force-removes the given container when the test ends,
+// however it ends, so that a failed assertion or a skip cannot leave a
+// container running on the developer's daemon.
+func removeContainerAtEnd(t *testing.T, cli *client.Client, containerID string) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		_, err := cli.ContainerRemove(context.Background(), containerID,
+			client.ContainerRemoveOptions{Force: true})
+		if err != nil {
+			t.Logf("container %s could not be removed: %s", containerID, err)
+		}
+	})
+}
+
 func startContainer(ctx context.Context, cli *client.Client, containerID string) error {
 	_, err := cli.ContainerStart(ctx, containerID, client.ContainerStartOptions{})
 
 	return err
-}
-
-// removeContainers removes all the containers given a list of containers as a
-// part of clean up step.
-func removeContainers(ctx context.Context, cli *client.Client, containerIDs []string) error {
-	for _, cid := range containerIDs {
-		_, err := cli.ContainerRemove(ctx, cid, client.ContainerRemoveOptions{Force: true})
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func TestDocker(t *testing.T) {
@@ -346,9 +369,7 @@ func TestDocker(t *testing.T) {
 	}
 
 	// create and start the test containers
-	var cntrNames = []string{"container_1", "container_2"}
-
-	cntrIDs, err := createContainers(ctx, cli, cntrNames)
+	cntrIDs, err := createContainers(ctx, t, cli, testContainerNames(t, 2))
 	if err != nil {
 		t.Skip("skipping docker tests: ", err)
 	}
@@ -407,12 +428,6 @@ func TestDocker(t *testing.T) {
 					remainList, err := dockerInterator.ContainerList(ctx)
 					So(err, ShouldBeNil)
 					So(remainList, ShouldNotBeNil)
-
-					// Cleanup: Remove all the dummy container
-					err = removeContainers(ctx, cli, cntrIDs)
-					if err != nil {
-						t.Log("Containers could not be removed: ", err)
-					}
 				})
 			})
 
@@ -430,4 +445,22 @@ func TestDocker(t *testing.T) {
 			})
 		})
 	})
+}
+
+// testContainerNames returns the given number of container names unique to this
+// test run, derived from the temporary directory the test framework made for it
+// the way container/run_test.go's realTestContainerName is, so that these tests
+// only ever create and destroy containers of their own: not a developer's, and
+// not those of a run happening at the same time.
+func testContainerNames(t *testing.T, n int) []string {
+	t.Helper()
+
+	prefix := filepath.Base(filepath.Dir(t.TempDir()))
+
+	names := make([]string, n)
+	for i := range n {
+		names[i] = fmt.Sprintf("%s_%d", prefix, i+1)
+	}
+
+	return names
 }

--- a/container/docker/docker_test.go
+++ b/container/docker/docker_test.go
@@ -34,13 +34,13 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/VertebrateResequencing/wr/container"
 	cn "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/jsonstream"
 	nw "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
 	. "github.com/smartystreets/goconvey/convey"
@@ -228,20 +228,49 @@ func listingDockerSocket(t *testing.T, containers []cn.Summary) string {
 	return "unix://" + sock
 }
 
+// pullTestImage pulls testImage, which the tests that need a real daemon run.
+// The progress stream has to be consumed for the pull to complete, but it is
+// not copied anywhere: it is a screenful of progress bars that says nothing a
+// passing test needs.
 func pullTestImage(ctx context.Context, cli *client.Client) error {
 	rc, err := cli.ImagePull(ctx, testImage, client.ImagePullOptions{})
 	if err != nil {
 		return err
 	}
 
-	_, copyErr := io.Copy(os.Stdout, rc)
+	drainErr := drainPullProgress(rc)
 	closeErr := rc.Close()
 
-	if copyErr != nil {
-		return copyErr
+	if drainErr != nil {
+		return drainErr
 	}
 
 	return closeErr
+}
+
+// drainPullProgress reads a pull's progress stream to its end and discards the
+// progress, but returns the first error the stream reports. A pull that fails
+// after the image reference has resolved says so only in the stream, so
+// discarding the whole thing would turn that into a bare "no such image" from
+// whatever tried to use the image next.
+func drainPullProgress(r io.Reader) error {
+	decoder := json.NewDecoder(r)
+
+	for {
+		var msg jsonstream.Message
+
+		if err := decoder.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+
+			return err
+		}
+
+		if msg.Error != nil {
+			return msg.Error
+		}
+	}
 }
 
 func TestDockerContainerLabels(t *testing.T) {

--- a/container/operator_test.go
+++ b/container/operator_test.go
@@ -31,6 +31,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -38,6 +39,18 @@ import (
 
 // fileMode is the mode of the temp file created for testing.
 const fileMode os.FileMode = 0600
+
+const (
+	// hugeOutputFileBytes is the size of the job output file that a careless
+	// --monitor_docker glob such as *.txt can match.
+	hugeOutputFileBytes = 32 * 1024 * 1024
+
+	// maxGlobAllocBytes is the most that looking for a cid may allocate,
+	// whatever the glob matches. findContainerID tries again every second for
+	// the life of the job, and the runner's own memory is added to the job's
+	// recorded PeakRAM.
+	maxGlobAllocBytes = 1024 * 1024
+)
 
 // MockInteractor represents a mock implementation of container.Interactor.
 type MockInteractor struct {
@@ -405,6 +418,49 @@ func TestOperator(t *testing.T) {
 			var e *OperatorError
 			So(errors.As(err, &e), ShouldBeTrue)
 			So(e.Unwrap(), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestCidGlobMemory(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("Given a cid glob that matches a job's huge output file", t, func() {
+		dir := t.TempDir()
+
+		f, err := os.OpenFile(filepath.Clean(filepath.Join(dir, "out.txt")),
+			os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+		So(err, ShouldBeNil)
+
+		_, err = f.WriteString("some job output\n")
+		So(err, ShouldBeNil)
+		So(f.Truncate(hugeOutputFileBytes), ShouldBeNil)
+		So(f.Close(), ShouldBeNil)
+
+		operator := NewOperator(&MockInteractor{
+			ContainerListFn: func() ([]*Container, error) {
+				return []*Container{{ID: testContainerID1}}, nil
+			},
+		})
+
+		Convey("looking for a container does not read that file in to memory", func() {
+			var (
+				cntr *Container
+				gerr error
+
+				before, after runtime.MemStats
+			)
+
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+
+			cntr, gerr = operator.GetContainerByPath(ctx, "*.txt", dir)
+
+			runtime.ReadMemStats(&after)
+
+			So(after.TotalAlloc-before.TotalAlloc, ShouldBeLessThan, maxGlobAllocBytes)
+			So(gerr, ShouldBeNil)
+			So(cntr, ShouldBeNil)
 		})
 	})
 }

--- a/container/run.go
+++ b/container/run.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/VertebrateResequencing/wr/clog"
@@ -66,6 +67,18 @@ const workDirMountArgs = ` -w "$PWD" --mount type=bind,source="$PWD",target="$PW
 // $PWD stays a shell expansion for the same reason it does in
 // workDirMountArgs.
 const singularityWorkDirArgs = ` -B "$PWD" --pwd "$PWD"`
+
+// staleContainerRemovalFormat removes the containers that the 2 `docker ps`
+// filters interpolated in to it select; see removeStaleContainerCmd for which
+// those are, and why only those.
+//
+// The removal is announced on STDERR because it destroys something, and that
+// lands in the job's own STDERR, where whoever wonders what happened to the
+// lost run's container can read it. `docker rm` prints the id it removed on
+// STDOUT, which would otherwise be mixed in to the command's own output.
+const staleContainerRemovalFormat = "for c in $(docker ps --all --quiet --filter %s --filter %s); do " +
+	`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; ` +
+	`docker rm --force "$c" >/dev/null; done; `
 
 // runAsCallingUserArgs makes the container's processes run as the user that runs
 // the command line, instead of as the user the image specifies (normally root).
@@ -150,6 +163,10 @@ func writeStringToFile(f *os.File, content string, cleanup func()) error {
 //     it creates in the working directory is owned by that user.
 //
 // * Automatically remove the container when it exits.
+//
+// It is prefixed by removeStaleContainerCmd, so that a container of the same
+// name that a previous run of the same thing left behind does not make this
+// run fail before it starts.
 func DockerRunCmd(image, cmdFile, name string, mounts, env []string, imageUser bool) string {
 	userArgs := runAsCallingUserArgs
 	if imageUser {
@@ -159,9 +176,10 @@ func DockerRunCmd(image, cmdFile, name string, mounts, env []string, imageUser b
 	mountArgs := dockerMounts(mounts)
 	envArgs := dockerEnv(env)
 
-	return fmt.Sprintf("cat %s | docker run --rm --name %s --label %s%s%s%s -i %s /bin/sh",
-		shellquote.Join(cmdFile), shellquote.Join(name), shellquote.Join(JobKeyLabel+"="+name),
-		userArgs, mountArgs, envArgs, shellquote.Join(image))
+	return removeStaleContainerCmd(name) +
+		fmt.Sprintf("cat %s | docker run --rm --name %s --label %s%s%s%s -i %s /bin/sh",
+			shellquote.Join(cmdFile), shellquote.Join(name), shellquote.Join(JobKeyLabel+"="+name),
+			userArgs, mountArgs, envArgs, shellquote.Join(image))
 }
 
 // dockerMounts takes a list of "/local/path[:/inside/container/path]" values
@@ -207,6 +225,42 @@ func MountSpecPaths(spec string) (local, inContainer string) {
 // a series of `docker run -e` args.
 func dockerEnv(names []string) string {
 	return listToPrefixedString(shellQuoteEach(names), " -e ")
+}
+
+// removeStaleContainerCmd returns shell that frees name for the `docker run`
+// that follows it, by removing every container that both holds that name and
+// carries JobKeyLabel with name as its value.
+//
+// --rm covers the normal case, but a container that outlives its `docker run`
+// client keeps the name - the runner SIGKILLed, the host lost, the daemon
+// restarted mid-run - and then every later run under that name fails at once
+// with docker's "container name is already in use".
+//
+// Both filters are required, and neither is redundant. The name filter says
+// the container is in our way; the label says it is ours to remove. Only we
+// set that label, so a container carrying it with this name is taken to be
+// one we started for this same thing, whose run has since been given up on -
+// doing work nobody will collect, and racing the run we are about to start in
+// the same working directory. That rests on one manager owning the key, which
+// is derived from Cwd, Cmd, mounts and image and names no manager: 2 managers
+// on one docker host running the identical command in the identical Cwd share
+// a key, so this would remove the other's live container, where before the
+// run merely failed loudly. A container of this name that we cannot prove is
+// ours is left alone and still fails the run, which is the safe way round:
+// #589 exists because an earlier version of this code decided a container was
+// the job's without proof, and being wrong here destroys a co-tenant's work
+// rather than merely mis-attributing it.
+//
+// The name goes through regexp.QuoteMeta because docker matches that filter as
+// a regular expression, so a name containing regex metacharacters would
+// otherwise match containers of other names.
+//
+// When the filters match nothing, which is every normal run, the loop body
+// runs no times: nothing is printed and no container is touched.
+func removeStaleContainerCmd(name string) string {
+	return fmt.Sprintf(staleContainerRemovalFormat,
+		shellquote.Join("name=^"+regexp.QuoteMeta(name)+"$"),
+		shellquote.Join("label="+JobKeyLabel+"="+name))
 }
 
 // listToPrefixedString creates a single string comprising vals concatenated

--- a/container/run.go
+++ b/container/run.go
@@ -55,6 +55,18 @@ const dockerMountParts = 2
 // contains a space.
 const workDirMountArgs = ` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`
 
+// singularityWorkDirArgs is workDirMountArgs in singularity's own syntax: -B
+// with no ":dest" binds the working directory at the same path it has outside,
+// which is what docker's target="$PWD" does, and --pwd then starts the
+// command there.
+//
+// Without these, the container gets the working directory only if the site's
+// singularity.conf happens to bind it, and starts in / if it does not.
+//
+// $PWD stays a shell expansion for the same reason it does in
+// workDirMountArgs.
+const singularityWorkDirArgs = ` -B "$PWD" --pwd "$PWD"`
+
 // runAsCallingUserArgs makes the container's processes run as the user that runs
 // the command line, instead of as the user the image specifies (normally root).
 // Without it, everything the command creates in the working directory
@@ -216,10 +228,11 @@ func listToPrefixedString(vals []string, prefix string) string {
 //   - Create a container.
 //   - That will run the command in the given file (by piping the file contents
 //     to the container's shell); use PrepareCmdFile() to create one.
-//   - That will mount the given disk locations, in the format
+//   - That will mount the current working directory at the same path inside
+//     the container and use it as the workdir.
+//   - That will also mount any given disk locations, in the format
 //     "/local/path:/inside/container/path" (the colon and inside path being
-//     optional if the same as local path). The CWD is always mounted at / in
-//     container.
+//     optional if the same as local path).
 //   - That will have all environment variables outside the container
 //     replicated inside the container.
 //   - That will run as the calling user, which singularity does by design, so
@@ -234,8 +247,10 @@ func SingularityRunCmd(image, cmdFile string, mounts []string) string {
 
 // singularityMounts takes a list of "/local/path[:/inside/container/path]"
 // values and converts them in to a series of `singularity shell -B` args.
+//
+// It always binds $PWD and makes it the container's working directory as well.
 func singularityMounts(mounts []string) string {
-	return listToPrefixedString(shellQuoteEach(mounts), " -B ")
+	return singularityWorkDirArgs + listToPrefixedString(shellQuoteEach(mounts), " -B ")
 }
 
 // shellQuoteEach shell quotes each of the given values, so that each stays a

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -26,11 +26,14 @@
 package container
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -66,6 +69,24 @@ const singularityImage = "docker://alpine"
 // expectedSingularityWorkDirArgs is the bind of the working directory, and the
 // choice of it as the container's cwd, that SingularityRunCmd always emits.
 const expectedSingularityWorkDirArgs = ` -B "$PWD" --pwd "$PWD"`
+
+// staleContainerSleepSecs is how long the container standing in for one that
+// outlived its `docker run` client sleeps for. It only has to outlast the test
+// that removes it.
+const staleContainerSleepSecs = 300
+
+// dockerShortIDLen is how many characters of a container id `docker ps` shows
+// when not asked for the full one, which is what our removal message names.
+const dockerShortIDLen = 12
+
+// expectedStaleRemoval is the removal of a stale container named "uniqueID"
+// that DockerRunCmd always emits before its `docker run`, so that a container
+// a lost run left behind under that name cannot make this run fail before it
+// starts.
+const expectedStaleRemoval = `for c in $(docker ps --all --quiet --filter name=^uniqueID\$ ` +
+	`--filter label=uk.ac.sanger.wr.job-key=uniqueID); do ` +
+	`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; ` +
+	`docker rm --force "$c" >/dev/null; done; `
 
 // mountNoColon is a mount spec with no ":/inside/container/path" part, so its
 // path is used on both sides of the mount. Several of the command-line tests
@@ -133,6 +154,25 @@ func TestRunRealAwkwardPaths(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(actual, ShouldEqual, homeDir+"\nhome.file\na.file\nb.file\n")
 	})
+}
+
+// realTestTryCmdStd is realTestTryCmd, also returning STDERR, which is where
+// docker puts its reason for refusing to run and where our own command line
+// announces anything it destroyed.
+func realTestTryCmdStd(cmdLine, homeDir string) (stdout, stderr string, err error) {
+	cmdLine = "set -o pipefail; " + cmdLine
+	cmd := exec.CommandContext(context.Background(), "/bin/bash", "-c", cmdLine)
+	cmd.Dir = homeDir
+	cmd.Env = os.Environ()
+
+	var outBuf, errBuf bytes.Buffer
+
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err = cmd.Run()
+
+	return outBuf.String(), errBuf.String(), err
 }
 
 func TestRunRealFileOwnership(t *testing.T) {
@@ -204,6 +244,141 @@ func soOwnedBy(t *testing.T, dir string, uid, gid int) {
 		So(int(stat.Uid), ShouldEqual, uid)
 		So(int(stat.Gid), ShouldEqual, gid)
 	}
+}
+
+func TestRunRealDockerStaleContainer(t *testing.T) {
+	Convey("DockerRunCmd's command really runs when a lost run of the same job left a container "+
+		"holding its name", t, func() {
+		cmdFile, homeDir, _, cleanup, err := realTestSetup(t, "docker", workDirCmd, plainTestDirNames())
+		if err != nil {
+			SkipConvey(fmt.Sprintf("Can't really test the docker stale container: %s", err), nil)
+
+			return
+		}
+
+		defer cleanup()
+
+		name := realTestContainerName(homeDir)
+		defer removeTestContainer(t, name)
+
+		// this stands in for the container of a run whose `docker run` client
+		// was SIGKILLed: still running, still holding the name, and still
+		// carrying the label wr gave it.
+		id, err := startTestContainer(t, name, JobKeyLabel+"="+name)
+		So(err, ShouldBeNil)
+		So(testContainerExists(t, name), ShouldBeTrue)
+
+		cmd := DockerRunCmd("alpine", cmdFile, name, nil, nil, false)
+		t.Logf("cmdline: %s", cmd)
+
+		stdout, stderr, err := realTestTryCmdStd(cmd, homeDir)
+
+		// the working directory workDirCmd reports names the container that
+		// really ran, and STDERR carries both docker's reason for refusing to
+		// run and our own account of what we removed.
+		t.Logf("stdout: %q, stderr: %q, err: %v", stdout, stderr, err)
+
+		So(err, ShouldBeNil)
+		So(stdout, ShouldEqual, homeDir+"\nhome.file\n")
+		So(stderr, ShouldEqual, "wr: removing container "+id[:dockerShortIDLen]+
+			", left behind by a lost run of this same command\n")
+	})
+
+	Convey("But it never removes a container of that name that is not this job's", t, func() {
+		cmdFile, homeDir, _, cleanup, err := realTestSetup(t, "docker", workDirCmd, plainTestDirNames())
+		if err != nil {
+			SkipConvey(fmt.Sprintf("Can't really test the docker stale container: %s", err), nil)
+
+			return
+		}
+
+		defer cleanup()
+
+		name := realTestContainerName(homeDir)
+		defer removeTestContainer(t, name)
+
+		// a co-tenant's container that happens to have our name carries no
+		// claim from us, so it is not ours to destroy, even though it is in
+		// our way.
+		_, err = startTestContainer(t, name, "")
+		So(err, ShouldBeNil)
+
+		cmd := DockerRunCmd("alpine", cmdFile, name, nil, nil, false)
+
+		stdout, stderr, err := realTestTryCmdStd(cmd, homeDir)
+		t.Logf("stdout: %q, stderr: %q, err: %v", stdout, stderr, err)
+
+		So(err, ShouldNotBeNil)
+		So(stderr, ShouldNotContainSubstring, "wr: removing container")
+		So(stderr, ShouldContainSubstring, "is already in use by container")
+		So(testContainerExists(t, name), ShouldBeTrue)
+	})
+}
+
+// realTestContainerName is a container name unique to this test run, derived
+// from the temporary directory realTestSetup made for it, so that these tests
+// only ever create and destroy containers of their own.
+func realTestContainerName(homeDir string) string {
+	return filepath.Base(filepath.Dir(homeDir))
+}
+
+// removeTestContainer force-removes the container this test run created with
+// the given name, if it is still there. The name is unique to the test run, so
+// nothing else can be removed by it.
+func removeTestContainer(t *testing.T, name string) {
+	t.Helper()
+
+	out, err := exec.CommandContext(context.Background(), "docker", "rm", "--force", name).CombinedOutput()
+	if err != nil {
+		t.Logf("docker rm --force %s failed: %s [%s]", name, err, out)
+	}
+}
+
+// startTestContainer starts a detached container with the given name, and the
+// given label if it is not blank, that sleeps until something removes it. It
+// stands in for a container that outlived the `docker run` client that created
+// it, and its id is returned.
+func startTestContainer(t *testing.T, name, label string) (string, error) {
+	t.Helper()
+
+	args := []string{"run", "--detach", "--name", name}
+	if label != "" {
+		args = append(args, "--label", label)
+	}
+
+	args = append(args, "alpine", "sleep", strconv.Itoa(staleContainerSleepSecs))
+
+	cmd := exec.CommandContext(context.Background(), "docker", args...)
+
+	var errBuf bytes.Buffer
+
+	// the id is read from STDOUT alone: docker announces any pull of a missing
+	// image on STDERR, so merging the two would make the "id" that pull's
+	// progress on a machine that has not cached the image.
+	cmd.Stderr = &errBuf
+
+	out, err := cmd.Output()
+	t.Logf("docker %v: %s [stderr: %s]", args, out, errBuf.String())
+
+	return strings.TrimSpace(string(out)), err
+}
+
+// testContainerExists says if a container of the given name exists, running or
+// not.
+func testContainerExists(t *testing.T, name string) bool {
+	t.Helper()
+
+	nameFilter := "name=^" + name + "$"
+
+	out, err := exec.CommandContext(context.Background(), "docker", "ps", "--all", "--quiet",
+		"--filter", nameFilter).Output()
+	if err != nil {
+		t.Logf("docker ps failed: %s", err)
+
+		return false
+	}
+
+	return len(strings.TrimSpace(string(out))) > 0
 }
 
 func TestRunRealSingularityWorkDir(t *testing.T) {
@@ -298,7 +473,7 @@ func TestRunDocker(t *testing.T) {
 	Convey("DockerRunCmd formulates the correct command line", t, func() {
 		cmd := DockerRunCmd("myimage", "/path/to/cmds", "uniqueID", nil, nil, false)
 
-		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
+		So(cmd, ShouldEqual, expectedStaleRemoval+"cat /path/to/cmds | docker run --rm --name uniqueID"+
 			" --label uk.ac.sanger.wr.job-key=uniqueID"+
 			` --user "$(id -u):$(id -g)"`+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage /bin/sh`)
@@ -306,7 +481,7 @@ func TestRunDocker(t *testing.T) {
 		cmd = DockerRunCmd("myimage", "/path/to/cmds", "uniqueID",
 			[]string{"/foo/bar:/bar", mountNoColon}, []string{"A", "B"}, false)
 
-		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
+		So(cmd, ShouldEqual, expectedStaleRemoval+"cat /path/to/cmds | docker run --rm --name uniqueID"+
 			" --label uk.ac.sanger.wr.job-key=uniqueID"+
 			` --user "$(id -u):$(id -g)"`+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
@@ -317,8 +492,23 @@ func TestRunDocker(t *testing.T) {
 	Convey("DockerRunCmd leaves --user off when told to run as the image's user", t, func() {
 		cmd := DockerRunCmd("myimage", "/path/to/cmds", "uniqueID", nil, nil, true)
 
-		So(cmd, ShouldEqual, "cat /path/to/cmds | docker run --rm --name uniqueID"+
+		So(cmd, ShouldEqual, expectedStaleRemoval+"cat /path/to/cmds | docker run --rm --name uniqueID"+
 			" --label uk.ac.sanger.wr.job-key=uniqueID"+
+			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage /bin/sh`)
+	})
+
+	Convey("DockerRunCmd escapes regex metacharacters in the name it filters stale containers by", t, func() {
+		// docker matches the name filter as a regular expression, so an
+		// unescaped "." here would have this job remove a container named
+		// "wrrevXG", which is somebody else's.
+		cmd := DockerRunCmd("myimage", "/path/to/cmds", "wrrev.G", nil, nil, true)
+
+		So(cmd, ShouldEqual, `for c in $(docker ps --all --quiet --filter name=^wrrev\\.G\$ `+
+			`--filter label=uk.ac.sanger.wr.job-key=wrrev.G); do `+
+			`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; `+
+			`docker rm --force "$c" >/dev/null; done; `+
+			"cat /path/to/cmds | docker run --rm --name wrrev.G"+
+			" --label uk.ac.sanger.wr.job-key=wrrev.G"+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD" -i myimage /bin/sh`)
 	})
 
@@ -326,7 +516,11 @@ func TestRunDocker(t *testing.T) {
 		cmd := DockerRunCmd("my image", "/path to/cmds", "unique ID",
 			[]string{"/foo/b ar;rm -rf x:/b ar", mountNoColon}, []string{"A B"}, false)
 
-		So(cmd, ShouldEqual, "cat '/path to/cmds' | docker run --rm --name 'unique ID'"+
+		So(cmd, ShouldEqual, `for c in $(docker ps --all --quiet --filter 'name=^unique ID$' `+
+			`--filter 'label=uk.ac.sanger.wr.job-key=unique ID'); do `+
+			`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; `+
+			`docker rm --force "$c" >/dev/null; done; `+
+			"cat '/path to/cmds' | docker run --rm --name 'unique ID'"+
 			" --label 'uk.ac.sanger.wr.job-key=unique ID'"+
 			` --user "$(id -u):$(id -g)"`+
 			` -w "$PWD" --mount type=bind,source="$PWD",target="$PWD"`+
@@ -511,12 +705,7 @@ func createRealTestFile(dir, baseName string) error {
 }
 
 func realTestTryCmd(cmdLine, homeDir string) (string, error) {
-	cmdLine = "set -o pipefail; " + cmdLine
-	cmd := exec.CommandContext(context.Background(), "/bin/bash", "-c", cmdLine)
-	cmd.Dir = homeDir
-	cmd.Env = os.Environ()
+	stdout, _, err := realTestTryCmdStd(cmdLine, homeDir)
 
-	out, err := cmd.Output()
-
-	return string(out), err
+	return stdout, err
 }

--- a/container/run_test.go
+++ b/container/run_test.go
@@ -54,6 +54,19 @@ const (
 // command makes in the caller's own Cwd.
 const ownershipCmd = "touch created.file && mkdir created.dir"
 
+// workDirCmd reports the container's working directory and lists what the
+// caller's own Cwd holds, so a test can see if the containerised command
+// really runs in that Cwd.
+const workDirCmd = "pwd && ls *.file"
+
+// singularityImage is the image the real singularity tests run, in the
+// docker:// form that makes singularity convert a docker image to a sif.
+const singularityImage = "docker://alpine"
+
+// expectedSingularityWorkDirArgs is the bind of the working directory, and the
+// choice of it as the container's cwd, that SingularityRunCmd always emits.
+const expectedSingularityWorkDirArgs = ` -B "$PWD" --pwd "$PWD"`
+
 // mountNoColon is a mount spec with no ":/inside/container/path" part, so its
 // path is used on both sides of the mount. Several of the command-line tests
 // mount it alongside one that does name an inside path.
@@ -114,7 +127,7 @@ func TestRunRealAwkwardPaths(t *testing.T) {
 
 		defer cleanup()
 
-		cmd := SingularityRunCmd("docker://alpine", cmdFile, mounts)
+		cmd := SingularityRunCmd(singularityImage, cmdFile, mounts)
 
 		actual, err := realTestTryCmd(cmd, homeDir)
 		So(err, ShouldBeNil)
@@ -191,6 +204,38 @@ func soOwnedBy(t *testing.T, dir string, uid, gid int) {
 		So(int(stat.Uid), ShouldEqual, uid)
 		So(int(stat.Gid), ShouldEqual, gid)
 	}
+}
+
+func TestRunRealSingularityWorkDir(t *testing.T) {
+	Convey("SingularityRunCmd's command really runs in the working directory, "+
+		"even at a site that binds nothing useful", t, func() {
+		cmdFile, homeDir, _, cleanup, err := realTestSetup(t, "singularity", workDirCmd, plainTestDirNames())
+		if err != nil {
+			SkipConvey(fmt.Sprintf("Can't really test the singularity working directory: %s", err), nil)
+
+			return
+		}
+
+		defer cleanup()
+
+		// singularity reads this the way it reads its --no-mount option, so it
+		// stands in for a singularity.conf that binds neither the user's home
+		// directory, nor the current working directory, nor /tmp.
+		t.Setenv("SINGULARITY_NO_MOUNT", "cwd,home,tmp")
+
+		cmd := SingularityRunCmd(singularityImage, cmdFile, nil)
+		t.Logf("cmdline: %s", cmd)
+
+		actual, err := realTestTryCmd(cmd, homeDir)
+
+		// workDirCmd's `pwd` names the directory the container actually
+		// started in, so log it before asserting: if the bind or the cwd is
+		// missing, `ls` fails and the error alone says only "exit status 1".
+		t.Logf("output: %q", actual)
+
+		So(err, ShouldBeNil)
+		So(actual, ShouldEqual, homeDir+"\nhome.file\n")
+	})
 }
 
 func TestRunPrepare(t *testing.T) {
@@ -295,17 +340,20 @@ func TestRunSingularity(t *testing.T) {
 	Convey("SingularityRunCmd formulates the correct command line", t, func() {
 		cmd := SingularityRunCmd("myimage", "/path/to/cmds", nil)
 
-		So(cmd, ShouldEqual, "cat /path/to/cmds | singularity shell myimage")
+		So(cmd, ShouldEqual, "cat /path/to/cmds | singularity shell"+
+			expectedSingularityWorkDirArgs+" myimage")
 
 		cmd = SingularityRunCmd("myimage", "/path/to/cmds", []string{"/foo/bar:/bar", mountNoColon})
 
-		So(cmd, ShouldEqual, "cat /path/to/cmds | singularity shell -B /foo/bar:/bar -B /foo/car myimage")
+		So(cmd, ShouldEqual, "cat /path/to/cmds | singularity shell"+
+			expectedSingularityWorkDirArgs+" -B /foo/bar:/bar -B /foo/car myimage")
 	})
 
 	Convey("SingularityRunCmd quotes values containing spaces and shell metacharacters", t, func() {
 		cmd := SingularityRunCmd("my image", "/path to/cmds", []string{"/foo/b ar;rm -rf x:/b ar", mountNoColon})
 
 		So(cmd, ShouldEqual, "cat '/path to/cmds' | singularity shell"+
+			expectedSingularityWorkDirArgs+
 			" -B '/foo/b ar;rm -rf x:/b ar' -B /foo/car 'my image'")
 	})
 }
@@ -345,7 +393,7 @@ func TestRunReal(t *testing.T) {
 
 		defer cleanup()
 
-		cmd := SingularityRunCmd("docker://alpine", cmdFile, mounts)
+		cmd := SingularityRunCmd(singularityImage, cmdFile, mounts)
 
 		actual, err := realTestTryCmd(cmd, homeDir)
 		So(err, ShouldBeNil)

--- a/fs/file/file.go
+++ b/fs/file/file.go
@@ -49,6 +49,10 @@ const maxFirstLineBytes = 4096
 // first line is longer than maxFirstLineBytes.
 var ErrLineTooLong = errors.New("first line longer than " + strconv.Itoa(maxFirstLineBytes) + " bytes")
 
+// ErrEmptyPath is wrapped by the error GetFirstLine and ToString return when
+// given an empty path.
+var ErrEmptyPath = errors.New("path is empty")
+
 // PathReadError records an path read error.
 type PathReadError struct {
 	path string
@@ -66,14 +70,14 @@ func (p *PathReadError) Unwrap() error {
 }
 
 // GetFirstLine returns the first line, excluding its newline, of the file at
-// the given absolute or tilda path.
+// the given absolute or tilde path.
 //
 // At most maxFirstLineBytes are read, so that a large file which is not the
 // short id file this is for does not get read in to memory; if the first line
 // is longer than that, the returned error wraps ErrLineTooLong.
 func GetFirstLine(filename string) (string, error) {
 	if filename == "" {
-		return "", &PathReadError{"", nil}
+		return "", &PathReadError{"", ErrEmptyPath}
 	}
 
 	absPath := fp.TildaToHome(filename)
@@ -116,11 +120,11 @@ func firstLine(r io.Reader) (string, error) {
 }
 
 // ToString takes the path to a file and returns its contents as a string. If
-// path begins with a tilda, TildaToHome() is used to first convert the path to
+// path begins with a tilde, TildaToHome() is used to first convert the path to
 // an absolute path, in order to find the file.
 func ToString(path string) (string, error) {
 	if path == "" {
-		return "", &PathReadError{"", nil}
+		return "", &PathReadError{"", ErrEmptyPath}
 	}
 
 	absPath := fp.TildaToHome(path)

--- a/fs/file/file.go
+++ b/fs/file/file.go
@@ -28,12 +28,26 @@ package file
 // this file implements utility routines related to files.
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
-	"strings"
+	"path/filepath"
+	"strconv"
 
 	fp "github.com/VertebrateResequencing/wr/fs/filepath"
 )
+
+// maxFirstLineBytes is the longest first line GetFirstLine will return. It is
+// far more than the 64 hexadecimal characters of the container ids that
+// GetFirstLine exists to read, and little enough that a file which merely
+// happens to match a cidfile glob never gets read in to memory.
+const maxFirstLineBytes = 4096
+
+// ErrLineTooLong is wrapped by the error GetFirstLine returns when a file's
+// first line is longer than maxFirstLineBytes.
+var ErrLineTooLong = errors.New("first line longer than " + strconv.Itoa(maxFirstLineBytes) + " bytes")
 
 // PathReadError records an path read error.
 type PathReadError struct {
@@ -46,17 +60,59 @@ func (p *PathReadError) Error() string {
 	return fmt.Sprintf("path [%s] could not be read: %s", p.path, p.Err)
 }
 
-// GetFirstLine reads the content of a file given its absolute or tilda path and
-// returns the first line excluding trailing newline.
+// Unwrap returns the error that stopped the path being read.
+func (p *PathReadError) Unwrap() error {
+	return p.Err
+}
+
+// GetFirstLine returns the first line, excluding its newline, of the file at
+// the given absolute or tilda path.
+//
+// At most maxFirstLineBytes are read, so that a large file which is not the
+// short id file this is for does not get read in to memory; if the first line
+// is longer than that, the returned error wraps ErrLineTooLong.
 func GetFirstLine(filename string) (string, error) {
-	content, err := ToString(filename)
+	if filename == "" {
+		return "", &PathReadError{"", nil}
+	}
+
+	absPath := fp.TildaToHome(filename)
+
+	f, err := os.Open(filepath.Clean(absPath))
 	if err != nil {
+		return "", &PathReadError{absPath, err}
+	}
+
+	defer f.Close()
+
+	line, err := firstLine(f)
+	if err != nil {
+		return "", &PathReadError{absPath, err}
+	}
+
+	return line, nil
+}
+
+// firstLine returns the content of r up to its first newline, reading no more
+// than maxFirstLineBytes+1 bytes. If r gives maxFirstLineBytes bytes without a
+// newline and still has more, ErrLineTooLong is returned.
+func firstLine(r io.Reader) (string, error) {
+	buf := make([]byte, maxFirstLineBytes+1)
+
+	n, err := io.ReadFull(r, buf)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return "", err
 	}
 
-	firstLine := strings.TrimSuffix(content, "\n")
+	if i := bytes.IndexByte(buf[:n], '\n'); i >= 0 {
+		return string(buf[:i]), nil
+	}
 
-	return firstLine, nil
+	if n > maxFirstLineBytes {
+		return "", ErrLineTooLong
+	}
+
+	return string(buf[:n]), nil
 }
 
 // ToString takes the path to a file and returns its contents as a string. If

--- a/fs/file/file.go
+++ b/fs/file/file.go
@@ -42,7 +42,7 @@ import (
 // maxFirstLineBytes is the longest first line GetFirstLine will return. It is
 // far more than the 64 hexadecimal characters of the container ids that
 // GetFirstLine exists to read, and little enough that a file which merely
-// happens to match a cidfile glob never gets read in to memory.
+// happens to match a cidfile glob never gets read into memory.
 const maxFirstLineBytes = 4096
 
 // ErrLineTooLong is wrapped by the error GetFirstLine returns when a file's
@@ -53,13 +53,13 @@ var ErrLineTooLong = errors.New("first line longer than " + strconv.Itoa(maxFirs
 // given an empty path.
 var ErrEmptyPath = errors.New("path is empty")
 
-// PathReadError records an path read error.
+// PathReadError records a path read error.
 type PathReadError struct {
 	path string
 	Err  error
 }
 
-// Error returns an error related to path could not be read.
+// Error returns an error related to a path that could not be read.
 func (p *PathReadError) Error() string {
 	return fmt.Sprintf("path [%s] could not be read: %s", p.path, p.Err)
 }
@@ -73,7 +73,7 @@ func (p *PathReadError) Unwrap() error {
 // the given absolute or tilde path.
 //
 // At most maxFirstLineBytes are read, so that a large file which is not the
-// short id file this is for does not get read in to memory; if the first line
+// short id file this is for does not get read into memory; if the first line
 // is longer than that, the returned error wraps ErrLineTooLong.
 func GetFirstLine(filename string) (string, error) {
 	if filename == "" {

--- a/fs/file/file_test.go
+++ b/fs/file/file_test.go
@@ -26,9 +26,12 @@
 package file
 
 import (
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -36,6 +39,21 @@ import (
 
 // fileMode is the mode of the temp file created for testing.
 const fileMode os.FileMode = 0600
+
+const (
+	// hugeFileBytes is the size of the files used to prove that GetFirstLine
+	// does not read a whole file to get its first line: a --monitor_docker
+	// glob can match a job's output file, which is arbitrarily large.
+	hugeFileBytes = 32 * 1024 * 1024
+
+	// maxFirstLineAllocBytes is the most GetFirstLine may allocate to return
+	// one short first line, however large the rest of the file is.
+	maxFirstLineAllocBytes = 1024 * 1024
+
+	// maxShownLineBytes is how much of an unexpectedly long line a failed
+	// assertion prints.
+	maxShownLineBytes = 20
+)
 
 func TestFile(t *testing.T) {
 	Convey("We can the first line of a file", t, func() {
@@ -98,4 +116,106 @@ func TestFile(t *testing.T) {
 		So(content, ShouldEqual, "")
 		So(err, ShouldNotBeNil)
 	})
+}
+
+func TestGetFirstLine(t *testing.T) {
+	Convey("GetFirstLine returns only the first line of a multi-line file", t, func() {
+		path := filepath.Join(t.TempDir(), "lines.txt")
+		err := os.WriteFile(path, []byte("id1\nsome other output\n"), fileMode)
+		So(err, ShouldBeNil)
+
+		line, err := GetFirstLine(path)
+		So(err, ShouldBeNil)
+		So(line, ShouldEqual, "id1")
+	})
+
+	Convey("GetFirstLine gets a short first line without reading a huge file", t, func() {
+		path := filepath.Join(t.TempDir(), "huge.txt")
+		So(writeHugeFile(path, "id1\n"), ShouldBeNil)
+
+		var (
+			line string
+			err  error
+		)
+
+		allocated := allocatedBy(func() {
+			line, err = GetFirstLine(path)
+		})
+
+		So(allocated, ShouldBeLessThan, maxFirstLineAllocBytes)
+		So(err, ShouldBeNil)
+		So(shorten(line), ShouldEqual, "id1")
+	})
+
+	Convey("GetFirstLine returns a first line of exactly maxFirstLineBytes", t, func() {
+		path := filepath.Join(t.TempDir(), "atlimit.txt")
+		line := strings.Repeat("a", maxFirstLineBytes)
+		So(os.WriteFile(path, []byte(line+"\n"), fileMode), ShouldBeNil)
+
+		got, err := GetFirstLine(path)
+		So(err, ShouldBeNil)
+		So(len(got), ShouldEqual, maxFirstLineBytes)
+	})
+
+	Convey("GetFirstLine refuses a huge file that has no newline at all", t, func() {
+		path := filepath.Join(t.TempDir(), "nonewline.txt")
+		So(writeHugeFile(path, ""), ShouldBeNil)
+
+		var (
+			line string
+			err  error
+		)
+
+		allocated := allocatedBy(func() {
+			line, err = GetFirstLine(path)
+		})
+
+		So(allocated, ShouldBeLessThan, maxFirstLineAllocBytes)
+		So(errors.Is(err, ErrLineTooLong), ShouldBeTrue)
+		So(line, ShouldBeEmpty)
+	})
+}
+
+// writeHugeFile creates a file of hugeFileBytes bytes that starts with the
+// given content and is padded out with NUL bytes, which contain no newline.
+func writeHugeFile(path, start string) error {
+	f, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, fileMode)
+	if err != nil {
+		return err
+	}
+
+	if _, err = f.WriteString(start); err != nil {
+		return err
+	}
+
+	if err = f.Truncate(hugeFileBytes); err != nil {
+		return err
+	}
+
+	return f.Close()
+}
+
+// allocatedBy returns how many bytes were allocated on the heap while running
+// fn.
+func allocatedBy(fn func()) uint64 {
+	var before, after runtime.MemStats
+
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	fn()
+
+	runtime.ReadMemStats(&after)
+
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+// shorten truncates s, so that an assertion that fails because GetFirstLine
+// returned the whole of a huge file prints something a human can read.
+func shorten(s string) string {
+	if len(s) > maxShownLineBytes {
+		return s[:maxShownLineBytes] + "..."
+	}
+
+	return s
 }

--- a/fs/file/file_test.go
+++ b/fs/file/file_test.go
@@ -118,6 +118,24 @@ func TestFile(t *testing.T) {
 	})
 }
 
+func TestEmptyPath(t *testing.T) {
+	Convey("GetFirstLine given an empty path says so, and the error matches ErrEmptyPath", t, func() {
+		line, err := GetFirstLine("")
+		So(line, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, ErrEmptyPath), ShouldBeTrue)
+		So(err.Error(), ShouldEqual, "path [] could not be read: path is empty")
+	})
+
+	Convey("ToString given an empty path says the same", t, func() {
+		content, err := ToString("")
+		So(content, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, ErrEmptyPath), ShouldBeTrue)
+		So(err.Error(), ShouldEqual, "path [] could not be read: path is empty")
+	})
+}
+
 func TestGetFirstLine(t *testing.T) {
 	Convey("GetFirstLine returns only the first line of a multi-line file", t, func() {
 		path := filepath.Join(t.TempDir(), "lines.txt")

--- a/jobqueue/job.go
+++ b/jobqueue/job.go
@@ -757,6 +757,17 @@ type Job struct {
 	// environment variable name values will also be set for import in to the
 	// container. Setting this sets (and overrides) MonitorDocker to this Job's
 	// Key(), which will also be the container's --name.
+	//
+	// A container of that name that also carries wr's own label naming that
+	// Key is removed before the new one is created, so that a Job whose
+	// container outlived the run that started it can still be retried. A
+	// container of that name without the label is left alone, and the run
+	// fails as it would have before.
+	//
+	// Normally only this Job's own earlier run can have left such a container
+	// behind. But Key() names no manager, so 2 managers on one docker host
+	// running this same Cmd in this same Cwd share a Key, and either could
+	// then remove a container the other has running.
 	WithDocker string
 
 	// WithSingularity will result in CmdLine() returning a `singularity shell`
@@ -914,6 +925,9 @@ type Job struct {
 // * Cmd is stored in a tmp file.
 // * A new `docker run` or `singularity shell` command is returned that:
 //   - Pulls the image specified in WithDocker|Singularity if it is missing.
+//   - With docker, first removes a container holding the name the new one
+//     needs, if it also carries our own label for this Job's Key (see
+//     WithDocker).
 //   - Creates a container (with docker, it's name will be our Key()).
 //   - That will mount Cwd inside the container and use it as the workdir.
 //   - That will also mount any ContainerMounts.

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -674,8 +674,10 @@ func TestJob(t *testing.T) {
 
 			defer cleanup()
 
+			singularityPrefix := ` | singularity shell -B "$PWD" --pwd "$PWD"`
+
 			So(cmd, ShouldStartWith, "cat ")
-			So(cmd, ShouldEndWith, " | singularity shell "+image)
+			So(cmd, ShouldEndWith, singularityPrefix+" "+image)
 			So(job.MonitorDocker, ShouldBeBlank)
 
 			Convey("That ContainerImageUser does not change, singularity having no such option", func() {
@@ -687,7 +689,7 @@ func TestJob(t *testing.T) {
 
 				defer cleanup()
 
-				So(cmd, ShouldEndWith, " | singularity shell "+image)
+				So(cmd, ShouldEndWith, singularityPrefix+" "+image)
 			})
 
 			Convey("That can include additional mounts", func() {
@@ -700,7 +702,7 @@ func TestJob(t *testing.T) {
 
 				defer cleanup()
 
-				So(cmd, ShouldEndWith, " | singularity shell -B /foo/bar:/bar -B /foo/baz:/baz "+image)
+				So(cmd, ShouldEndWith, singularityPrefix+" -B /foo/bar:/bar -B /foo/baz:/baz "+image)
 			})
 		})
 	})

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -590,7 +590,10 @@ func TestJob(t *testing.T) {
 			defer cleanup()
 
 			// both filters on the removal carry the job's key, so it can only
-			// ever remove a container wr itself started for this same job.
+			// remove a container wr itself started under that key: normally
+			// just this job's own, but 2 managers share a key when they run
+			// this same Cmd in this same Cwd, and container/run.go's
+			// removeStaleContainerCmd says what that costs.
 			staleRemoval := fmt.Sprintf(`for c in $(docker ps --all --quiet --filter name=^%[1]s\$ `+
 				`--filter label=uk.ac.sanger.wr.job-key=%[1]s); do `+
 				`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; `+

--- a/jobqueue/job_test.go
+++ b/jobqueue/job_test.go
@@ -589,7 +589,13 @@ func TestJob(t *testing.T) {
 
 			defer cleanup()
 
-			So(cmd, ShouldStartWith, "cat ")
+			// both filters on the removal carry the job's key, so it can only
+			// ever remove a container wr itself started for this same job.
+			staleRemoval := fmt.Sprintf(`for c in $(docker ps --all --quiet --filter name=^%[1]s\$ `+
+				`--filter label=uk.ac.sanger.wr.job-key=%[1]s); do `+
+				`echo "wr: removing container $c, left behind by a lost run of this same command" >&2; `+
+				`docker rm --force "$c" >/dev/null; done; cat `, job.Key())
+			So(cmd, ShouldStartWith, staleRemoval)
 
 			dockerPrefix := ` | docker run --rm --name %[1]s --label uk.ac.sanger.wr.job-key=%[1]s` +
 				` --user "$(id -u):$(id -g)"` +


### PR DESCRIPTION
Finishes `origin/record-container-monitor-gaps` (`.docs/bugfixes/260903-8.md`).
Items 1, 2 and 3 of that record merged as #589, #587 and #590; these are the
four that remained. Each was re-verified against `develop` before work started.

## 4. A lost run left a container that made every retry fail

`containerRunCmd` passes `j.Key()` as docker's `--name`. `--rm` covers the
normal case, but a container that outlives its client keeps the name — the
runner SIGKILLed, the host lost, the daemon restarted mid-run. wr's only
removal path is `KillContainer` from a live runner that has already identified
the container, so after a lost run **every retry died** at `docker run` with
"container name already in use", and the job was unrunnable until someone
intervened by hand.

`DockerRunCmd`'s line now begins by removing a container matching **both**
filters: the name says it is in our way, and wr's own
`uk.ac.sanger.wr.job-key` label says it is ours. Name and label are unchanged,
so #589's monitor correlation is untouched — verified by driving the real
`Operator` over the real docker `Interactor`.

Safety was the point, and it was tested rather than argued. Eight real-docker
cases: a running or exited leftover with our label is removed; one carrying
**another job's** label, or **no** label, survives and the run fails exactly as
before; the `^…$` anchors and `regexp.QuoteMeta` stop near-miss names matching.
Eight hostile shell names — command substitution, backticks, quote breakouts,
an embedded newline — created zero files.

The comment states what the safety rests on rather than asserting the
conclusion: `Job.Key()` names no manager, so two managers on one docker host
running the identical command in the identical `Cwd` share a key. Within one
manager the property holds, verified against `wr retry`, `jobConfirmedDead` and
the release latch.

## 5. Singularity jobs did not run in their own working directory

`SingularityRunCmd`'s doc promised "The CWD is always mounted at / in
container". It emitted neither a bind nor `--pwd`, so the command ran wherever
the site's `singularity.conf` put it — commonly `/`, or the user's real home,
with the job's workspace not visible at all and `--change_home` having no
effect inside the container.

Two pre-existing promises already said otherwise: `wr add`'s help since 2021,
and `Job.WithSingularity`'s field doc. So the code was made to match, not the
comments.

Proved against singularity-ce 4.1.1, not asserted:

```
old: cat cmd.sh | singularity shell alpine.sif
     /
     ls: *.file: No such file or directory      exit=1
new: cat cmd.sh | singularity shell -B "$PWD" --pwd "$PWD" alpine.sif
     /tmp/item5test/home
     home.file                                  exit=0
```

The existing real tests were structurally blind to this: they build their
working directory under `/tmp`, which singularity binds by default, so the job
landed correctly by accident. The new test sets `SINGULARITY_NO_MOUNT` to stand
in for a site that binds nothing — and that `t.Setenv` is itself load-bearing.

## 6. A cid-file glob re-read a large file every second

`GetFirstLine` read the whole file. A `--monitor_docker` glob matching a job's
own output file re-read it every second for the life of the job, and the cost
landed in the job's recorded PeakRAM through `ownMemoryMB()` — and so in the
RAM wr reserves next run. Measured: a 500 MB file took `ownMemoryMB()` from 2 MB
to **957 MB**.

**It also never returned a first line.** For any multi-line file it returned
everything with one trailing newline trimmed, so a cidfile with trailing content
never matched a container and the job ran unmonitored, silently. That fix
widens what wr kills — a newly-identified container is SIGKILLed with the job —
so it has its own CHANGELOG entry rather than being folded into the memory one.

Bounded at 4096 bytes, 64× what a container id needs. Tests measure allocation,
which is the harm itself; proved deterministic over 25 in-process runs and 20
separate processes.

## 7. The docker tests used your real daemon

`pullUbuntuImage` pulled `ubuntu:latest` into the developer's daemon,
**re-pointing their tag**, and the tests took the names `container_1` and
`container_2`. All three problems were reproduced: a colliding name makes the
whole test **silently skip**; the tag really is re-pointed; a failure leaks
containers.

Now `alpine` pinned to its multi-architecture index digest, names derived per
run from `t.TempDir()`, and cleanup registered before the start attempt so a
container that fails to start is still removed. Verified by planting a *fake*
`alpine:latest` standing in for a developer's own build: it survived untouched,
and the pull landed as a separate digest-only reference. The `Platform: amd64`
pin is gone, so the test runs on arm64 instead of silently skipping.

## Gates

| Gate | Result |
|---|---|
| `make lint` | 0 issues. |
| `make test` | 644 passed · 13 skipped |
| `make race` | 644 passed · 13 skipped |

644 is develop's 640 plus four new tests. No web files, so `browser-test` is
not applicable.

Full write-up, including every mutation and the reasoning behind each design
choice, in `.docs/bugfixes/260909-fix-container-monitor-gaps.md`.
