### PR TITLE
Stage manual backups under a name nobody owns

### DIFF
--- a/.docs/bugfixes/260910-3.md
+++ b/.docs/bugfixes/260910-3.md
@@ -147,3 +147,36 @@ concatenation, exactly as `BackupDB` used to. They stay that way.
   backup staging was fixed", which is not what happened. The multi-GB-leak
   reasoning stays here and in the `db.go` comment, where a developer will
   look; the CHANGELOG carries only the precaution a user can act on.
+
+## Review finding on PR #594
+
+- [x] `errWithRemoval` used `fmt.Errorf("%w\n%w", ...)` where the rest of the
+  file uses `errors.Join`.
+    - Copilot review thread on `jobqueue/client.go:806`, PR #594.
+    - Premise verified before acting: `errors.Join` is used at
+      `client.go:618`, `1702` and `1799`, and 8 times repo-wide, while
+      `fmt.Errorf("%w\n%w", ...)` appeared exactly ONCE in non-test code -
+      this line, carried over unchanged from the code this PR replaced.
+    - Copilot's stated RATIONALE is wrong, measured on go1.26.3 rather than
+      recalled: `fmt.Errorf` with 2 `%w` verbs already preserves identity.
+      Both forms implement `Unwrap() []error` returning both errors in order,
+      neither implements `Unwrap() error`, and `errors.Is` finds both through
+      either. The error STRING is byte-identical too, because `errors.Join`
+      separates with `"\n"` itself. So nothing was broken; the merit is
+      consistency with the other 8 sites, which is reason enough on its own.
+    - The nil handling is the part that matters. `errors.Join(err, nil)` does
+      NOT return `err`; it returns a `*errors.joinError` wrapping the single
+      error. So collapsing this to
+      `return errors.Join(err, os.Remove(path))` WOULD have been a real
+      behaviour change - the success path would hand the caller a wrapper
+      instead of their own error value, breaking `==` and any type assertion.
+      The `rerr != nil` guard is therefore kept, and the success path still
+      returns exactly `err`.
+    - No new test, per testing-principles: every observable boundary is
+      unchanged, so a test could only assert the concrete error type or which
+      constructor was used. The existing "cannot be published" block still
+      covers the path and asserts nothing about the error string, so no
+      existing assertion needed updating or weakening. Note it exercises the
+      branch where `os.Remove` SUCCEEDS, so it would not have caught a wrongly
+      collapsed rewrite either - which is why the nil behaviour was checked
+      directly rather than left to the suite.

--- a/.docs/bugfixes/260910-3.md
+++ b/.docs/bugfixes/260910-3.md
@@ -1,0 +1,142 @@
+# Bugfixes 2026-09-10
+
+fix-backup-tmp-clobber
+
+- [x] `Client.BackupDB` destroys whatever is at `<path>.tmp`, whether the
+  backup succeeds or fails.
+    - `jobqueue/client.go`'s `BackupDB` does:
+
+      ```go
+      tmpPath := path + ".tmp"
+
+      err = os.WriteFile(tmpPath, resp.DB, dbFilePermission)
+      if err != nil {
+          rerr := os.Remove(tmpPath)
+          ...
+      }
+
+      return os.Rename(tmpPath, path)
+      ```
+
+      `os.WriteFile` is `O_WRONLY|O_CREATE|O_TRUNC` with no `O_EXCL`, so an
+      existing `<path>.tmp` is truncated and overwritten without a word. On
+      success it is then RENAMED AWAY over `path`; on failure it is REMOVED.
+      Either way the user's own file is gone.
+    - So `wr manager backup -p mydb.db` silently destroys an unrelated
+      `mydb.db.tmp`. `.tmp` beside a database is not an exotic name for a user
+      to have chosen.
+    - Re-verified on `develop` at `d82db55` before this branch started; the
+      record that filed it (`origin/record-cli-and-db-paths`,
+      `.docs/bugfixes/260903-9.md` item 3) cites `client.go:858-875`, and the
+      code has since moved to around line 1255, which is why this file names
+      functions rather than lines.
+    - The manager has 2 more fixed temporary paths of the same shape, both
+      derived in `jobqueue/db.go`: `dbBkFile + ".tmp"` and
+      `dbFile + ".s3backup_tmp"`, written by `accessor.DownloadFile` and
+      removed in a deferred call. Whoever takes this should decide whether
+      they are the same defect - they are the MANAGER's own files in the
+      manager's own directory, not a path the user just named on a command
+      line, so the argument for them is weaker and should be made explicitly
+      rather than assumed either way.
+    - The record makes one correction worth keeping, so nobody re-reports it:
+      the `.upgrade` sidecar is NOT this shape.
+      `internal/db_upgrade_status.go` uses `os.CreateTemp(dir, base+".tmp.")`,
+      so its temporary name is unique; only the final sidecar path is fixed,
+      and that is its designed location.
+    - Fix shape: do not choose a name that might already be somebody's file.
+      `os.CreateTemp` in the same directory gives a unique one and is what the
+      `.upgrade` sidecar already does, so the repo has the pattern. Whatever
+      is chosen must still land the finished backup at `path` by rename, so
+      the backup stays atomic from a reader's point of view.
+
+## As fixed
+
+- `BackupDB` stages through
+  `os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.")` - the
+  pattern `internal/db_upgrade_status.go` already uses - then publishes with
+  `os.Rename`. Same directory by construction, so the rename cannot cross a
+  filesystem.
+- The damage was WORSE than this item described, and the reviewer confirmed it
+  by reimplementing the old code standalone: giving your own `<path>.tmp` mode
+  0400 did NOT protect it. The write failed with EACCES and the cleanup
+  deleted the file anyway, because unlinking needs write permission on the
+  DIRECTORY, not on the file. So the careful thing a user might do made no
+  difference, and they were left with no `.tmp` and no backup either.
+- 3 destruction modes, each red before the fix: the file renamed away over
+  `path` on success; removed on write failure; and left behind, database-sized,
+  when the RENAME fails, because the old code returned that error without
+  cleaning up.
+- `tmp.Chmod(dbFilePermission)` is load-bearing and is NOT redundant with
+  `os.CreateTemp`'s 0600: `CreateTemp` is subject to the umask, so under
+  `umask 0277` it yields 0400. The reviewer measured that, and also found the
+  call had NO test behind it - deleting it left the suite green, because under
+  any ordinary umask 0600 survives unaided. Pinned since with a test that sets
+  a hostile umask.
+- Incidental pre-fix wart the fix also removes: `os.WriteFile` does not change
+  the mode of an EXISTING file, so the published backup could previously
+  inherit whatever mode the user's clobbered `.tmp` happened to have.
+- Concurrency is strictly better, measured over 200 runs of 2 concurrent
+  backups to one path: post-fix `torn=0 errors=0 leftoverStagingFiles=0`;
+  pre-fix 189 of 400 calls returned an error, the loser's rename hitting
+  ENOENT after the winner moved the shared file away - and that loser also
+  returned without cleaning up.
+
+- The `Chmod` is now pinned by `TestBackupStagedModeSurvivesHostileUmask`,
+  which sets `umask 0277` around the backup and asserts the published file is
+  `dbFilePermission`. Red without the `Chmod`:
+  `Expected: fs.FileMode(384) Actual: fs.FileMode(256)`, that is 0600 wanted,
+  0400 got. The window is 1 call wide on purpose, because `syscall.Umask` is
+  PROCESS-wide and the suite runs tests in parallel.
+- NO `fsync` was added, deliberately. `os.Rename` is atomic for a concurrent
+  READER, which is what this bug is about; it is not a power-loss guarantee,
+  and the old code gave none either. Rather than widen the fix, `BackupDB`'s
+  doc now states exactly which of the 2 it provides, so nobody reads "atomic"
+  as durability. Adding `fsync` is a separate, arguable change - it costs a
+  full flush of a multi-GB file on every manual backup.
+
+## The 2 manager-side staging paths in db.go are DELIBERATELY left fixed
+
+This is the decision this item asked for, recorded here because the argument
+was otherwise made only in conversation and would have been lost - which the
+reviewer flagged as blocking, correctly: the next reader would either re-file
+it or "fix" it into the leak described below.
+
+`jobqueue/db.go` derives `dbBkFile + ".tmp"` and `dbFile + ".s3backup_tmp"` by
+concatenation, exactly as `BackupDB` used to. They stay that way.
+
+- A fixed, REUSED name is load-bearing for a PERIODIC writer. `backupTicker`
+  polls every 1s and `waitBeforeBackup` spaces runs by at least
+  `minimumTimeBetweenBackups` = 30s, so a busy manager stages a backup roughly
+  every 30 seconds, indefinitely - order 2,900 a day.
+- `copyBackup` streams `tx.WriteTo`, so each staging file is a FULL database
+  copy; `initDB`'s own comment names production's multi-GB size.
+- NOTHING SWEEPS. Verified: no startup glob, no `WalkDir`, no age-based
+  cleanup anywhere in `db.go` or `internal/`. The only reason the manager does
+  not accumulate junk today is that the fixed name is reused -
+  `O_CREATE|O_TRUNC` reclaims a leftover from a crashed process on the next
+  backup.
+- So `os.CreateTemp` there would leak one multi-GB file per crash or OOM-kill,
+  forever, in the directory holding the live database: a disk-fill that takes
+  the manager down, which is worse than the bug being fixed. `O_EXCL` is worse
+  still - one stale leftover would fail EVERY subsequent backup, and
+  `handleFailedBackup` only logs, so disaster-recovery backups would stop
+  silently.
+- The client path has neither exposure: one shot, staged and then renamed or
+  removed within the call.
+- HONEST CAVEAT, and the reason this is a judgement rather than a rule:
+  `ManagerDBBkFile` is configurable (`internal/config.go`, default `db_bk`
+  under `~/.wr_<deployment>/`). A user who points it at, say, `/data/wr_db_bk`
+  and happens to own `/data/wr_db_bk.tmp` loses that file. That is a deliberate
+  persistent config choice naming a file the manager owns and rewrites, not an
+  ad-hoc argument on a command line, so the exposure is far narrower than
+  `wr manager backup -p <anything>` - but it is not zero, and this record
+  should not pretend the path is unreachable.
+- What would have to change to revisit it: a report of that caveat actually
+  biting. The fix then is NOT simply `os.CreateTemp`, which reintroduces the
+  unbounded leak; it needs a unique name PLUS startup and periodic sweeping of
+  stale `db_bk.tmp.*` files, which is a materially bigger change than this bug.
+- Corroboration only, not a reason: several tests watch the fixed name's
+  lifecycle (`jobqueue_test.go` waits for `managerDBBkFile + ".tmp"` to appear
+  and disappear, and 4 `reliable4_*` tests watch or remove `_bk.tmp`).
+  Existing tests asserting a behaviour are evidence that it is current, not
+  that it is right.

--- a/.docs/bugfixes/260910-3.md
+++ b/.docs/bugfixes/260910-3.md
@@ -140,3 +140,10 @@ concatenation, exactly as `BackupDB` used to. They stay that way.
   and disappear, and 4 `reliable4_*` tests watch or remove `_bk.tmp`).
   Existing tests asserting a behaviour are evidence that it is current, not
   that it is right.
+- CHANGELOG entry added under `[Unreleased]` -> `Fixed`, and it names the
+  manager-side limit in 1 sentence rather than hiding it: if you point
+  `managerdbbkfile` at a path, do not keep a file of your own at that path
+  with `.tmp` on the end. Without that sentence the entry would read as "wr's
+  backup staging was fixed", which is not what happened. The multi-GB-leak
+  reasoning stays here and in the `db.go` comment, where a developer will
+  look; the CHANGELOG carries only the precaution a user can act on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,21 @@ project adheres to [Semantic Versioning](http://semver.org/).
   so. wr now reads just the first line, so the container's peak RAM and total
   CPU are added to the usage wr reports for the command - and, as for any
   monitored container, wr kills that container too when you kill the job.
+- `wr manager backup -p <path>` no longer destroys a file of yours at
+  `<path>.tmp`. wr staged every backup at that exact name, overwriting what was
+  there without a word and then either renaming it away over `<path>` when the
+  backup succeeded or deleting it when it failed; making your own `<path>.tmp`
+  read-only did not save it, because deleting a file needs write permission on
+  its directory rather than on the file, so you were left with neither your file
+  nor a backup. A backup whose final rename failed also left a database-sized
+  staging file behind, and of two backups running to the same `<path>` at once
+  one usually failed, its rename finding the shared staging file already moved
+  away. wr now stages the backup under a unique name in `<path>`'s own
+  directory, so no file of yours is touched, anyone reading `<path>` still sees
+  either the old backup or the complete new one, and a backup that fails leaves
+  nothing behind. The manager's own automatic backups still stage under a fixed
+  `.tmp` name, deliberately: if you point `managerdbbkfile` at a path, don't
+  keep a file of your own at that path with `.tmp` on the end.
 
 
 ## [0.37.2] - 2026-09-01

--- a/jobqueue/backup_tmp_clobber_test.go
+++ b/jobqueue/backup_tmp_clobber_test.go
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package jobqueue
+
+// This file pins the fix for bugfix 260910-3: `wr manager backup -p mydb.db`
+// used to stage the backup at the FIXED path `mydb.db.tmp`, so a file the user
+// already had there was truncated and then either renamed away over the backup
+// (on success) or removed (on failure). The path is one a user types on a
+// command line, in a directory full of their own files, and nothing warns them.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	jqs "github.com/VertebrateResequencing/wr/jobqueue/scheduler"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	// backupTmpUserContent is what the user's own file at <backup path>.tmp
+	// holds, so a survivor can be told apart from a file wr overwrote with a
+	// database.
+	backupTmpUserContent = "a file of the user's that has nothing to do with wr\n"
+
+	// backupTmpUserMode makes the user's file unwritable, which is how the
+	// failure path is reached honestly: `os.WriteFile` on an existing 0400 file
+	// fails with EACCES, and the pre-fix cleanup then removed it.
+	backupTmpUserMode = 0o400
+
+	// backupTmpWritableMode is an ordinary mode for the user's file, so the
+	// pre-fix write succeeds and the file is renamed away instead.
+	backupTmpWritableMode = 0o600
+
+	// backupTmpDirMode is the mode of the directory that stands in the way of
+	// the publishing rename.
+	backupTmpDirMode = 0o700
+
+	// backupTmpHostileUmask masks off the owner's write bit as well as all of
+	// group and other, so os.CreateTemp on its own would produce a 0400 file.
+	// Under any ordinary umask (0002, 0022) CreateTemp's 0600 arrives intact,
+	// which is why only a umask like this one can show that stageBackup sets
+	// the mode itself.
+	backupTmpHostileUmask = 0o277
+
+	// backupTmpStagedContent stands in for the database bytes the server would
+	// send; staging only cares that there are some.
+	backupTmpStagedContent = "the bytes a backup would be made of"
+)
+
+// TestBackupDBSparesUnrelatedTmpFile proves BackupDB destroys nothing the user
+// already has beside the path they asked for, whether the backup succeeds or
+// fails, and that the backup itself still lands complete and readable.
+func TestBackupDBSparesUnrelatedTmpFile(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	ctx := context.Background()
+
+	Convey("Given a server, a client and a job", t, func() {
+		config, serverConfig, addr, standardReqs, clientConnectTime := jobqueueTestInit(false)
+
+		server, _, token, err := serve(ctx, serverConfig)
+		So(err, ShouldBeNil)
+
+		defer server.Stop(ctx, true)
+
+		jq, err := Connect(addr, config.ManagerCAFile, config.ManagerCertDomain, token, clientConnectTime)
+		So(err, ShouldBeNil)
+
+		defer disconnect(jq)
+
+		backupTmpAddJob(jq, standardReqs)
+
+		dir := t.TempDir()
+		backupPath := filepath.Join(dir, "mydb.db")
+		userPath := backupPath + ".tmp"
+
+		Convey("A backup beside a writable file of the user's leaves that file alone", func() {
+			So(os.WriteFile(userPath, []byte(backupTmpUserContent), backupTmpWritableMode), ShouldBeNil)
+
+			errb := jq.BackupDB(backupPath)
+
+			// the survival of the user's file is asserted before the backup's
+			// own outcome, because GoConvey halts a block at its first failure
+			// and the destroyed file is the thing this test exists to catch.
+			backupTmpAssertUserFileIntact(userPath, backupTmpWritableMode)
+
+			So(errb, ShouldBeNil)
+			assertNonEmptyFile(backupPath)
+			assertBoltLiveJobs(backupPath, 1)
+		})
+
+		Convey("A backup beside a read-only file of the user's leaves that file alone", func() {
+			So(os.WriteFile(userPath, []byte(backupTmpUserContent), backupTmpUserMode), ShouldBeNil)
+
+			errb := jq.BackupDB(backupPath)
+
+			backupTmpAssertUserFileIntact(userPath, backupTmpUserMode)
+
+			So(errb, ShouldBeNil)
+			assertNonEmptyFile(backupPath)
+			assertBoltLiveJobs(backupPath, 1)
+		})
+
+		Convey("A backup lands atomically at the asked-for path, leaving no staging file behind", func() {
+			So(jq.BackupDB(backupPath), ShouldBeNil)
+
+			info, errs := os.Stat(backupPath)
+			So(errs, ShouldBeNil)
+			So(info.Mode().Perm(), ShouldEqual, os.FileMode(dbFilePermission))
+
+			So(backupTmpDirEntries(dir), ShouldResemble, []string{"mydb.db"})
+		})
+
+		Convey("A backup that cannot be published leaves no staging file behind either", func() {
+			// a directory at the asked-for path cannot be renamed over, which
+			// fails the backup after the staging file has been written.
+			So(os.Mkdir(backupPath, backupTmpDirMode), ShouldBeNil)
+			So(os.WriteFile(filepath.Join(backupPath, "occupied"),
+				[]byte(backupTmpUserContent), backupTmpWritableMode), ShouldBeNil)
+
+			So(jq.BackupDB(backupPath), ShouldNotBeNil)
+
+			So(backupTmpDirEntries(dir), ShouldResemble, []string{"mydb.db"})
+		})
+	})
+}
+
+// backupTmpAddJob adds one job through jq, so the backup taken afterwards is a
+// real database with a countable live job in it.
+func backupTmpAddJob(jq *Client, reqs *jqs.Requirements) {
+	inserts, already, err := jq.Add([]*Job{{
+		Cmd:          "echo backup-tmp-clobber",
+		Cwd:          defaultUploadDir,
+		ReqGroup:     "backup_tmp_clobber",
+		RepGroup:     "backup_tmp_clobber",
+		Requirements: reqs,
+	}}, os.Environ(), true)
+	So(err, ShouldBeNil)
+	So(inserts, ShouldEqual, 1)
+	So(already, ShouldEqual, 0)
+}
+
+// backupTmpAssertUserFileIntact asserts the user's file still exists with the
+// content and mode they gave it.
+func backupTmpAssertUserFileIntact(path string, mode os.FileMode) {
+	info, err := os.Stat(path)
+	So(err, ShouldBeNil)
+
+	if err != nil {
+		return
+	}
+
+	So(info.Mode().Perm(), ShouldEqual, mode)
+
+	content, err := os.ReadFile(path)
+	So(err, ShouldBeNil)
+	So(string(content), ShouldEqual, backupTmpUserContent)
+}
+
+// backupTmpDirEntries returns the names of everything in dir, so a test can say
+// what wr left behind.
+func backupTmpDirEntries(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	So(err, ShouldBeNil)
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+
+	return names
+}
+
+// TestBackupStagedModeSurvivesHostileUmask proves a staged backup gets the mode
+// a database is meant to have even when the process umask would strip it. That
+// staged file is the backup: BackupDB renames it over the path the user asked
+// for, so its mode is the mode the user is left holding.
+func TestBackupStagedModeSurvivesHostileUmask(t *testing.T) {
+	if runnermode || servermode {
+		return
+	}
+
+	Convey("A backup staged under a umask that would strip the owner's write bit still has dbFilePermission", t, func() {
+		// the temp dir has to exist before the umask changes, or the umask
+		// would make the dir itself unwritable and nothing could be staged in
+		// it.
+		dir := t.TempDir()
+
+		tmpPath := backupTmpStageUnderUmask(filepath.Join(dir, "mydb.db"), backupTmpHostileUmask)
+
+		info, err := os.Stat(tmpPath)
+		So(err, ShouldBeNil)
+		So(info.Mode().Perm(), ShouldEqual, os.FileMode(dbFilePermission))
+	})
+}
+
+// backupTmpStageUnderUmask stages a backup for path with the process umask set
+// to umask, and returns the staged file's name.
+//
+// syscall.Umask is process-wide and every test in a package shares one process,
+// so the umask is restored as the helper returns (deferred, so a failed
+// assertion inside cannot leak it) rather than at the end of the test. No test
+// in this package calls t.Parallel(), so no other test body can run inside this
+// window, but background goroutines outliving earlier tests could still create
+// files in it, and one call is as narrow as the window gets.
+func backupTmpStageUnderUmask(path string, umask int) string {
+	previous := syscall.Umask(umask)
+	defer syscall.Umask(previous)
+
+	tmpPath, err := stageBackup(path, []byte(backupTmpStagedContent))
+	So(err, ShouldBeNil)
+
+	return tmpPath
+}

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -775,6 +775,36 @@ func (c *Client) release(job *Job, jes *JobEndState, failreason string, attempte
 	return nil
 }
 
+// stageBackup writes db to a uniquely named file in path's own directory,
+// returning that file's name for the caller to rename over path. The name is
+// unique because a fixed name is one the user may already have a file at, and
+// staging there would destroy it. The directory is path's own so that the
+// publishing rename stays within one filesystem.
+func stageBackup(path string, db []byte) (string, error) {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.")
+	if err != nil {
+		return "", err
+	}
+
+	tmpPath := tmp.Name()
+
+	if err = writeBackupTemp(tmp, db); err != nil {
+		return "", errWithRemoval(err, tmpPath)
+	}
+
+	return tmpPath, nil
+}
+
+// errWithRemoval removes path, returning err with any removal error joined on
+// to it so a leftover staging file is never silently left behind.
+func errWithRemoval(err error, path string) error {
+	if rerr := os.Remove(path); rerr != nil {
+		return fmt.Errorf("%w\n%w", err, rerr)
+	}
+
+	return err
+}
+
 // reserveHostAndPid returns this runner's hostname (falling back to localhost if
 // it can't be determined) and its own pid, to stamp on a reserve request so the
 // server can record which runner holds the reservation before the command's own
@@ -1246,25 +1276,28 @@ func (c *Client) ShutdownServer() bool {
 
 // BackupDB backs up the server's database to the given path. Note that
 // automatic backups occur to the configured location without calling this.
+//
+// The backup is staged in a uniquely named file in path's own directory and
+// then renamed over path, so a concurrent reader of path sees either the old
+// file or the complete new one, and no other file of yours is disturbed. The
+// staged bytes are not fsynced before the rename, so that covers a concurrent
+// reader, not a machine that loses power mid-backup.
 func (c *Client) BackupDB(path string) error {
 	resp, err := c.request(&clientRequest{Method: "backup"})
 	if err != nil {
 		return err
 	}
 
-	tmpPath := path + ".tmp"
-
-	err = os.WriteFile(tmpPath, resp.DB, dbFilePermission)
+	tmpPath, err := stageBackup(path, resp.DB)
 	if err != nil {
-		rerr := os.Remove(tmpPath)
-		if rerr != nil {
-			err = fmt.Errorf("%w\n%w", err, rerr)
-		}
-
 		return err
 	}
 
-	return os.Rename(tmpPath, path)
+	if err = os.Rename(tmpPath, path); err != nil {
+		return errWithRemoval(err, tmpPath)
+	}
+
+	return nil
 }
 
 // Add adds new jobs to the job queue, but only if those jobs aren't already in
@@ -1449,6 +1482,25 @@ type executeCmd struct {
 	liveStdout           *liveTailSaver
 	stderrWait           <-chan error
 	stdoutWait           <-chan error
+}
+
+// writeBackupTemp writes db to tmp and closes it. os.CreateTemp's mode is
+// subject to the umask, so the mode the backup is meant to have is set
+// explicitly.
+func writeBackupTemp(tmp *os.File, db []byte) error {
+	if _, err := tmp.Write(db); err != nil {
+		_ = tmp.Close()
+
+		return err
+	}
+
+	if err := tmp.Chmod(dbFilePermission); err != nil {
+		_ = tmp.Close()
+
+		return err
+	}
+
+	return tmp.Close()
 }
 
 // buildExecCmd builds the exec.Cmd that will run the job's command line jc,

--- a/jobqueue/client.go
+++ b/jobqueue/client.go
@@ -799,7 +799,7 @@ func stageBackup(path string, db []byte) (string, error) {
 // to it so a leftover staging file is never silently left behind.
 func errWithRemoval(err error, path string) error {
 	if rerr := os.Remove(path); rerr != nil {
-		return fmt.Errorf("%w\n%w", err, rerr)
+		return errors.Join(err, rerr)
 	}
 
 	return err

--- a/jobqueue/db.go
+++ b/jobqueue/db.go
@@ -978,6 +978,12 @@ func initDB(ctx context.Context, dbFile, dbBkFile, deployment string, wipeDevDB,
 
 	var accessor *muxfys.S3Accessor
 
+	// this staging name is deliberately fixed, not os.CreateTemp unique like
+	// the client's stageBackup(): copyBackup() opens it O_CREATE|O_TRUNC, so a
+	// leftover from a crashed manager is reclaimed by the next backup. Nothing
+	// sweeps these, and a busy manager writes one every 30s indefinitely, so a
+	// unique name would leak an entire db copy (multi-GB in production) per
+	// crash, and O_EXCL would make one stale leftover fail every later backup.
 	backupPathTmp := dbBkFile + ".tmp"
 
 	var msg string
@@ -1018,6 +1024,7 @@ func initDB(ctx context.Context, dbFile, dbBkFile, deployment string, wipeDevDB,
 				return nil, "", err
 			}
 
+			// fixed for the same reason as backupPathTmp above.
 			backupPathTmp = dbFile + ".s3backup_tmp"
 
 			if _, err = os.Stat(dbFile); os.IsNotExist(err) {


### PR DESCRIPTION
`wr manager backup -p <path>` staged the backup at `<path>.tmp`, a fixed name.
If you already had a file there, it was destroyed without a word: renamed away
over `<path>` on success, deleted on failure.

Making your own `<path>.tmp` read-only did **not** protect it. Unlinking needs
write permission on the *directory*, not on the file, so the write failed with
EACCES and the cleanup deleted the file anyway - leaving you with neither your
file nor a backup. The reviewer confirmed that by reimplementing the old code
standalone.

Two more failure modes came with it:

- a failed final rename returned the error and left a full database-sized
  staging file behind;
- of two concurrent backups to one path, the loser's rename hit ENOENT after
  the winner moved the shared file away. Measured over 200 runs of 2 concurrent
  backups: 189 of 400 calls errored. Post-fix: `torn=0 errors=0
  leftoverStagingFiles=0`.

## The fix

`BackupDB` now stages through
`os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.")` - the pattern
`internal/db_upgrade_status.go` already uses - and publishes with `os.Rename`.
Same directory by construction, so the rename cannot cross a filesystem.

`tmp.Chmod(dbFilePermission)` is load-bearing and is not redundant with
`os.CreateTemp`'s 0600: `CreateTemp` is subject to the umask, so under
`umask 0277` it yields 0400. That call had **no test behind it** - deleting it
left the suite green. It is now pinned by
`TestBackupStagedModeSurvivesHostileUmask`.

## The manager's own staging paths are deliberately left fixed

`jobqueue/db.go` derives `dbBkFile + ".tmp"` and `dbFile + ".s3backup_tmp"` the
same way. They stay. A busy manager stages a backup roughly every 30s -
order 2,900 a day - and each staging file is a full database copy. Nothing
sweeps them; the only reason junk does not accumulate is that the fixed name is
reused. `os.CreateTemp` there would leak one multi-GB file per crash, forever,
next to the live database; `O_EXCL` would be worse still, since one stale
leftover would silently fail every later backup.

The honest caveat, and the reason this is a judgement rather than a rule:
`ManagerDBBkFile` is configurable, so someone who points it at `/data/wr_db_bk`
and owns `/data/wr_db_bk.tmp` still loses that file. The exposure is far
narrower than `wr manager backup -p <anything>`, but it is not zero, and the
CHANGELOG entry names the precaution. Full reasoning in
`.docs/bugfixes/260910-3.md`.

## Gates

Run centrally on this head's code: `make lint` 0 issues, `make test` 653
passed / 13 skipped, `make race` 653 passed / 13 skipped. The expected count was
derived independently: develop lists 651 runnable tests, this branch adds 2.
No web UI touched, so no `make browser-test`.
